### PR TITLE
Error strings should not be capitalized

### DIFF
--- a/ds1307/ds1307.go
+++ b/ds1307/ds1307.go
@@ -74,7 +74,7 @@ func (d *Device) Seek(offset int64, whence int) (int64, error) {
 	case 2:
 		whence = SRAMEndAddress
 	default:
-		return 0, errors.New("Invalid starting point")
+		return 0, errors.New("invalid starting point")
 	}
 	d.AddressSRAM = uint8(whence) + uint8(offset)
 	if d.AddressSRAM > SRAMEndAddress {
@@ -87,7 +87,7 @@ func (d *Device) Seek(offset int64, whence int) (int64, error) {
 // returns number of bytes written and error, if any
 func (d *Device) Write(data []byte) (n int, err error) {
 	if int(d.AddressSRAM)+len(data)-1 > SRAMEndAddress {
-		return 0, errors.New("Writing outside of SRAM")
+		return 0, errors.New("writing outside of SRAM")
 	}
 	buffer := make([]byte, len(data)+1)
 	buffer[0] = d.AddressSRAM

--- a/gps/ublox.go
+++ b/gps/ublox.go
@@ -49,5 +49,5 @@ func sendCommand(gpsDevice GPSDevice, command []byte) (err error) {
 			}
 		}
 	}
-	return errors.New("No ACK to GPS command")
+	return errors.New("no ACK to GPS command")
 }

--- a/hd44780/gpio.go
+++ b/hd44780/gpio.go
@@ -87,7 +87,7 @@ func (g *GPIO) write4BitMode(data byte) {
 // Ram address can be changed by writing address in command mode
 func (g *GPIO) Read(data []byte) (n int, err error) {
 	if len(data) == 0 {
-		return 0, errors.New("Length greater than 0 is required")
+		return 0, errors.New("length greater than 0 is required")
 	}
 	g.rw.High()
 	g.reconfigureGPIOMode(machine.PinInput)

--- a/hd44780/hd44780.go
+++ b/hd44780/hd44780.go
@@ -66,7 +66,7 @@ func (d *Device) Configure(cfg Config) error {
 	d.width = uint8(cfg.Width)
 	d.height = uint8(cfg.Height)
 	if d.width == 0 || d.height == 0 {
-		return errors.New("Width and height must be set")
+		return errors.New("width and height must be set")
 	}
 	memoryMap := uint8(ONE_LINE)
 	if d.height > 1 {

--- a/pcd8544/pcd8544.go
+++ b/pcd8544/pcd8544.go
@@ -127,7 +127,7 @@ func (d *Device) GetPixel(x int16, y int16) bool {
 func (d *Device) SetBuffer(buffer []byte) error {
 	if int16(len(buffer)) != d.bufferSize {
 		//return ErrBuffer
-		return errors.New("Wrong size buffer")
+		return errors.New("wrong size buffer")
 	}
 	for i := int16(0); i < d.bufferSize; i++ {
 		d.buffer[i] = buffer[i]

--- a/ssd1306/ssd1306.go
+++ b/ssd1306/ssd1306.go
@@ -219,7 +219,7 @@ func (d *Device) GetPixel(x int16, y int16) bool {
 func (d *Device) SetBuffer(buffer []byte) error {
 	if int16(len(buffer)) != d.bufferSize {
 		//return ErrBuffer
-		return errors.New("Wrong size buffer")
+		return errors.New("wrong size buffer")
 	}
 	for i := int16(0); i < d.bufferSize; i++ {
 		d.buffer[i] = buffer[i]


### PR DESCRIPTION
According to https://github.com/golang/go/wiki/CodeReviewComments#error-strings

> Error strings should not be capitalized (unless beginning with proper nouns or acronyms) or end with punctuation, since they are usually printed following other context. That is, use fmt.Errorf("something bad") not fmt.Errorf("Something bad"), so that log.Printf("Reading %s: %v", filename, err) formats without a spurious capital letter mid-message. This does not apply to logging, which is implicitly line-oriented and not combined inside other messages.