### PR TITLE
ws2812: Add build tag for Arduino Nano33 IoT

### DIFF
--- a/ws2812/ws2812_m0_48m.go
+++ b/ws2812/ws2812_m0_48m.go
@@ -1,4 +1,4 @@
-// +build circuitplay_express itsybitsy_m0
+// +build circuitplay_express itsybitsy_m0 arduino_nano33
 
 package ws2812
 


### PR DESCRIPTION
Uses `atsamd21` to cover anything using the same chip. Should I be more specific?