### PR TITLE
espat: update commands

### DIFF
--- a/espat/README.md
+++ b/espat/README.md
@@ -1,0 +1,69 @@
+# ESP-AT Driver
+
+This package provides a driver to use a separate connected WiFi processor either the ESP8266 or the ESP32 from Espressif. 
+
+The way this driver works is by using the UART interface to communicate with the WiFi chip using the Espressif AT command set.
+
+## ESP-AT Firmware Installation
+
+In order to use this driver, you must have the ESP-AT firmware installed on the ESP8266/ESP32 chip.
+
+### Installing on ESP32
+
+The official repository for the ESP-AT for the ESP32 processor is located here:
+
+https://github.com/espressif/esp32-at
+
+Your best option is to follow the instructions in the official repo.
+
+### Installing on ESP8266
+
+The official repository for the AT command set firmware for the ESP8266 processor is located here:
+
+https://github.com/espressif/ESP8266_NONOS_SDK
+
+First clone the repo:
+
+```shell
+git clone https://github.com/espressif/ESP8266_NONOS_SDK.git
+```
+
+You will also need to install the Espressif `esptool` to flash this firmware on your ESP8266:
+
+https://github.com/espressif/esptool
+
+Once you have obtained the binary code, and installed `esptool`, you can flash the ESP8266.
+
+Here is an example shell script that flashes a Wemos D1 Mini board:
+
+
+```python
+#!/bin/sh
+SPToolDir="$HOME/.local/lib/python2.7/site-packages"
+FirmwareDir="$HOME/Development/ESP8266_NONOS_SDK"
+cd "$SPToolDir"
+port=/dev/ttyUSB0
+if [ ! -c $port ]; then
+   port=/dev/ttyUSB0
+fi
+if [ ! -c $port ]; then
+   echo "No device appears to be plugged in.  Stopping."
+fi
+printf "Writing AT firmware to the Wemos D1 Mini in 3..."
+sleep 1; printf "2..."
+sleep 1; printf "1..."
+sleep 1; echo "done."
+echo "Erasing the flash first"
+esptool.py --port $port erase_flash
+esptool.py --port /dev/ttyUSB0 --baud 115200 \
+   write_flash -fm dio -ff 20m -fs detect \
+   0x0000 "$FirmwareDir/bin/boot_v1.7.bin" \
+   0x01000 "$FirmwareDir/bin/at/512+512/user1.1024.new.2.bin" \
+   0x3fc000 "$FirmwareDir/bin/esp_init_data_default_v05.bin"  \
+   0x7e000 "$FirmwareDir/bin/blank.bin" \
+   0x3fe000 "$FirmwareDir/bin/blank.bin"
+
+echo "Check the boot by typing: miniterm $port 74800"
+echo " and then resetting.  Use Ctrl-] to quit miniterm."
+
+```

