### PR TITLE
ws2812: better support the nrf52832

### DIFF
--- a/ws2812/ws2812_m4_64m.go
+++ b/ws2812/ws2812_m4_64m.go
@@ -17,12 +17,12 @@ func (d Device) WriteByte(c byte) error {
 
 	// See:
 	// https://wp.josh.com/2014/05/13/ws2812-neopixels-are-not-so-finicky-once-you-get-to-know-them/
-	// T0H: 14-16 cycles or  218.75ns -  250.00ns
+	// T0H: 17-19 cycles or  265.63ns -  296.88ns
 	// T0L: 54-56 cycles or  843.75ns -  875.00ns
-	//   +: 68-72 cycles or 1062.50ns - 1125.00ns
-	// T1H: 36-38 cycles or  562.50ns -  593.75ns
+	//   +: 71-75 cycles or 1109.38ns - 1171.88ns
+	// T1H: 39-41 cycles or  609.38ns -  640.63ns
 	// T1L: 30-32 cycles or  468.75ns -  500.0ns
-	//   +: 66-70 cycles or 1031.25ns - 1093.75ns
+	//   +: 69-73 cycles or 1078.13ns - 1140.63ns
 	// A branch is treated here as 1-3 cycles, because apparently it might get
 	// speculated. This is more of a guess than hard fact, because the only docs
 	// by ARM that state this are now considered superseded (by what?).
@@ -32,6 +32,9 @@ func (d Device) WriteByte(c byte) error {
 		str   {maskSet}, {portSet}     @ [2]   T0H and T0L start here
 		lsls  {value}, #1              @ [1]
 		nop                            @ [10]
+		nop
+		nop
+		nop
 		nop
 		nop
 		nop


### PR DESCRIPTION
This has cost me _hours_ to find. There are many clones of the ws2812
and they have slightly different timing characteristics. Some don't work
so well when you get close to the minimum T1H time: a 1-bit may be
interpreted as a 0-bit.