### PR TITLE
all: refactor all current drivers to use new machine.Pin interface

### DIFF
--- a/easystepper/easystepper.go
+++ b/easystepper/easystepper.go
@@ -8,24 +8,20 @@ import (
 
 // Device holds the pins and the delay between steps
 type Device struct {
-	pins       [4]machine.GPIO
+	pins       [4]machine.Pin
 	stepDelay  int32
 	stepNumber int32
 }
 
 // New returns a new easystepper driver given 4 pins numbers (not pin object),
 // number of steps and rpm
-func New(pin1 uint8, pin2 uint8, pin3 uint8, pin4 uint8, steps int32, rpm int32) Device {
-	m1 := machine.GPIO{pin1}
-	m1.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
-	m2 := machine.GPIO{pin2}
-	m2.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
-	m3 := machine.GPIO{pin3}
-	m3.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
-	m4 := machine.GPIO{pin4}
-	m4.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+func New(pin1, pin2, pin3, pin4 machine.Pin, steps int32, rpm int32) Device {
+	pin1.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	pin2.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	pin3.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	pin4.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	return Device{
-		pins:      [4]machine.GPIO{m1, m2, m3, m4},
+		pins:      [4]machine.Pin{pin1, pin2, pin3, pin4},
 		stepDelay: 60000000 / (steps * rpm),
 	}
 }

--- a/examples/espat/espconsole/main.go
+++ b/examples/espat/espconsole/main.go
@@ -25,9 +25,9 @@ const pass = "YOURPASS"
 
 // change these to connect to a different UART or pins for the ESP8266/ESP32
 var (
-	uart       = machine.UART1
-	tx   uint8 = machine.D10
-	rx   uint8 = machine.D11
+	uart = machine.UART1
+	tx   = machine.D10
+	rx   = machine.D11
 
 	console = machine.UART0
 

--- a/examples/espat/esphub/main.go
+++ b/examples/espat/esphub/main.go
@@ -22,9 +22,9 @@ const pass = "YOURPASS"
 
 // change these to connect to a different UART or pins for the ESP8266/ESP32
 var (
-	uart       = machine.UART1
-	tx   uint8 = machine.D10
-	rx   uint8 = machine.D11
+	uart = machine.UART1
+	tx   = machine.D10
+	rx   = machine.D11
 
 	console = machine.UART0
 
@@ -38,8 +38,8 @@ func main() {
 	adaptor = espat.New(uart)
 	adaptor.Configure()
 
-	readyled := machine.GPIO{machine.LED}
-	readyled.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+	readyled := machine.LED
+	readyled.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	readyled.High()
 
 	// first check if connected

--- a/examples/espat/espstation/main.go
+++ b/examples/espat/espstation/main.go
@@ -22,9 +22,9 @@ const hubIP = "0.0.0.0"
 
 // change these to connect to a different UART or pins for the ESP8266/ESP32
 var (
-	uart       = machine.UART1
-	tx   uint8 = machine.D10
-	rx   uint8 = machine.D11
+	uart = machine.UART1
+	tx   = machine.D10
+	rx   = machine.D11
 
 	console = machine.UART0
 

--- a/examples/hd44780/customchar/main.go
+++ b/examples/hd44780/customchar/main.go
@@ -9,7 +9,7 @@ import (
 func main() {
 
 	lcd, _ := hd44780.NewGPIO4Bit(
-		[]uint8{machine.P0, machine.P1, machine.P2, machine.P3},
+		[]machine.Pin{machine.P0, machine.P1, machine.P2, machine.P3},
 		machine.P4,
 		machine.P5,
 		machine.P6,

--- a/examples/hd44780/text/main.go
+++ b/examples/hd44780/text/main.go
@@ -9,7 +9,7 @@ import (
 func main() {
 
 	lcd, _ := hd44780.NewGPIO4Bit(
-		[]uint8{machine.P0, machine.P1, machine.P2, machine.P3},
+		[]machine.Pin{machine.P0, machine.P1, machine.P2, machine.P3},
 		machine.P4,
 		machine.P5,
 		machine.P6,

--- a/examples/pcd8544/setbuffer/main.go
+++ b/examples/pcd8544/setbuffer/main.go
@@ -9,12 +9,12 @@ import (
 )
 
 func main() {
-	dcPin := machine.GPIO{machine.P3}
-	dcPin.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
-	rstPin := machine.GPIO{machine.P4}
-	rstPin.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
-	scePin := machine.GPIO{machine.P5}
-	scePin.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+	dcPin := machine.P3
+	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	rstPin := machine.P4
+	rstPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	scePin := machine.P5
+	scePin.Configure(machine.PinConfig{Mode: machine.PinOutput})
 
 	machine.SPI0.Configure(machine.SPIConfig{})
 

--- a/examples/pcd8544/setpixel/main.go
+++ b/examples/pcd8544/setpixel/main.go
@@ -9,12 +9,12 @@ import (
 )
 
 func main() {
-	dcPin := machine.GPIO{machine.P3}
-	dcPin.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
-	rstPin := machine.GPIO{machine.P4}
-	rstPin.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
-	scePin := machine.GPIO{machine.P5}
-	scePin.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+	dcPin := machine.P3
+	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	rstPin := machine.P4
+	rstPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	scePin := machine.P5
+	scePin.Configure(machine.PinConfig{Mode: machine.PinOutput})
 
 	machine.SPI0.Configure(machine.SPIConfig{})
 

--- a/examples/ws2812/main.go
+++ b/examples/ws2812/main.go
@@ -14,8 +14,8 @@ import (
 )
 
 func main() {
-	neo := machine.GPIO{machine.NEOPIXELS}
-	neo.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+	neo := machine.NEOPIXELS
+	neo.Configure(machine.PinConfig{Mode: machine.PinOutput})
 
 	ws := ws2812.New(neo)
 	leds := make([]color.RGBA, 10)

--- a/hd44780/hd44780.go
+++ b/hd44780/hd44780.go
@@ -3,6 +3,7 @@ package hd44780
 import (
 	"errors"
 	"io"
+	"machine"
 	"time"
 )
 
@@ -38,7 +39,7 @@ type Config struct {
 }
 
 // NewGPIO4Bit returns 4bit data length HD44780 driver. Datapins are LCD DB pins starting from DB4 to DB7
-func NewGPIO4Bit(dataPins []uint8, e, rs, rw uint8) (Device, error) {
+func NewGPIO4Bit(dataPins []machine.Pin, e, rs, rw machine.Pin) (Device, error) {
 	const fourBitMode = 4
 	if len(dataPins) != fourBitMode {
 		return Device{}, errors.New("4 pins are required in data slice (D4-D7) when HD44780 is used in 4 bit mode")
@@ -47,7 +48,7 @@ func NewGPIO4Bit(dataPins []uint8, e, rs, rw uint8) (Device, error) {
 }
 
 // NewGPIO8Bit returns 8bit data length HD44780 driver. Datapins are LCD DB pins starting from DB0 to DB7
-func NewGPIO8Bit(dataPins []uint8, e, rs, rw uint8) (Device, error) {
+func NewGPIO8Bit(dataPins []machine.Pin, e, rs, rw machine.Pin) (Device, error) {
 	const eightBitMode = 8
 	if len(dataPins) != eightBitMode {
 		return Device{}, errors.New("8 pins are required in data slice (D0-D7) when HD44780 is used in 8 bit mode")

--- a/hub75/hub75.go
+++ b/hub75/hub75.go
@@ -21,12 +21,12 @@ type Config struct {
 
 type Device struct {
 	bus               machine.SPI
-	a                 machine.GPIO
-	b                 machine.GPIO
-	c                 machine.GPIO
-	d                 machine.GPIO
-	oe                machine.GPIO
-	lat               machine.GPIO
+	a                 machine.Pin
+	b                 machine.Pin
+	c                 machine.Pin
+	d                 machine.Pin
+	oe                machine.Pin
+	lat               machine.Pin
 	width             int16
 	height            int16
 	brightness        uint8
@@ -51,28 +51,22 @@ type Device struct {
 }
 
 // New returns a new HUB75 driver. Pass in a fully configured SPI bus.
-func New(b machine.SPI, latPin uint8, oePin uint8, aPin uint8, bPin uint8, cPin uint8, dPin uint8) Device {
-	pinA := machine.GPIO{aPin}
-	pinA.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
-	pinB := machine.GPIO{bPin}
-	pinB.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
-	pinC := machine.GPIO{cPin}
-	pinC.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
-	pinD := machine.GPIO{dPin}
-	pinD.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
-	pinOE := machine.GPIO{oePin}
-	pinOE.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
-	pinLAT := machine.GPIO{latPin}
-	pinLAT.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+func New(b machine.SPI, latPin, oePin, aPin, bPin, cPin, dPin machine.Pin) Device {
+	aPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	bPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	cPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	dPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	oePin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	latPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
 
 	return Device{
 		bus: b,
-		a:   pinA,
-		b:   pinB,
-		c:   pinC,
-		d:   pinD,
-		oe:  pinOE,
-		lat: pinLAT,
+		a:   aPin,
+		b:   bPin,
+		c:   cPin,
+		d:   dPin,
+		oe:  oePin,
+		lat: latPin,
 	}
 }
 

--- a/microbitmatrix/microbitmatrix.go
+++ b/microbitmatrix/microbitmatrix.go
@@ -45,7 +45,7 @@ type Config struct {
 }
 
 type Device struct {
-	pin      [12]*machine.GPIO
+	pin      [12]machine.Pin
 	buffer   [3][9]bool
 	rotation uint8
 }
@@ -59,9 +59,9 @@ func New() Device {
 func (d *Device) Configure(cfg Config) {
 	d.SetRotation(cfg.Rotation)
 
-	for i := uint8(machine.LED_COL_1); i <= machine.LED_ROW_3; i++ {
-		d.pin[i-machine.LED_COL_1] = &machine.GPIO{i}
-		d.pin[i-machine.LED_COL_1].Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+	for i := machine.LED_COL_1; i <= machine.LED_ROW_3; i++ {
+		d.pin[i-machine.LED_COL_1] = i
+		d.pin[i-machine.LED_COL_1].Configure(machine.PinConfig{Mode: machine.PinOutput})
 	}
 	d.ClearDisplay()
 	d.DisableAll()

--- a/pcd8544/pcd8544.go
+++ b/pcd8544/pcd8544.go
@@ -13,9 +13,9 @@ import (
 // Device wraps an SPI connection.
 type Device struct {
 	bus        machine.SPI
-	dcPin      machine.GPIO
-	rstPin     machine.GPIO
-	scePin     machine.GPIO
+	dcPin      machine.Pin
+	rstPin     machine.Pin
+	scePin     machine.Pin
 	buffer     []byte
 	width      int16
 	height     int16
@@ -28,7 +28,7 @@ type Config struct {
 }
 
 // New creates a new PCD8544 connection. The SPI bus must already be configured.
-func New(bus machine.SPI, dcPin machine.GPIO, rstPin machine.GPIO, scePin machine.GPIO) *Device {
+func New(bus machine.SPI, dcPin, rstPin, scePin machine.Pin) *Device {
 	return &Device{
 		bus:    bus,
 		dcPin:  dcPin,

--- a/ssd1306/ssd1306.go
+++ b/ssd1306/ssd1306.go
@@ -35,9 +35,9 @@ type I2CBus struct {
 
 type SPIBus struct {
 	wire     machine.SPI
-	dcPin    machine.GPIO
-	resetPin machine.GPIO
-	csPin    machine.GPIO
+	dcPin    machine.Pin
+	resetPin machine.Pin
+	csPin    machine.Pin
 }
 
 type Buser interface {
@@ -59,19 +59,16 @@ func NewI2C(bus machine.I2C) Device {
 }
 
 // NewSPI creates a new SSD1306 connection. The SPI wire must already be configured.
-func NewSPI(bus machine.SPI, dcPin uint8, resetPin uint8, csPin uint8) Device {
-	pinDc := machine.GPIO{dcPin}
-	pinDc.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
-	pinReset := machine.GPIO{resetPin}
-	pinReset.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
-	pinCs := machine.GPIO{csPin}
-	pinCs.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+func NewSPI(bus machine.SPI, dcPin, resetPin, csPin machine.Pin) Device {
+	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	resetPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	return Device{
 		bus: &SPIBus{
 			wire:     bus,
-			dcPin:    pinDc,
-			resetPin: pinReset,
-			csPin:    pinCs,
+			dcPin:    dcPin,
+			resetPin: resetPin,
+			csPin:    csPin,
 		},
 	}
 }

--- a/thermistor/thermistor.go
+++ b/thermistor/thermistor.go
@@ -43,7 +43,7 @@ type Device struct {
 }
 
 // New returns a new thermistor driver given an ADC pin.
-func New(pin uint8) Device {
+func New(pin machine.Pin) Device {
 	adc := machine.ADC{pin}
 	return Device{
 		adc:                &adc,

--- a/waveshare-epd/epd2in13/epd2in13.go
+++ b/waveshare-epd/epd2in13/epd2in13.go
@@ -17,10 +17,10 @@ type Config struct {
 
 type Device struct {
 	bus          machine.SPI
-	cs           machine.GPIO
-	dc           machine.GPIO
-	rst          machine.GPIO
-	busy         machine.GPIO
+	cs           machine.Pin
+	dc           machine.Pin
+	rst          machine.Pin
+	busy         machine.Pin
 	width        int16
 	height       int16
 	buffer       []uint8
@@ -44,21 +44,17 @@ var lutPartialUpdate = [30]uint8{
 }
 
 // New returns a new epd2in13x driver. Pass in a fully configured SPI bus.
-func New(bus machine.SPI, csPin uint8, dcPin uint8, rstPin uint8, busyPin uint8) Device {
-	pinCs := machine.GPIO{csPin}
-	pinCs.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
-	pinDc := machine.GPIO{dcPin}
-	pinDc.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
-	pinRst := machine.GPIO{rstPin}
-	pinRst.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
-	pinBusy := machine.GPIO{busyPin}
-	pinBusy.Configure(machine.GPIOConfig{Mode: machine.GPIO_INPUT})
+func New(bus machine.SPI, csPin, dcPin, rstPin, busyPin machine.Pin) Device {
+	csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	rstPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	busyPin.Configure(machine.PinConfig{Mode: machine.PinInput})
 	return Device{
 		bus:  bus,
-		cs:   pinCs,
-		dc:   pinDc,
-		rst:  pinRst,
-		busy: pinBusy,
+		cs:   csPin,
+		dc:   dcPin,
+		rst:  rstPin,
+		busy: busyPin,
 	}
 }
 

--- a/waveshare-epd/epd2in13x/epd2in13x.go
+++ b/waveshare-epd/epd2in13x/epd2in13x.go
@@ -18,10 +18,10 @@ type Config struct {
 
 type Device struct {
 	bus          machine.SPI
-	cs           machine.GPIO
-	dc           machine.GPIO
-	rst          machine.GPIO
-	busy         machine.GPIO
+	cs           machine.Pin
+	dc           machine.Pin
+	rst          machine.Pin
+	busy         machine.Pin
 	width        int16
 	height       int16
 	buffer       [][]uint8
@@ -31,21 +31,17 @@ type Device struct {
 type Color uint8
 
 // New returns a new epd2in13x driver. Pass in a fully configured SPI bus.
-func New(bus machine.SPI, csPin uint8, dcPin uint8, rstPin uint8, busyPin uint8) Device {
-	pinCs := machine.GPIO{csPin}
-	pinCs.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
-	pinDc := machine.GPIO{dcPin}
-	pinDc.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
-	pinRst := machine.GPIO{rstPin}
-	pinRst.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
-	pinBusy := machine.GPIO{busyPin}
-	pinBusy.Configure(machine.GPIOConfig{Mode: machine.GPIO_INPUT})
+func New(bus machine.SPI, csPin, dcPin, rstPin, busyPin machine.Pin) Device {
+	csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	rstPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	busyPin.Configure(machine.PinConfig{Mode: machine.PinInput})
 	return Device{
 		bus:  bus,
-		cs:   pinCs,
-		dc:   pinDc,
-		rst:  pinRst,
-		busy: pinBusy,
+		cs:   csPin,
+		dc:   dcPin,
+		rst:  rstPin,
+		busy: busyPin,
 	}
 }
 

--- a/ws2812/ws2812.go
+++ b/ws2812/ws2812.go
@@ -8,12 +8,12 @@ import (
 
 // Device wraps a pin object for an easy driver interface.
 type Device struct {
-	Pin machine.GPIO
+	Pin machine.Pin
 }
 
 // New returns a new WS2812 driver. It does not touch the pin object: you have
 // to configure it as an output pin before calling New.
-func New(pin machine.GPIO) Device {
+func New(pin machine.Pin) Device {
 	return Device{pin}
 }
 


### PR DESCRIPTION
This PR refactors all current drivers to use new machine.Pin interface instead of the older machine.GPIO interface.

In order for it to pass tests and be able to be merged, the PR https://github.com/tinygo-org/tinygo/pull/314 must be merged first.