### PR TITLE
ws2812: fix "invalid symbol redefinition" error

### DIFF
--- a/ws2812/ws2812_m0_16m.go
+++ b/ws2812/ws2812_m0_16m.go
@@ -24,13 +24,13 @@ func (d Device) WriteByte(c byte) error {
 	// T1H: 8  cycles or 500.0ns -> together 19 cycles or 1187.5ns
 	value := uint32(c) << 24
 	arm.AsmFull(`
-	send_bit:
+	1: @ send_bit
 		str   {maskSet}, {portSet}     @ [2]   T0H and T0L start here
 		nop                            @ [1]
 		lsls  {value}, #1              @ [1]
-		bcs.n skip_store               @ [1/3]
+		bcs.n 2f                       @ [1/3] skip_store
 		str   {maskClear}, {portClear} @ [2]   T0H -> T0L transition
-	skip_store:
+	2: @ skip_store
 		nop                            @ [4]
 		nop
 		nop
@@ -39,7 +39,7 @@ func (d Device) WriteByte(c byte) error {
 		nop                            @ [2]
 		nop
 		subs  {i}, #1                  @ [1]
-		bne.n send_bit                 @ [1/3]
+		bne.n 1b                       @ [1/3] send_bit
 	`, map[string]interface{}{
 		"value":     value,
 		"i":         8,

--- a/ws2812/ws2812_m0_48m.go
+++ b/ws2812/ws2812_m0_48m.go
@@ -23,7 +23,7 @@ func (d Device) WriteByte(c byte) error {
 	// T1L: 22 cycles or 458.3ns -> together 49 cycles or 1020.8ns
 	value := uint32(c) << 24
 	arm.AsmFull(`
-	send_bit:
+	1: @ send_bit
 		str   {maskSet}, {portSet}     @ [2]   T0H and T0L start here
 		lsls  {value}, #1              @ [1]
 		nop                            @ [6]
@@ -32,9 +32,9 @@ func (d Device) WriteByte(c byte) error {
 		nop
 		nop
 		nop
-		bcs.n skip_store               @ [1/3]
+		bcs.n 2f                       @ [1/3] skip_store
 		str   {maskClear}, {portClear} @ [2]   T0H -> T0L transition
-	skip_store:
+	2: @ skip_store
 		nop                            @ [15]
 		nop
 		nop
@@ -68,7 +68,7 @@ func (d Device) WriteByte(c byte) error {
 		nop
 		nop
 		subs  {i}, #1                  @ [1]
-		bne.n send_bit                 @ [1/3]
+		bne.n 1b                       @ [1/3] send_bit
 	`, map[string]interface{}{
 		"value":     value,
 		"i":         8,

--- a/ws2812/ws2812_m4_120m.go
+++ b/ws2812/ws2812_m4_120m.go
@@ -29,7 +29,7 @@ func (d Device) WriteByte(c byte) error {
 	// by ARM that state this are now considered superseded (by what?).
 	value := uint32(c) << 24
 	arm.AsmFull(`
-	send_bit:
+	1: @ send_bit
 		str   {maskSet}, {portSet}     @ [2]   T0H and T0L start here
 		lsls  {value}, #1              @ [1]
 		nop                            @ [28]
@@ -60,9 +60,9 @@ func (d Device) WriteByte(c byte) error {
 		nop
 		nop
 		nop
-		bcs.n skip_store               @ [1-3]
+		bcs.n 2f                       @ [1-3] skip_store
 		str   {maskClear}, {portClear} @ [2]   T0H -> T0L transition
-	skip_store:
+	2: @ skip_store
 		nop                            @ [41]
 		nop
 		nop
@@ -160,7 +160,7 @@ func (d Device) WriteByte(c byte) error {
 		nop
 		nop
 		subs  {i}, #1                  @ [1]
-		bne.n send_bit                 @ [1-3]
+		bne.n 1b                       @ [1-3] send_bit
 	`, map[string]interface{}{
 		"value":     value,
 		"i":         8,

--- a/ws2812/ws2812_m4_64m.go
+++ b/ws2812/ws2812_m4_64m.go
@@ -28,7 +28,7 @@ func (d Device) WriteByte(c byte) error {
 	// by ARM that state this are now considered superseded (by what?).
 	value := uint32(c) << 24
 	arm.AsmFull(`
-	send_bit:
+	1: @ send_bit
 		str   {maskSet}, {portSet}     @ [2]   T0H and T0L start here
 		lsls  {value}, #1              @ [1]
 		nop                            @ [13]
@@ -44,9 +44,9 @@ func (d Device) WriteByte(c byte) error {
 		nop
 		nop
 		nop
-		bcs.n skip_store               @ [1-3]
+		bcs.n 2f                       @ [1-3] skip_store
 		str   {maskClear}, {portClear} @ [2]   T0H -> T0L transition
-	skip_store:
+	2: @ skip_store
 		nop                            @ [22]
 		nop
 		nop
@@ -97,7 +97,7 @@ func (d Device) WriteByte(c byte) error {
 		nop
 		nop
 		subs  {i}, #1                  @ [1]
-		bne.n send_bit                 @ [1-3]
+		bne.n 1b                       @ [1-3] send_bit
 	`, map[string]interface{}{
 		"value":     value,
 		"i":         8,


### PR DESCRIPTION
Named local labels shouldn't be used in LLVM because they might get
duplicated resulting in multiple symbol definitions and a compiler
error. Instead, use numeric labels.

---

This fixes just the case for the samd21, other targets also need fixing.