--- a/espat/commands.go
+++ b/espat/commands.go
@@ -42,12 +42,14 @@ const (
 	Disconnect = "+CWQAP"
 
 	// Set softAP configuration. This also activates the ESP8266/ESP32 to act as an access point.
-	// The settings will not be saved in flash memory, so they will be forgotten on next reset.
-	SoftAPConfigCurrent = "+CWSAP_CUR"
+	// On the ESP8266 the settings will not be saved in flash memory, so they will be forgotten on next reset.
+	// On the ESP32 the settings WILL be saved in flash memory, so they will be used on next reset.
+	SoftAPConfigCurrent = "+CWSAP"
 
-	// Set softAP configuration as saved in flash. This also activates the ESP8266/ESP32 to act as an
-	// access point. The settings will be saved in flash memory, so they will be used on next reset.
-	SoftAPConfigFlash = "+CWSAP_DEF"
+	// Set softAP configuration. This also activates the ESP8266/ESP32 to act as an access point.
+	// On the ESP8266 the settings will not be saved in flash memory, so they will be forgotten on next reset.
+	// On the ESP32 the settings WILL be saved in flash memory, so they will be used on next reset.
+	SoftAPConfigFlash = "+CWSAP"
 
 	// List station IP's connected to softAP
 	ListConnectedIP = "+CWLIF"
@@ -65,12 +67,14 @@ const (
 	SetStationIP = "+CIPSTA"
 
 	// Set IP address of ESP8266/ESP32 when acting as access point.
-	// The IP address will not be saved in flash memory, so it will be forgotten on next reset.
-	SetSoftAPIPCurrent = "+CIPAP_CUR"
+	// On the ESP8266 the IP address will not be saved in flash memory, so it will be forgotten on next reset.
+	// On the ESP32 the IP address WILL be saved in flash memory, so it will be used on next reset.
+	SetSoftAPIPCurrent = "+CIPAP"
 
 	// Set IP address of ESP8266/ESP32 when acting as access point.
-	// The IP address will be saved in flash memory, so they will be used on next reset.
-	SetSoftAPIPFlash = "+CIPAP_DEF"
+	// On the ESP8266 the IP address will not be saved in flash memory, so it will be forgotten on next reset.
+	// On the ESP32 the IP address WILL be saved in flash memory, so it will be used on next reset.
+	SetSoftAPIPFlash = "+CIPAP"
 )
 
 // TCP/IP commands

--- a/espat/commands.go
+++ b/espat/commands.go
@@ -85,6 +85,9 @@ const (
 	// Establish TCP connection or register UDP port
 	TCPConnect = "+CIPSTART"
 
+	// DNS Lookup
+	TCPDNSLookup = "+CIPDOMAIN"
+
 	// Send Data
 	TCPSend = "+CIPSEND"
 

--- a/espat/espat.go
+++ b/espat/espat.go
@@ -36,6 +36,9 @@ type Device struct {
 	socketdata []byte
 }
 
+// ActiveDevice is the currently configured Device in use. There can only be one.
+var ActiveDevice *Device
+
 // New returns a new espat driver. Pass in a fully configured UART bus.
 func New(b machine.UART) *Device {
 	return &Device{bus: b, response: make([]byte, 512), socketdata: make([]byte, 0, 1024)}
@@ -43,6 +46,7 @@ func New(b machine.UART) *Device {
 
 // Configure sets up the device for communication.
 func (d Device) Configure() {
+	ActiveDevice = &d
 }
 
 // Connected checks if there is communication with the ESP8266/ESP32.

--- a/espat/mqtt/mqtt.go
+++ b/espat/mqtt/mqtt.go
@@ -1,0 +1,186 @@
+package mqtt
+
+import (
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/eclipse/paho.mqtt.golang/packets"
+	"tinygo.org/x/drivers/espat"
+)
+
+// NewClient will create an MQTT v3.1.1 client with all of the options specified
+// in the provided ClientOptions. The client must have the Connect method called
+// on it before it may be used. This is to make sure resources (such as a net
+// connection) are created before the application is actually ready.
+func NewClient(o *ClientOptions) Client {
+	c := &mqttclient{opts: o, adaptor: o.Adaptor}
+	return c
+}
+
+type mqttclient struct {
+	adaptor   *espat.Device
+	conn      espat.Conn
+	connected bool
+	opts      *ClientOptions
+	mid       uint16
+}
+
+// AddRoute allows you to add a handler for messages on a specific topic
+// without making a subscription. For example having a different handler
+// for parts of a wildcard subscription
+func (c *mqttclient) AddRoute(topic string, callback MessageHandler) {
+	return
+}
+
+// IsConnected returns a bool signifying whether
+// the client is connected or not.
+func (c *mqttclient) IsConnected() bool {
+	return c.connected
+}
+
+// IsConnectionOpen return a bool signifying whether the client has an active
+// connection to mqtt broker, i.e not in disconnected or reconnect mode
+func (c *mqttclient) IsConnectionOpen() bool {
+	return c.connected
+}
+
+// Connect will create a connection to the message broker.
+func (c *mqttclient) Connect() Token {
+	var err error
+
+	// make connection
+	if strings.Contains(c.opts.Servers, "ssl://") {
+		url := strings.TrimPrefix(c.opts.Servers, "ssl://")
+		c.conn, err = c.adaptor.DialTLS("tcp", url, nil)
+		if err != nil {
+			return &mqtttoken{err: err}
+		}
+	} else if strings.Contains(c.opts.Servers, "tcp://") {
+		url := strings.TrimPrefix(c.opts.Servers, "tcp://")
+		c.conn, err = c.adaptor.Dial("tcp", url)
+		if err != nil {
+			return &mqtttoken{err: err}
+		}
+	} else {
+		// invalid protocol
+		return &mqtttoken{err: errors.New("invalid protocol")}
+	}
+
+	// send the MQTT connect message
+	connectPkt := packets.NewControlPacket(packets.Connect).(*packets.ConnectPacket)
+	connectPkt.Qos = 0
+	if c.opts.Username != "" {
+		connectPkt.Username = c.opts.Username
+		connectPkt.UsernameFlag = true
+	}
+
+	if c.opts.Password != "" {
+		connectPkt.Password = []byte(c.opts.Password)
+		connectPkt.PasswordFlag = true
+	}
+
+	connectPkt.ClientIdentifier = c.opts.ClientID //"tinygo-client-" + randomString(10)
+	connectPkt.ProtocolVersion = byte(c.opts.ProtocolVersion)
+	connectPkt.ProtocolName = "MQTT"
+	connectPkt.Keepalive = 30
+
+	err = connectPkt.Write(c.conn)
+	if err != nil {
+		return &mqtttoken{err: err}
+	}
+
+	// TODO: handle timeout
+	for {
+		packet, _ := packets.ReadPacket(c.conn)
+
+		if packet != nil {
+			ack, ok := packet.(*packets.ConnackPacket)
+			if ok {
+				if ack.ReturnCode == 0 {
+					// success
+					return &mqtttoken{}
+				}
+				// otherwise something went wrong
+				return &mqtttoken{err: errors.New(packet.String())}
+			}
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	c.connected = true
+	return &mqtttoken{}
+}
+
+// Disconnect will end the connection with the server, but not before waiting
+// the specified number of milliseconds to wait for existing work to be
+// completed.
+func (c *mqttclient) Disconnect(quiesce uint) {
+	c.conn.Close()
+	return
+}
+
+// Publish will publish a message with the specified QoS and content
+// to the specified topic.
+// Returns a token to track delivery of the message to the broker
+func (c *mqttclient) Publish(topic string, qos byte, retained bool, payload interface{}) Token {
+	pub := packets.NewControlPacket(packets.Publish).(*packets.PublishPacket)
+	pub.Qos = qos
+	pub.TopicName = topic
+	switch payload.(type) {
+	case string:
+		pub.Payload = []byte(payload.(string))
+	case []byte:
+		pub.Payload = payload.([]byte)
+	default:
+		return &mqtttoken{err: errors.New("Unknown payload type")}
+	}
+	pub.MessageID = c.mid
+	c.mid++
+
+	err := pub.Write(c.conn)
+	return &mqtttoken{err: err}
+}
+
+// Subscribe starts a new subscription. Provide a MessageHandler to be executed when
+// a message is published on the topic provided.
+func (c *mqttclient) Subscribe(topic string, qos byte, callback MessageHandler) Token {
+	return &mqtttoken{}
+}
+
+// SubscribeMultiple starts a new subscription for multiple topics. Provide a MessageHandler to
+// be executed when a message is published on one of the topics provided.
+func (c *mqttclient) SubscribeMultiple(filters map[string]byte, callback MessageHandler) Token {
+	return &mqtttoken{}
+}
+
+// Unsubscribe will end the subscription from each of the topics provided.
+// Messages published to those topics from other clients will no longer be
+// received.
+func (c *mqttclient) Unsubscribe(topics ...string) Token {
+	return &mqtttoken{}
+}
+
+// OptionsReader returns a ClientOptionsReader which is a copy of the clientoptions
+// in use by the client.
+func (c *mqttclient) OptionsReader() ClientOptionsReader {
+	r := ClientOptionsReader{}
+	return r
+}
+
+type mqtttoken struct {
+	err error
+}
+
+func (t *mqtttoken) Wait() bool {
+	return true
+}
+
+func (t *mqtttoken) WaitTimeout(time.Duration) bool {
+	return true
+}
+
+func (t *mqtttoken) Error() error {
+	return t.err
+}

--- a/espat/mqtt/mqtt.go
+++ b/espat/mqtt/mqtt.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/eclipse/paho.mqtt.golang/packets"
 	"tinygo.org/x/drivers/espat"
+	"tinygo.org/x/drivers/espat/net"
+	"tinygo.org/x/drivers/espat/tls"
 )
 
 // NewClient will create an MQTT v3.1.1 client with all of the options specified
@@ -20,7 +22,7 @@ func NewClient(o *ClientOptions) Client {
 
 type mqttclient struct {
 	adaptor   *espat.Device
-	conn      espat.Conn
+	conn      net.Conn
 	connected bool
 	opts      *ClientOptions
 	mid       uint16
@@ -52,13 +54,13 @@ func (c *mqttclient) Connect() Token {
 	// make connection
 	if strings.Contains(c.opts.Servers, "ssl://") {
 		url := strings.TrimPrefix(c.opts.Servers, "ssl://")
-		c.conn, err = c.adaptor.DialTLS("tcp", url, nil)
+		c.conn, err = tls.Dial("tcp", url, nil)
 		if err != nil {
 			return &mqtttoken{err: err}
 		}
 	} else if strings.Contains(c.opts.Servers, "tcp://") {
 		url := strings.TrimPrefix(c.opts.Servers, "tcp://")
-		c.conn, err = c.adaptor.Dial("tcp", url)
+		c.conn, err = net.Dial("tcp", url)
 		if err != nil {
 			return &mqtttoken{err: err}
 		}

--- a/espat/mqtt/paho.go
+++ b/espat/mqtt/paho.go
@@ -1,0 +1,245 @@
+// The following code is a slightly modified version of code taken from the Paho MQTT library.
+// It is here until TinyGo can compile the "net" package from the standard library, at which time
+// it can be removed.
+
+/*
+ * Copyright (c) 2013 IBM Corp.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Seth Hoenig
+ *    Allan Stockdill-Mander
+ *    Mike Robertson
+ */
+
+// Portions copyright © 2018 TIBCO Software Inc.
+
+package mqtt
+
+import (
+	"strings"
+	"time"
+
+	"tinygo.org/x/drivers/espat"
+)
+
+const (
+	disconnected uint32 = iota
+	connecting
+	reconnecting
+	connected
+)
+
+// Client is the interface definition for a Client as used by this
+// library, the interface is primarily to allow mocking tests.
+//
+// It is an MQTT v3.1.1 client for communicating
+// with an MQTT server using non-blocking methods that allow work
+// to be done in the background.
+// An application may connect to an MQTT server using:
+//   A plain TCP socket
+//   A secure SSL/TLS socket
+//   A websocket
+// To enable ensured message delivery at Quality of Service (QoS) levels
+// described in the MQTT spec, a message persistence mechanism must be
+// used. This is done by providing a type which implements the Store
+// interface. For convenience, FileStore and MemoryStore are provided
+// implementations that should be sufficient for most use cases. More
+// information can be found in their respective documentation.
+// Numerous connection options may be specified by configuring a
+// and then supplying a ClientOptions type.
+type Client interface {
+	// IsConnected returns a bool signifying whether
+	// the client is connected or not.
+	IsConnected() bool
+	// IsConnectionOpen return a bool signifying wether the client has an active
+	// connection to mqtt broker, i.e not in disconnected or reconnect mode
+	IsConnectionOpen() bool
+	// Connect will create a connection to the message broker, by default
+	// it will attempt to connect at v3.1.1 and auto retry at v3.1 if that
+	// fails
+	Connect() Token
+	// Disconnect will end the connection with the server, but not before waiting
+	// the specified number of milliseconds to wait for existing work to be
+	// completed.
+	Disconnect(quiesce uint)
+	// Publish will publish a message with the specified QoS and content
+	// to the specified topic.
+	// Returns a token to track delivery of the message to the broker
+	Publish(topic string, qos byte, retained bool, payload interface{}) Token
+	// Subscribe starts a new subscription. Provide a MessageHandler to be executed when
+	// a message is published on the topic provided, or nil for the default handler
+	Subscribe(topic string, qos byte, callback MessageHandler) Token
+	// SubscribeMultiple starts a new subscription for multiple topics. Provide a MessageHandler to
+	// be executed when a message is published on one of the topics provided, or nil for the
+	// default handler
+	SubscribeMultiple(filters map[string]byte, callback MessageHandler) Token
+	// Unsubscribe will end the subscription from each of the topics provided.
+	// Messages published to those topics from other clients will no longer be
+	// received.
+	Unsubscribe(topics ...string) Token
+	// AddRoute allows you to add a handler for messages on a specific topic
+	// without making a subscription. For example having a different handler
+	// for parts of a wildcard subscription
+	AddRoute(topic string, callback MessageHandler)
+	// OptionsReader returns a ClientOptionsReader which is a copy of the clientoptions
+	// in use by the client.
+	OptionsReader() ClientOptionsReader
+}
+
+// Token defines the interface for the tokens used to indicate when
+// actions have completed.
+type Token interface {
+	Wait() bool
+	WaitTimeout(time.Duration) bool
+	Error() error
+}
+
+// MessageHandler is a callback type which can be set to be
+// executed upon the arrival of messages published to topics
+// to which the client is subscribed.
+type MessageHandler func(Client, Message)
+
+// Message defines the externals that a message implementation must support
+// these are received messages that are passed to the callbacks, not internal
+// messages
+type Message interface {
+	Duplicate() bool
+	Qos() byte
+	Retained() bool
+	Topic() string
+	MessageID() uint16
+	Payload() []byte
+	Ack()
+}
+
+type message struct {
+	duplicate bool
+	qos       byte
+	retained  bool
+	topic     string
+	messageID uint16
+	payload   []byte
+	ack       func()
+}
+
+func (m *message) Duplicate() bool {
+	return m.duplicate
+}
+
+func (m *message) Qos() byte {
+	return m.qos
+}
+
+func (m *message) Retained() bool {
+	return m.retained
+}
+
+func (m *message) Topic() string {
+	return m.topic
+}
+
+func (m *message) MessageID() uint16 {
+	return m.messageID
+}
+
+func (m *message) Payload() []byte {
+	return m.payload
+}
+
+func (m *message) Ack() {
+	return
+}
+
+// ClientOptionsReader provides an interface for reading ClientOptions after the client has been initialized.
+type ClientOptionsReader struct {
+	options *ClientOptions
+}
+
+// ClientOptions contains configurable options for an MQTT Client.
+type ClientOptions struct {
+	Adaptor *espat.Device
+
+	//Servers                 []*url.URL
+	Servers  string
+	ClientID string
+	Username string
+	Password string
+	//CredentialsProvider     CredentialsProvider
+	CleanSession            bool
+	Order                   bool
+	WillEnabled             bool
+	WillTopic               string
+	WillPayload             []byte
+	WillQos                 byte
+	WillRetained            bool
+	ProtocolVersion         uint
+	protocolVersionExplicit bool
+	//TLSConfig               *tls.Config
+	KeepAlive            int64
+	PingTimeout          time.Duration
+	ConnectTimeout       time.Duration
+	MaxReconnectInterval time.Duration
+	AutoReconnect        bool
+	//Store                   Store
+	//DefaultPublishHandler   MessageHandler
+	//OnConnect               OnConnectHandler
+	//OnConnectionLost        ConnectionLostHandler
+	WriteTimeout        time.Duration
+	MessageChannelDepth uint
+	ResumeSubs          bool
+	//HTTPHeaders             http.Header
+}
+
+// NewClientOptions returns a new ClientOptions struct.
+func NewClientOptions(adaptor *espat.Device) *ClientOptions {
+	return &ClientOptions{Adaptor: adaptor, ProtocolVersion: 4}
+}
+
+// AddBroker adds a broker URI to the list of brokers to be used. The format should be
+// scheme://host:port
+// Where "scheme" is one of "tcp", "ssl", or "ws", "host" is the ip-address (or hostname)
+// and "port" is the port on which the broker is accepting connections.
+//
+// Default values for hostname is "127.0.0.1", for schema is "tcp://".
+//
+// An example broker URI would look like: tcp://foobar.com:1883
+func (o *ClientOptions) AddBroker(server string) *ClientOptions {
+	if len(server) > 0 && server[0] == ':' {
+		server = "127.0.0.1" + server
+	}
+	if !strings.Contains(server, "://") {
+		server = "tcp://" + server
+	}
+
+	o.Servers = server
+	return o
+}
+
+// SetClientID will set the client id to be used by this client when
+// connecting to the MQTT broker. According to the MQTT v3.1 specification,
+// a client id mus be no longer than 23 characters.
+func (o *ClientOptions) SetClientID(id string) *ClientOptions {
+	o.ClientID = id
+	return o
+}
+
+// SetUsername will set the username to be used by this client when connecting
+// to the MQTT broker. Note: without the use of SSL/TLS, this information will
+// be sent in plaintext accross the wire.
+func (o *ClientOptions) SetUsername(u string) *ClientOptions {
+	o.Username = u
+	return o
+}
+
+// SetPassword will set the password to be used by this client when connecting
+// to the MQTT broker. Note: without the use of SSL/TLS, this information will
+// be sent in plaintext accross the wire.
+func (o *ClientOptions) SetPassword(p string) *ClientOptions {
+	o.Password = p
+	return o
+}

--- a/espat/net.go
+++ b/espat/net.go
@@ -2,6 +2,7 @@ package espat
 
 import (
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -154,6 +155,51 @@ func (c *SerialConn) SetReadDeadline(t time.Time) error {
 // A zero value for t means Write will not time out.
 func (c *SerialConn) SetWriteDeadline(t time.Time) error {
 	return nil
+}
+
+// ResolveTCPAddr returns an address of TCP end point.
+//
+// The network must be a TCP network name.
+//
+func (d *Device) ResolveTCPAddr(network, address string) (*TCPAddr, error) {
+	// TODO: make sure network is 'tcp'
+	// separate domain from port, if any
+	r := strings.Split(address, ":")
+	ip, err := d.GetDNS(r[0])
+	if err != nil {
+		return nil, err
+	}
+	if len(r) > 1 {
+		port, e := strconv.Atoi(r[1])
+		if e != nil {
+			return nil, e
+		}
+		return &TCPAddr{IP: ip, Port: port}, nil
+	}
+	return &TCPAddr{IP: ip}, nil
+}
+
+// ResolveUDPAddr returns an address of UDP end point.
+//
+// The network must be a UDP network name.
+//
+func (d *Device) ResolveUDPAddr(network, address string) (*UDPAddr, error) {
+	// TODO: make sure network is 'udp'
+	// separate domain from port, if any
+	r := strings.Split(address, ":")
+	ip, err := d.GetDNS(r[0])
+	if err != nil {
+		return nil, err
+	}
+	if len(r) > 1 {
+		port, e := strconv.Atoi(r[1])
+		if e != nil {
+			return nil, e
+		}
+		return &UDPAddr{IP: ip, Port: port}, nil
+	}
+
+	return &UDPAddr{IP: ip}, nil
 }
 
 // The following definitions are here to support a Golang standard package

--- a/espat/tcp.go
+++ b/espat/tcp.go
@@ -1,7 +1,9 @@
 package espat
 
 import (
+	"errors"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -19,9 +21,12 @@ func (d *Device) ConnectTCPSocket(addr, port string) error {
 	protocol := "TCP"
 	val := "\"" + protocol + "\",\"" + addr + "\"," + port
 	d.Set(TCPConnect, val)
-	time.Sleep(pause * time.Millisecond)
-	d.Response()
-	return nil
+	time.Sleep(1000 * time.Millisecond)
+	r := d.Response()
+	if strings.Contains(string(r), "OK") {
+		return nil
+	}
+	return errors.New("ConnectTCPSocket error:" + string(r))
 }
 
 // ConnectUDPSocket creates a new UDP connection for the ESP8266/ESP32.
@@ -30,8 +35,11 @@ func (d *Device) ConnectUDPSocket(addr, sendport, listenport string) error {
 	val := "\"" + protocol + "\",\"" + addr + "\"," + sendport + "," + listenport + ",2"
 	d.Set(TCPConnect, val)
 	time.Sleep(pause * time.Millisecond)
-	d.Response()
-	return nil
+	r := d.Response()
+	if strings.Contains(string(r), "OK") {
+		return nil
+	}
+	return errors.New("ConnectUDPSocket error:" + string(r))
 }
 
 // DisconnectSocket disconnects the ESP8266/ESP32 from the current TCP/UDP connection.
@@ -78,17 +86,22 @@ func (d *Device) GetTCPTransferMode() []byte {
 func (d *Device) StartSocketSend(size int) error {
 	val := strconv.Itoa(size)
 	d.Set(TCPSend, val)
+	time.Sleep(pause * time.Millisecond)
 
-	// TODO: wait until ">" is received, which indicates
+	// when ">" is received, it indicates
 	// ready to receive data
-	d.Response()
-	return nil
+	r := d.Response()
+	if strings.Contains(string(r), ">") {
+		return nil
+	}
+	return errors.New("StartSocketSend error:" + string(r))
 }
 
 // EndSocketSend tell the ESP8266/ESP32 the TCP/UDP socket data sending is complete,
 // and to return to command mode. This is only used in "unvarnished" raw mode.
 func (d *Device) EndSocketSend() error {
 	d.Write([]byte("+++"))
+	time.Sleep(pause * time.Millisecond)
 
 	// TODO: wait until ">" is received, which indicates
 	// ready to receive data

--- a/espat/tcp.go
+++ b/espat/tcp.go
@@ -54,6 +54,20 @@ func (d *Device) ConnectUDPSocket(addr, sendport, listenport string) error {
 	return errors.New("ConnectUDPSocket error:" + string(r))
 }
 
+// ConnectSSLSocket creates a new SSL socket connection for the ESP8266/ESP32.
+// Currently only supports single connection mode.
+func (d *Device) ConnectSSLSocket(addr, port string) error {
+	protocol := "SSL"
+	val := "\"" + protocol + "\",\"" + addr + "\"," + port + ",120"
+	d.Set(TCPConnect, val)
+	time.Sleep(5000 * time.Millisecond)
+	r := d.Response()
+	if strings.Contains(string(r), "CONNECT") {
+		return nil
+	}
+	return errors.New("ConnectSSLSocket error:" + string(r))
+}
+
 // DisconnectSocket disconnects the ESP8266/ESP32 from the current TCP/UDP connection.
 func (d *Device) DisconnectSocket() error {
 	d.Execute(TCPClose)

--- a/espat/tcp.go
+++ b/espat/tcp.go
@@ -15,14 +15,14 @@ const (
 )
 
 // GetDNS returns the IP address for a domain name.
-func (d *Device) GetDNS(domain string) (IP, error) {
+func (d *Device) GetDNS(domain string) (string, error) {
 	d.Set(TCPDNSLookup, "\""+domain+"\"")
 	r := strings.Split(string(d.Response(1000)), ":")
 	if len(r) != 2 {
-		return nil, errors.New("Invalid domain lookup result")
+		return "", errors.New("Invalid domain lookup result")
 	}
 	res := strings.Split(r[1], "\r\n")
-	return IP(res[0]), nil
+	return res[0], nil
 }
 
 // ConnectTCPSocket creates a new TCP socket connection for the ESP8266/ESP32.

--- a/espat/tcp.go
+++ b/espat/tcp.go
@@ -15,11 +15,23 @@ const (
 	TCPTransferModeUnvarnished = 1
 )
 
+// GetDNS returns the IP address for a domain name.
+func (d *Device) GetDNS(domain string) (IP, error) {
+	d.Set(TCPDNSLookup, "\""+domain+"\"")
+	time.Sleep(1000 * time.Millisecond)
+	r := strings.Split(string(d.Response()), ":")
+	if len(r) != 2 {
+		return nil, errors.New("Invalid domain lookup result")
+	}
+	res := strings.Split(r[1], "\r\n")
+	return IP(res[0]), nil
+}
+
 // ConnectTCPSocket creates a new TCP socket connection for the ESP8266/ESP32.
 // Currently only supports single connection mode.
 func (d *Device) ConnectTCPSocket(addr, port string) error {
 	protocol := "TCP"
-	val := "\"" + protocol + "\",\"" + addr + "\"," + port
+	val := "\"" + protocol + "\",\"" + addr + "\"," + port + ",120"
 	d.Set(TCPConnect, val)
 	time.Sleep(1000 * time.Millisecond)
 	r := d.Response()

--- a/espat/tcp.go
+++ b/espat/tcp.go
@@ -19,7 +19,7 @@ func (d *Device) ConnectTCPSocket(addr, port string) error {
 	protocol := "TCP"
 	val := "\"" + protocol + "\",\"" + addr + "\"," + port
 	d.Set(TCPConnect, val)
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(pause * time.Millisecond)
 	d.Response()
 	return nil
 }

--- a/espat/tls/tls.go
+++ b/espat/tls/tls.go
@@ -1,0 +1,39 @@
+// Package tls is intended to provide a minimal set of compatible interfaces with the
+// Go standard library's tls package.
+package tls
+
+import (
+	"strconv"
+
+	"tinygo.org/x/drivers/espat"
+	"tinygo.org/x/drivers/espat/net"
+)
+
+// Dial makes a TLS network connection. It tries to provide a mostly compatible interface
+// to tls.Dial().
+// Dial connects to the given network address.
+func Dial(network, address string, config *Config) (*net.TCPSerialConn, error) {
+	raddr, err := net.ResolveTCPAddr(network, address)
+	if err != nil {
+		return nil, err
+	}
+
+	addr := raddr.IP.String()
+	sendport := strconv.Itoa(raddr.Port)
+
+	// disconnect any old socket
+	espat.ActiveDevice.DisconnectSocket()
+
+	// connect new socket
+	err = espat.ActiveDevice.ConnectSSLSocket(addr, sendport)
+	if err != nil {
+		return nil, err
+	}
+
+	return net.NewTCPSerialConn(net.SerialConn{Adaptor: espat.ActiveDevice}, nil, raddr), nil
+}
+
+// Config is a placeholder for future compatibility with
+// tls.Config.
+type Config struct {
+}

--- a/espat/wifi.go
+++ b/espat/wifi.go
@@ -2,7 +2,6 @@ package espat
 
 import (
 	"strconv"
-	"time"
 )
 
 const (
@@ -19,15 +18,14 @@ const (
 // GetWifiMode returns the ESP8266/ESP32 wifi mode.
 func (d *Device) GetWifiMode() []byte {
 	d.Query(WifiMode)
-	return d.Response()
+	return d.Response(100)
 }
 
 // SetWifiMode sets the ESP8266/ESP32 wifi mode.
 func (d *Device) SetWifiMode(mode int) error {
 	val := strconv.Itoa(mode)
 	d.Set(WifiMode, val)
-	time.Sleep(pause * time.Millisecond)
-	d.Response()
+	d.Response(pause)
 	return nil
 }
 
@@ -36,7 +34,7 @@ func (d *Device) SetWifiMode(mode int) error {
 // GetConnectedAP returns the ESP8266/ESP32 is currently connected to as a client.
 func (d *Device) GetConnectedAP() []byte {
 	d.Query(ConnectAP)
-	return d.Response()
+	return d.Response(100)
 }
 
 // ConnectToAP connects the ESP8266/ESP32 to an access point.
@@ -44,32 +42,28 @@ func (d *Device) GetConnectedAP() []byte {
 func (d *Device) ConnectToAP(ssid, pwd string, ws int) error {
 	val := "\"" + ssid + "\",\"" + pwd + "\""
 	d.Set(ConnectAP, val)
-	// TODO: a better way to wait for connect and check for up to ws seconds.
-	time.Sleep(time.Duration(ws) * time.Second)
-	d.Response()
+	d.Response(ws * 1000)
 	return nil
 }
 
 // DisconnectFromAP disconnects the ESP8266/ESP32 from the current access point.
 func (d *Device) DisconnectFromAP() error {
 	d.Execute(Disconnect)
-	time.Sleep(1000 * time.Millisecond)
-	d.Response()
+	d.Response(1000)
 	return nil
 }
 
 // GetClientIP returns the ESP8266/ESP32 current client IP addess when connected to an Access Point.
 func (d *Device) GetClientIP() string {
 	d.Query(SetStationIP)
-	return string(d.Response())
+	return string(d.Response(100))
 }
 
 // SetClientIP sets the ESP8266/ESP32 current client IP addess when connected to an Access Point.
 func (d *Device) SetClientIP(ipaddr string) []byte {
 	val := "\"" + ipaddr + "\""
 	d.Set(ConnectAP, val)
-	time.Sleep(500 * time.Millisecond)
-	d.Response()
+	d.Response(500)
 	return nil
 }
 
@@ -78,7 +72,7 @@ func (d *Device) SetClientIP(ipaddr string) []byte {
 // GetAPConfig returns the ESP8266/ESP32 current configuration when acting as an Access Point.
 func (d *Device) GetAPConfig() string {
 	d.Query(SoftAPConfigCurrent)
-	return string(d.Response())
+	return string(d.Response(100))
 }
 
 // SetAPConfig sets the ESP8266/ESP32 current configuration when acting as an Access Point.
@@ -89,29 +83,27 @@ func (d *Device) SetAPConfig(ssid, pwd string, ch, security int) error {
 	ecnval := strconv.Itoa(security)
 	val := "\"" + ssid + "\",\"" + pwd + "\"," + chval + "," + ecnval
 	d.Set(SoftAPConfigCurrent, val)
-	time.Sleep(1000 * time.Millisecond)
-	d.Response()
+	d.Response(1000)
 	return nil
 }
 
 // GetAPClients returns the ESP8266/ESP32 current clients when acting as an Access Point.
 func (d *Device) GetAPClients() string {
 	d.Query(ListConnectedIP)
-	return string(d.Response())
+	return string(d.Response(100))
 }
 
 // GetAPIP returns the ESP8266/ESP32 current IP addess when configured as an Access Point.
 func (d *Device) GetAPIP() string {
 	d.Query(SetSoftAPIPCurrent)
-	return string(d.Response())
+	return string(d.Response(100))
 }
 
 // SetAPIP sets the ESP8266/ESP32 current IP addess when configured as an Access Point.
 func (d *Device) SetAPIP(ipaddr string) error {
 	val := "\"" + ipaddr + "\""
 	d.Set(SetSoftAPIPCurrent, val)
-	time.Sleep(500 * time.Millisecond)
-	d.Response()
+	d.Response(500)
 	return nil
 }
 
@@ -119,7 +111,7 @@ func (d *Device) SetAPIP(ipaddr string) error {
 // from flash storage. These settings are those used after a reset.
 func (d *Device) GetAPConfigFlash() string {
 	d.Query(SoftAPConfigFlash)
-	return string(d.Response())
+	return string(d.Response(100))
 }
 
 // SetAPConfigFlash sets the ESP8266/ESP32 current configuration acting as an Access Point,
@@ -131,8 +123,7 @@ func (d *Device) SetAPConfigFlash(ssid, pwd string, ch, security int) error {
 	ecnval := strconv.Itoa(security)
 	val := "\"" + ssid + "\",\"" + pwd + "\"," + chval + "," + ecnval
 	d.Set(SoftAPConfigFlash, val)
-	time.Sleep(1000 * time.Millisecond)
-	d.Response()
+	d.Response(1000)
 	return nil
 }
 
@@ -140,7 +131,7 @@ func (d *Device) SetAPConfigFlash(ssid, pwd string, ch, security int) error {
 // This is the IP address that will be used after a reset.
 func (d *Device) GetAPIPFlash() string {
 	d.Query(SetSoftAPIPFlash)
-	return string(d.Response())
+	return string(d.Response(100))
 }
 
 // SetAPIPFlash sets the ESP8266/ESP32 current IP addess when configured as an Access Point.
@@ -148,7 +139,6 @@ func (d *Device) GetAPIPFlash() string {
 func (d *Device) SetAPIPFlash(ipaddr string) error {
 	val := "\"" + ipaddr + "\""
 	d.Set(SetSoftAPIPFlash, val)
-	time.Sleep(500 * time.Millisecond)
-	d.Response()
+	d.Response(500)
 	return nil
 }

--- a/examples/espat/espconsole/main.go
+++ b/examples/espat/espconsole/main.go
@@ -80,11 +80,8 @@ func main() {
 				input[i+1] = byte('\n')
 				adaptor.Write(input[:i+2])
 
-				// give the ESP8266 a chance to respond.
-				time.Sleep(10 * time.Millisecond)
-
 				// display response
-				console.Write(adaptor.Response())
+				console.Write(adaptor.Response(100))
 
 				// prompt
 				prompt()
@@ -118,6 +115,7 @@ func connectToAP() {
 
 // provide access point
 func provideAP() {
+	time.Sleep(500 * time.Millisecond)
 	console.Write([]byte("Starting wifi network as access point '"))
 	console.Write([]byte(ssid))
 	console.Write([]byte("'...\r\n"))

--- a/examples/espat/esphub/main.go
+++ b/examples/espat/esphub/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"tinygo.org/x/drivers/espat"
+	"tinygo.org/x/drivers/espat/net"
 )
 
 // change actAsAP to true to act as an access point instead of connecting to one.
@@ -25,8 +26,6 @@ var (
 	uart = machine.UART1
 	tx   = machine.D10
 	rx   = machine.D11
-
-	console = machine.UART0
 
 	adaptor *espat.Device
 )
@@ -44,7 +43,7 @@ func main() {
 
 	// first check if connected
 	if adaptor.Connected() {
-		console.Write([]byte("Connected to wifi adaptor.\r\n"))
+		println("Connected to wifi adaptor.")
 		adaptor.Echo(false)
 
 		if actAsAP {
@@ -53,24 +52,22 @@ func main() {
 			connectToAP()
 		}
 	} else {
-		console.Write([]byte("\r\n"))
-		console.Write([]byte("Unable to connect to wifi adaptor.\r\n"))
+		println("Unable to connect to wifi adaptor.")
 		return
 	}
 
 	// now make UDP connection
-	laddr := &espat.UDPAddr{Port: 2222}
-	console.Write([]byte("Loading UDP listener...\r\n"))
-	conn, _ := adaptor.ListenUDP("UDP", laddr)
+	laddr := &net.UDPAddr{Port: 2222}
+	println("Loading UDP listener...")
+	conn, _ := net.ListenUDP("UDP", laddr)
 
-	console.Write([]byte("Waiting for data...\r\n"))
+	println("Waiting for data...")
 	data := make([]byte, 50)
 	blink := true
 	for {
 		n, _ := conn.Read(data)
 		if n > 0 {
-			console.Write(data[:n])
-			console.Write([]byte("\r\n"))
+			println(string(data[:n]))
 			conn.Write([]byte("hello back\r\n"))
 		}
 		blink = !blink
@@ -83,29 +80,26 @@ func main() {
 	}
 
 	// Right now this code is never reached. Need a way to trigger it...
-	console.Write([]byte("Disconnecting UDP...\r\n"))
+	println("Disconnecting UDP...")
 	conn.Close()
-	console.Write([]byte("Done.\r\n"))
+	println("Done.")
 }
 
 // connect to access point
 func connectToAP() {
-	console.Write([]byte("Connecting to wifi network...\r\n"))
+	println("Connecting to wifi network...")
 	adaptor.SetWifiMode(espat.WifiModeClient)
 	adaptor.ConnectToAP(ssid, pass, 10)
-	console.Write([]byte("Connected.\r\n"))
-	console.Write([]byte(adaptor.GetClientIP()))
-	console.Write([]byte("\r\n"))
+	println("Connected.")
+	println(adaptor.GetClientIP())
 }
 
 // provide access point
 func provideAP() {
-	console.Write([]byte("Starting wifi network as access point '"))
-	console.Write([]byte(ssid))
-	console.Write([]byte("'...\r\n"))
+	println("Starting wifi network as access point:")
+	println(ssid)
 	adaptor.SetWifiMode(espat.WifiModeAP)
 	adaptor.SetAPConfig(ssid, pass, 7, espat.WifiAPSecurityWPA2_PSK)
-	console.Write([]byte("Ready.\r\n"))
-	console.Write([]byte(adaptor.GetAPIP()))
-	console.Write([]byte("\r\n"))
+	println("Ready.")
+	println(adaptor.GetAPIP())
 }

--- a/examples/espat/espstation/main.go
+++ b/examples/espat/espstation/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"tinygo.org/x/drivers/espat"
+	"tinygo.org/x/drivers/espat/net"
 )
 
 // access point info
@@ -26,8 +27,6 @@ var (
 	tx   = machine.D10
 	rx   = machine.D11
 
-	console = machine.UART0
-
 	adaptor *espat.Device
 )
 
@@ -40,44 +39,42 @@ func main() {
 
 	// first check if connected
 	if adaptor.Connected() {
-		console.Write([]byte("Connected to wifi adaptor.\r\n"))
+		println("Connected to wifi adaptor.")
 		adaptor.Echo(false)
 
 		connectToAP()
 	} else {
-		console.Write([]byte("\r\n"))
-		console.Write([]byte("Unable to connect to wifi adaptor.\r\n"))
+		println("Unable to connect to wifi adaptor.")
 		return
 	}
 
 	// now make UDP connection
-	ip := espat.ParseIP(hubIP)
-	raddr := &espat.UDPAddr{IP: ip, Port: 2222}
-	laddr := &espat.UDPAddr{Port: 2222}
+	ip := net.ParseIP(hubIP)
+	raddr := &net.UDPAddr{IP: ip, Port: 2222}
+	laddr := &net.UDPAddr{Port: 2222}
 
-	console.Write([]byte("Dialing UDP connection...\r\n"))
-	conn, _ := adaptor.DialUDP("udp", laddr, raddr)
+	println("Dialing UDP connection...")
+	conn, _ := net.DialUDP("udp", laddr, raddr)
 
 	for {
 		// send data
-		console.Write([]byte("Sending data...\r\n"))
+		println("Sending data...")
 		conn.Write([]byte("hello\r\n"))
 
 		time.Sleep(1000 * time.Millisecond)
 	}
 
 	// Right now this code is never reached. Need a way to trigger it...
-	console.Write([]byte("Disconnecting UDP...\r\n"))
+	println("Disconnecting UDP...")
 	conn.Close()
-	console.Write([]byte("Done.\r\n"))
+	println("Done.")
 }
 
 // connect to access point
 func connectToAP() {
-	console.Write([]byte("Connecting to wifi network...\r\n"))
+	println("Connecting to wifi network...")
 	adaptor.SetWifiMode(espat.WifiModeClient)
 	adaptor.ConnectToAP(ssid, pass, 10)
-	console.Write([]byte("Connected.\r\n"))
-	console.Write([]byte(adaptor.GetClientIP()))
-	console.Write([]byte("\r\n"))
+	println("Connected.")
+	println(adaptor.GetClientIP())
 }

--- a/examples/espat/mqttclient/main.go
+++ b/examples/espat/mqttclient/main.go
@@ -1,0 +1,148 @@
+// This is a sensor station that uses a ESP8266 or ESP32 running on the device UART1.
+// It creates an MQTT connection that publishes a message every second
+// to an MQTT broker.
+//
+// In other words:
+// Your computer <--> UART0 <--> MCU <--> UART1 <--> ESP8266 <--> Internet <--> MQTT broker.
+//
+// You must install the Paho MQTT package to build this program:
+//
+// 		go get github.com/eclipse/paho.mqtt.golang
+//
+package main
+
+import (
+	"machine"
+	"time"
+
+	"github.com/eclipse/paho.mqtt.golang/packets"
+	"tinygo.org/x/drivers/espat"
+)
+
+// access point info
+const ssid = "YOURSSID"
+const pass = "YOURPASS"
+
+// IP address of the MQTT broker to use. Replace with your own info.
+const server = "test.mosquitto.org:1883"
+
+// change these to connect to a different UART or pins for the ESP8266/ESP32
+var (
+	uart = machine.UART1
+	tx   = machine.D10
+	rx   = machine.D11
+
+	console = machine.UART0
+
+	adaptor *espat.Device
+	conn    *espat.TCPSerialConn
+	err     error
+	mid     uint16
+)
+
+func main() {
+	uart.Configure(machine.UARTConfig{TX: tx, RX: rx})
+
+	time.Sleep(3000 * time.Millisecond)
+
+	// Init esp8266/esp32
+	adaptor = espat.New(uart)
+	adaptor.Configure()
+
+	// first check if connected
+	if adaptor.Connected() {
+		console.Write([]byte("Connected to wifi adaptor.\r\n"))
+		adaptor.Echo(false)
+
+		connectToAP()
+	} else {
+		console.Write([]byte("\r\n"))
+		console.Write([]byte("Unable to connect to wifi adaptor.\r\n"))
+		return
+	}
+
+	// now make TCP connection
+	raddr, _ := adaptor.ResolveTCPAddr("tcp", server)
+	if raddr != nil {
+		println("The IP address from DNS lookup is:")
+		println(string(raddr.IP))
+		println(raddr.Port)
+	}
+	laddr := &espat.TCPAddr{Port: 1883}
+
+	console.Write([]byte("Dialing TCP connection...\r\n"))
+	conn, err = adaptor.DialTCP("tcp", laddr, raddr)
+	if err != nil {
+		println("tcp connect error")
+		println(err.Error())
+	}
+
+	err = connectToMQTTServer()
+
+	for {
+		console.Write([]byte("Publishing MQTT packets...\r\n"))
+
+		publish := packets.NewControlPacket(packets.Publish).(*packets.PublishPacket)
+		publish.Qos = 0
+		publish.TopicName = "tinygo"
+		publish.Payload = []byte("Hello, mqtt\r\n")
+		publish.MessageID = mid
+		mid++
+
+		publish.Write(conn)
+
+		time.Sleep(1000 * time.Millisecond)
+	}
+
+	// Right now this code is never reached. Need a way to trigger it...
+	console.Write([]byte("Disconnecting TCP...\r\n"))
+	conn.Close()
+	console.Write([]byte("Done.\r\n"))
+}
+
+// connect to access point
+func connectToAP() {
+	console.Write([]byte("Connecting to wifi network...\r\n"))
+	adaptor.SetWifiMode(espat.WifiModeClient)
+	adaptor.ConnectToAP(ssid, pass, 10)
+	console.Write([]byte("Connected.\r\n"))
+	console.Write([]byte(adaptor.GetClientIP()))
+	console.Write([]byte("\r\n"))
+}
+
+func connectToMQTTServer() error {
+	// send the MQTT connect message
+	connectPkt := packets.NewControlPacket(packets.Connect).(*packets.ConnectPacket)
+	connectPkt.Qos = 0
+	// connectPkt.Username = "tinygo"
+	// connectPkt.Password = []byte("1234")
+	connectPkt.ClientIdentifier = "tinygo-client"
+	connectPkt.ProtocolVersion = 4
+	connectPkt.ProtocolName = "MQTT"
+	connectPkt.Keepalive = 30
+
+	console.Write([]byte("Sending MQTT connect...\r\n"))
+	err := connectPkt.Write(conn)
+	if err != nil {
+		println("mqtt connect error")
+		println(err.Error())
+		return err
+	}
+
+	console.Write([]byte("Waiting for MQTT connect...\r\n"))
+	// TODO: handle timeout
+	for {
+		packet, _ := packets.ReadPacket(conn)
+
+		if packet != nil {
+			_, ok := packet.(*packets.ConnackPacket)
+			if ok {
+				console.Write([]byte("Connected to MQTT server.\r\n"))
+				println(packet.String())
+				return nil
+			}
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/examples/espat/tcpclient/main.go
+++ b/examples/espat/tcpclient/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"tinygo.org/x/drivers/espat"
+	"tinygo.org/x/drivers/espat/net"
 )
 
 // access point info
@@ -26,8 +27,6 @@ var (
 	tx   = machine.PA22
 	rx   = machine.PA23
 
-	console = machine.UART0
-
 	adaptor *espat.Device
 )
 
@@ -40,44 +39,42 @@ func main() {
 
 	// first check if connected
 	if adaptor.Connected() {
-		console.Write([]byte("Connected to wifi adaptor.\r\n"))
+		println("Connected to wifi adaptor.")
 		adaptor.Echo(false)
 
 		connectToAP()
 	} else {
-		console.Write([]byte("\r\n"))
-		console.Write([]byte("Unable to connect to wifi adaptor.\r\n"))
+		println("Unable to connect to wifi adaptor.")
 		return
 	}
 
 	// now make TCP connection
-	ip := espat.ParseIP(serverIP)
-	raddr := &espat.TCPAddr{IP: ip, Port: 8080}
-	laddr := &espat.TCPAddr{Port: 8080}
+	ip := net.ParseIP(serverIP)
+	raddr := &net.TCPAddr{IP: ip, Port: 8080}
+	laddr := &net.TCPAddr{Port: 8080}
 
-	console.Write([]byte("Dialing TCP connection...\r\n"))
-	conn, _ := adaptor.DialTCP("tcp", laddr, raddr)
+	println("Dialing TCP connection...")
+	conn, _ := net.DialTCP("tcp", laddr, raddr)
 
 	for {
 		// send data
-		console.Write([]byte("Sending data...\r\n"))
+		println("Sending data...")
 		conn.Write([]byte("hello\r\n"))
 
 		time.Sleep(1000 * time.Millisecond)
 	}
 
 	// Right now this code is never reached. Need a way to trigger it...
-	console.Write([]byte("Disconnecting TCP...\r\n"))
+	println("Disconnecting TCP...")
 	conn.Close()
-	console.Write([]byte("Done.\r\n"))
+	println("Done.")
 }
 
 // connect to access point
 func connectToAP() {
-	console.Write([]byte("Connecting to wifi network...\r\n"))
+	println("Connecting to wifi network...")
 	adaptor.SetWifiMode(espat.WifiModeClient)
 	adaptor.ConnectToAP(ssid, pass, 10)
-	console.Write([]byte("Connected.\r\n"))
-	console.Write([]byte(adaptor.GetClientIP()))
-	console.Write([]byte("\r\n"))
+	println("Connected.")
+	println(adaptor.GetClientIP())
 }

--- a/examples/espat/tcpclient/main.go
+++ b/examples/espat/tcpclient/main.go
@@ -1,0 +1,83 @@
+// This is a sensor station that uses a ESP8266 or ESP32 running on the device UART1.
+// It creates a UDP connection you can use to get info to/from your computer via the microcontroller.
+//
+// In other words:
+// Your computer <--> UART0 <--> MCU <--> UART1 <--> ESP8266
+//
+package main
+
+import (
+	"machine"
+	"time"
+
+	"tinygo.org/x/drivers/espat"
+)
+
+// access point info
+const ssid = "YOURSSID"
+const pass = "YOURPASS"
+
+// IP address of the server aka "hub". Replace with your own info.
+const serverIP = "0.0.0.0"
+
+// change these to connect to a different UART or pins for the ESP8266/ESP32
+var (
+	uart = machine.UART1
+	tx   = machine.PA22
+	rx   = machine.PA23
+
+	console = machine.UART0
+
+	adaptor *espat.Device
+)
+
+func main() {
+	uart.Configure(machine.UARTConfig{TX: tx, RX: rx})
+
+	// Init esp8266/esp32
+	adaptor = espat.New(uart)
+	adaptor.Configure()
+
+	// first check if connected
+	if adaptor.Connected() {
+		console.Write([]byte("Connected to wifi adaptor.\r\n"))
+		adaptor.Echo(false)
+
+		connectToAP()
+	} else {
+		console.Write([]byte("\r\n"))
+		console.Write([]byte("Unable to connect to wifi adaptor.\r\n"))
+		return
+	}
+
+	// now make TCP connection
+	ip := espat.ParseIP(serverIP)
+	raddr := &espat.TCPAddr{IP: ip, Port: 8080}
+	laddr := &espat.TCPAddr{Port: 8080}
+
+	console.Write([]byte("Dialing TCP connection...\r\n"))
+	conn, _ := adaptor.DialTCP("tcp", laddr, raddr)
+
+	for {
+		// send data
+		console.Write([]byte("Sending data...\r\n"))
+		conn.Write([]byte("hello\r\n"))
+
+		time.Sleep(1000 * time.Millisecond)
+	}
+
+	// Right now this code is never reached. Need a way to trigger it...
+	console.Write([]byte("Disconnecting TCP...\r\n"))
+	conn.Close()
+	console.Write([]byte("Done.\r\n"))
+}
+
+// connect to access point
+func connectToAP() {
+	console.Write([]byte("Connecting to wifi network...\r\n"))
+	adaptor.SetWifiMode(espat.WifiModeClient)
+	adaptor.ConnectToAP(ssid, pass, 10)
+	console.Write([]byte("Connected.\r\n"))
+	console.Write([]byte(adaptor.GetClientIP()))
+	console.Write([]byte("\r\n"))
+}


### PR DESCRIPTION
This PR adds several important features to the ESP-AT driver:

- ensure compatibility with both ESP8266 and ESP32
- adds support for TLS connections using the ESP-AT command set implementation
- changes the `Reponse()` method to use a timeout value instead of fixed time pauses for better performance and stability
- adds an example program that uses MQTT/MQTTS to publish messages to an MQTT broker.
- adds several more methods that are interface compatible with the `net` package such as `Dial()`.