### PR TITLE
examples: add example for mpu6050

### DIFF
--- a/examples/mpu6050/main.go
+++ b/examples/mpu6050/main.go
@@ -1,0 +1,22 @@
+// Connects to an MPU6050 I2C accelerometer/gyroscope.
+package main
+
+import (
+	"machine"
+	"time"
+
+	"github.com/tinygo-org/drivers/mpu6050"
+)
+
+func main() {
+	machine.I2C0.Configure(machine.I2CConfig{})
+
+	accel := mpu6050.New(machine.I2C0)
+	accel.Configure()
+
+	for {
+		x, y, z := accel.ReadAcceleration()
+		println(x, y, z)
+		time.Sleep(time.Millisecond * 100)
+	}
+}


### PR DESCRIPTION
This PR adds an example for the MPU6050.