### PR TITLE
i2c: refactor all i2c drivers to use Address property of Driver.

### DIFF
--- a/bh1750/bh1750.go
+++ b/bh1750/bh1750.go
@@ -16,8 +16,9 @@ type SamplingMode byte
 
 // Device wraps an I2C connection to a bh1750 device.
 type Device struct {
-	bus  machine.I2C
-	mode SamplingMode
+	bus     machine.I2C
+	Address uint16
+	mode    SamplingMode
 }
 
 // New creates a new bh1750 connection. The I2C bus must already be
@@ -26,14 +27,15 @@ type Device struct {
 // This function only creates the Device object, it does not touch the device.
 func New(bus machine.I2C) Device {
 	return Device{
-		bus:  bus,
-		mode: CONTINUOUS_HIGH_RES_MODE,
+		bus:     bus,
+		Address: Address,
+		mode:    CONTINUOUS_HIGH_RES_MODE,
 	}
 }
 
 // Configure sets up the device for communication
 func (d *Device) Configure() {
-	d.bus.Tx(Address, []byte{POWER_ON}, nil)
+	d.bus.Tx(d.Address, []byte{POWER_ON}, nil)
 	d.SetMode(d.mode)
 }
 
@@ -41,7 +43,7 @@ func (d *Device) Configure() {
 func (d *Device) RawSensorData() uint16 {
 
 	buf := []byte{1, 0}
-	d.bus.Tx(Address, nil, buf)
+	d.bus.Tx(d.Address, nil, buf)
 	return (uint16(buf[0]) << 8) | uint16(buf[1])
 }
 
@@ -65,6 +67,6 @@ func (d *Device) Illuminance() int32 {
 // SetMode changes the reading mode for the sensor
 func (d *Device) SetMode(mode SamplingMode) {
 	d.mode = mode
-	d.bus.Tx(Address, []byte{byte(d.mode)}, nil)
+	d.bus.Tx(d.Address, []byte{byte(d.mode)}, nil)
 	time.Sleep(10 * time.Millisecond)
 }

--- a/blinkm/blinkm.go
+++ b/blinkm/blinkm.go
@@ -9,7 +9,8 @@ import (
 
 // Device wraps an I2C connection to a BlinkM device.
 type Device struct {
-	bus machine.I2C
+	bus     machine.I2C
+	Address uint16
 }
 
 // New creates a new BlinkM connection. The I2C bus must already be
@@ -17,38 +18,43 @@ type Device struct {
 //
 // This function only creates the Device object, it does not touch the device.
 func New(bus machine.I2C) Device {
-	return Device{bus}
+	return Device{bus, Address}
+}
+
+// Configure sets up the device for communication
+func (d *Device) Configure() {
+	d.bus.Tx(d.Address, []byte{'o'}, nil)
 }
 
 // Version returns the version of firmware on the BlinkM.
 func (d Device) Version() (major, minor byte, err error) {
 	version := []byte{0, 0}
-	d.bus.ReadRegister(Address, GET_FIRMWARE, version)
+	d.bus.Tx(d.Address, []byte{GET_FIRMWARE}, version)
 	return version[0], version[1], nil
 }
 
 // SetRGB sets the RGB color on the BlinkM.
 func (d Device) SetRGB(r, g, b byte) error {
-	d.bus.WriteRegister(Address, TO_RGB, []byte{r, g, b})
+	d.bus.Tx(d.Address, []byte{TO_RGB, r, g, b}, nil)
 	return nil
 }
 
 // GetRGB gets the current RGB color on the BlinkM.
 func (d Device) GetRGB() (r, g, b byte, err error) {
 	color := []byte{0, 0, 0}
-	d.bus.ReadRegister(Address, GET_RGB, color)
+	d.bus.Tx(d.Address, []byte{GET_RGB}, color)
 	return color[0], color[1], color[2], nil
 }
 
 // FadeToRGB sets the RGB color on the BlinkM by fading from the current color
 // to the new color.
 func (d Device) FadeToRGB(r, g, b byte) error {
-	d.bus.WriteRegister(Address, FADE_TO_RGB, []byte{r, g, b})
+	d.bus.Tx(d.Address, []byte{FADE_TO_RGB, r, g, b}, nil)
 	return nil
 }
 
 // StopScript stops whatever script is currently running on the BlinkM.
 func (d Device) StopScript() error {
-	d.bus.WriteRegister(Address, STOP_SCRIPT, nil)
+	d.bus.Tx(d.Address, []byte{STOP_SCRIPT}, nil)
 	return nil
 }

--- a/mma8653/mma8653.go
+++ b/mma8653/mma8653.go
@@ -11,7 +11,8 @@ import (
 
 // Device wraps an I2C connection to a MMA8653 device.
 type Device struct {
-	bus machine.I2C
+	bus     machine.I2C
+	Address uint16
 }
 
 // New creates a new MMA8653 connection. The I2C bus must already be
@@ -19,28 +20,28 @@ type Device struct {
 //
 // This function only creates the Device object, it does not touch the device.
 func New(bus machine.I2C) Device {
-	return Device{bus}
+	return Device{bus, Address}
 }
 
 // Connected returns whether a MMA8653 has been found.
 // It does a "who am I" request and checks the response.
 func (d Device) Connected() bool {
 	data := []byte{0}
-	d.bus.ReadRegister(Address, WHO_AM_I, data)
+	d.bus.ReadRegister(uint8(d.Address), WHO_AM_I, data)
 	return data[0] == 0x5A
 }
 
 // Configure sets up the device for communication.
 func (d Device) Configure(speed DataRate) {
 	data := (uint8(speed) << 3) | 1 // set data rate and ACTIVE mode
-	d.bus.WriteRegister(Address, CTRL_REG1, []uint8{data})
+	d.bus.WriteRegister(uint8(d.Address), CTRL_REG1, []uint8{data})
 }
 
 // ReadAcceleration reads the current acceleration from the device and returns
 // it.
 func (d Device) ReadAcceleration() (x int16, y int16, z int16) {
 	data := make([]byte, 6)
-	d.bus.ReadRegister(Address, OUT_X_MSB, data)
+	d.bus.ReadRegister(uint8(d.Address), OUT_X_MSB, data)
 	x = int16((uint16(data[0]) << 8) | uint16(data[1]))
 	y = int16((uint16(data[2]) << 8) | uint16(data[3]))
 	z = int16((uint16(data[4]) << 8) | uint16(data[5]))

--- a/mpu6050/mpu6050.go
+++ b/mpu6050/mpu6050.go
@@ -12,7 +12,8 @@ import (
 
 // Device wraps an I2C connection to a MPU6050 device.
 type Device struct {
-	bus machine.I2C
+	bus     machine.I2C
+	Address uint16
 }
 
 // New creates a new MPU6050 connection. The I2C bus must already be
@@ -20,27 +21,27 @@ type Device struct {
 //
 // This function only creates the Device object, it does not touch the device.
 func New(bus machine.I2C) Device {
-	return Device{bus}
+	return Device{bus, Address}
 }
 
 // Connected returns whether a MPU6050 has been found.
 // It does a "who am I" request and checks the response.
 func (d Device) Connected() bool {
 	data := []byte{0}
-	d.bus.ReadRegister(Address, WHO_AM_I, data)
+	d.bus.ReadRegister(uint8(d.Address), WHO_AM_I, data)
 	return data[0] == 0x68
 }
 
 // Configure sets up the device for communication.
 func (d Device) Configure() {
-	d.bus.WriteRegister(Address, PWR_MGMT_1, []uint8{0})
+	d.bus.WriteRegister(uint8(d.Address), PWR_MGMT_1, []uint8{0})
 }
 
 // ReadAcceleration reads the current acceleration from the device and returns
 // it.
 func (d Device) ReadAcceleration() (x int16, y int16, z int16) {
 	data := make([]byte, 6)
-	d.bus.ReadRegister(Address, ACCEL_XOUT_H, data)
+	d.bus.ReadRegister(uint8(d.Address), ACCEL_XOUT_H, data)
 	x = int16((uint16(data[0]) << 8) | uint16(data[1]))
 	y = int16((uint16(data[2]) << 8) | uint16(data[3]))
 	z = int16((uint16(data[4]) << 8) | uint16(data[5]))
@@ -50,7 +51,7 @@ func (d Device) ReadAcceleration() (x int16, y int16, z int16) {
 // ReadRotation reads the current rotation from the device and returns it.
 func (d Device) ReadRotation() (x int16, y int16, z int16) {
 	data := make([]byte, 6)
-	d.bus.ReadRegister(Address, GYRO_XOUT_H, data)
+	d.bus.ReadRegister(uint8(d.Address), GYRO_XOUT_H, data)
 	x = int16((uint16(data[0]) << 8) | uint16(data[1]))
 	y = int16((uint16(data[2]) << 8) | uint16(data[3]))
 	z = int16((uint16(data[4]) << 8) | uint16(data[5]))

--- a/vl53v1x/vl53l1x.go
+++ b/vl53v1x/vl53l1x.go
@@ -35,6 +35,7 @@ type resultBuffer struct {
 // Device wraps an I2C connection to a VL53L1X device.
 type Device struct {
 	bus                machine.I2C
+	Address            uint16
 	mode               DistanceMode
 	timeout            uint32
 	fastOscillatorFreq uint16
@@ -53,6 +54,7 @@ type Device struct {
 func New(bus machine.I2C) Device {
 	return Device{
 		bus:     bus,
+		Address: Address,
 		mode:    LONG,
 		timeout: 500,
 	}
@@ -287,7 +289,7 @@ func (d *Device) readResults() {
 	data := make([]byte, 17)
 	msb := byte((RESULT_RANGE_STATUS >> 8) & 0xFF)
 	lsb := byte(RESULT_RANGE_STATUS & 0xFF)
-	d.bus.Tx(Address, []byte{msb, lsb}, data)
+	d.bus.Tx(d.Address, []byte{msb, lsb}, data)
 	d.results.status = data[0]
 	// data[1] report_status : not used
 	d.results.streamCount = data[2]
@@ -430,7 +432,7 @@ func (d *Device) StopContinuous() {
 func (d *Device) writeReg(reg uint16, value uint8) {
 	msb := byte((reg >> 8) & 0xFF)
 	lsb := byte(reg & 0xFF)
-	d.bus.Tx(Address, []byte{msb, lsb, value}, nil)
+	d.bus.Tx(d.Address, []byte{msb, lsb, value}, nil)
 }
 
 // writeReg16Bit sends two bytes to the specified register address
@@ -440,7 +442,7 @@ func (d *Device) writeReg16Bit(reg uint16, value uint16) {
 	data[1] = byte(reg & 0xFF)
 	data[2] = byte((value >> 8) & 0xFF)
 	data[3] = byte(value & 0xFF)
-	d.bus.Tx(Address, data, nil)
+	d.bus.Tx(d.Address, data, nil)
 }
 
 // writeReg32Bit sends four bytes to the specified register address
@@ -452,7 +454,7 @@ func (d *Device) writeReg32Bit(reg uint16, value uint32) {
 	data[3] = byte((value >> 16) & 0xFF)
 	data[4] = byte((value >> 8) & 0xFF)
 	data[5] = byte(value & 0xFF)
-	d.bus.Tx(Address, data, nil)
+	d.bus.Tx(d.Address, data, nil)
 }
 
 // readReg reads a single byte from the specified address
@@ -460,7 +462,7 @@ func (d *Device) readReg(reg uint16) uint8 {
 	data := []byte{0}
 	msb := byte((reg >> 8) & 0xFF)
 	lsb := byte(reg & 0xFF)
-	d.bus.Tx(Address, []byte{msb, lsb}, data)
+	d.bus.Tx(d.Address, []byte{msb, lsb}, data)
 	return data[0]
 }
 
@@ -470,7 +472,7 @@ func (d *Device) readReg16Bit(reg uint16) uint16 {
 	data := []byte{0, 0}
 	msb := byte((reg >> 8) & 0xFF)
 	lsb := byte(reg & 0xFF)
-	d.bus.Tx(Address, []byte{msb, lsb}, data)
+	d.bus.Tx(d.Address, []byte{msb, lsb}, data)
 	return readUint(data[0], data[1])
 }
 
@@ -480,7 +482,7 @@ func (d *Device) readReg32Bit(reg uint16) uint32 {
 	data := make([]byte, 4)
 	msb := byte((reg >> 8) & 0xFF)
 	lsb := byte(reg & 0xFF)
-	d.bus.Tx(Address, []byte{msb, lsb}, data)
+	d.bus.Tx(d.Address, []byte{msb, lsb}, data)
 	return readUint32(data)
 }
 


### PR DESCRIPTION
This PR refactors all current i2c drivers to use Address property of Driver. It allows variations of a driver to override the default address as discussed in #14 
