### PR TITLE
bmp180: change method names/signature for obtaining temperature/pressure

### DIFF
--- a/bmp180/bmp180.go
+++ b/bmp180/bmp180.go
@@ -1,5 +1,5 @@
 // Package bmp180 provides a driver for the BMP180 digital pressure sensor
-// by Bosch
+// by Bosch.
 //
 // Datasheet:
 // https://cdn-shop.adafruit.com/datasheets/BST-BMP180-DS000-09.pdf
@@ -12,7 +12,7 @@ import (
 	"machine"
 )
 
-// BMP180OversamplingMode is the oversampling ratio of the pressure measurement.
+// OversamplingMode is the oversampling ratio of the pressure measurement.
 type OversamplingMode uint
 
 // calibrationCoefficients reads at startup and stores the calibration coefficients
@@ -41,7 +41,8 @@ type Device struct {
 // New creates a new BMP180 connection. The I2C bus must already be
 // configured.
 //
-// This function only creates the Device object, it does not touch the device.
+// This function only creates the Device object, it does not initialize the device.
+// You must call Configure() first in order to use the device itself.
 func New(bus machine.I2C) Device {
 	return Device{
 		bus:     bus,
@@ -59,7 +60,7 @@ func (d *Device) Connected() bool {
 }
 
 // Configure sets up the device for communication and
-// read the calibration coefficientes.
+// read the calibration coefficients.
 func (d *Device) Configure() {
 	data := make([]byte, 22)
 	err := d.bus.ReadRegister(uint8(d.Address), AC1_MSB, data)
@@ -79,8 +80,8 @@ func (d *Device) Configure() {
 	d.calibrationCoefficients.md = readInt(data[20], data[21])
 }
 
-// Temperature returns the temperature in celsius milli degrees (ºC/1000)
-func (d *Device) Temperature() (temperature int32, err error) {
+// ReadTemperature returns the temperature in celsius milli degrees (ºC/1000).
+func (d *Device) ReadTemperature() (temperature int32, err error) {
 	rawTemp, err := d.rawTemp()
 	if err != nil {
 		return
@@ -90,8 +91,8 @@ func (d *Device) Temperature() (temperature int32, err error) {
 	return 100 * t, nil
 }
 
-// Pressure returns the pressure in milli pascals (mPa)
-func (d *Device) Pressure() (pressure int32, err error) {
+// ReadPressure returns the pressure in milli pascals (mPa).
+func (d *Device) ReadPressure() (pressure int32, err error) {
 	rawTemp, err := d.rawTemp()
 	if err != nil {
 		return

--- a/examples/bme280/main.go
+++ b/examples/bme280/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"time"
+
+	"machine"
+
+	"github.com/tinygo-org/drivers/bme280"
+)
+
+func main() {
+	machine.I2C0.Configure(machine.I2CConfig{})
+	sensor := bme280.New(machine.I2C0)
+	sensor.Configure()
+
+	connected := sensor.Connected()
+	if !connected {
+		println("BME280 not detected")
+		return
+	}
+	//println("BME280 detected")
+
+	for {
+		temp, _ := sensor.ReadTemperature()
+		println("Temperature:", temp/10, "ºC")
+
+		time.Sleep(2 * time.Second)
+	}
+}

--- a/examples/bmp180/main.go
+++ b/examples/bmp180/main.go
@@ -3,8 +3,9 @@ package main
 import (
 	"time"
 
-	"github.com/tinygo-org/drivers/bmp180"
 	"machine"
+
+	"github.com/tinygo-org/drivers/bmp180"
 )
 
 func main() {
@@ -20,10 +21,10 @@ func main() {
 	println("BMP180 detected")
 
 	for {
-		temp, _ := sensor.Temperature()
+		temp, _ := sensor.ReadTemperature()
 		println("Temperature:", float32(temp)/1000, "ºC")
 
-		pressure, _ := sensor.Pressure()
+		pressure, _ := sensor.ReadPressure()
 		println("Pressure", float32(pressure)/100000, "hPa")
 
 		time.Sleep(2 * time.Second)

--- a/examples/buzzer/main.go
+++ b/examples/buzzer/main.go
@@ -1,0 +1,42 @@
+
+package main
+
+import (
+	"machine"
+	"time"
+
+	"github.com/tinygo-org/drivers/buzzer"
+)
+
+type note struct {
+	tone     float64
+	duration float64
+}
+
+func main() {
+	speaker := machine.GPIO{machine.PA30}
+	speaker.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+	speaker.Set(true)
+
+	bzrPin := machine.GPIO{machine.A0}
+	bzrPin.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+
+	bzr := buzzer.New(machine.A0)
+
+	song := []note{
+		{buzzer.C4, buzzer.Quarter},
+		{buzzer.D4, buzzer.Quarter},
+		{buzzer.E4, buzzer.Quarter},
+		{buzzer.F4, buzzer.Quarter},
+		{buzzer.G4, buzzer.Quarter},
+		{buzzer.A4, buzzer.Quarter},
+		{buzzer.B4, buzzer.Quarter},
+		{buzzer.C5, buzzer.Quarter},
+	}
+
+	for _, val := range song {
+		bzr.Tone(val.tone, val.duration)
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+


### PR DESCRIPTION
This PR changes the method names/signature for obtaining temperature and pressure to be uniform with other similar drivers.
