### PR TITLE
ws2812: fix timings for the nrf51

### DIFF
--- a/ws2812/ws2812_m0_16m.go
+++ b/ws2812/ws2812_m0_16m.go
@@ -17,14 +17,16 @@ func (d Device) WriteByte(c byte) error {
 
 	// See:
 	// https://wp.josh.com/2014/05/13/ws2812-neopixels-are-not-so-finicky-once-you-get-to-know-them/
-	// T0H: 4  cycles or 250ns
-	// T0L: 14 cycles or 875ns -> together 18 cycles or 1125ns
-	// T1H: 10 cycles or 625ns
-	// T1H: 8  cycles or 500ns -> together 18 cycles or 1125ns
+	// Note: timings have been increased slightly to also support ws2811 LEDs.
+	// T0H: 5  cycles or 312.5ns
+	// T0L: 14 cycles or 875.0ns -> together 19 cycles or 1187.5ns
+	// T1H: 11 cycles or 687.5ns
+	// T1H: 8  cycles or 500.0ns -> together 19 cycles or 1187.5ns
 	value := uint32(c) << 24
 	arm.AsmFull(`
 	send_bit:
 		str   {maskSet}, {portSet}     @ [2]   T0H and T0L start here
+		nop                            @ [1]
 		lsls  {value}, #1              @ [1]
 		bcs.n skip_store               @ [1/3]
 		str   {maskClear}, {portClear} @ [2]   T0H -> T0L transition


### PR DESCRIPTION
The timings needed to be changed slightly for ws2811 chips which are slightly slower.

Before this change, my string of ws2811 LEDs would flicker slightly (LEDs randomly turning off a very short time). With this extra nop, it's super solid.

![ws2811](https://user-images.githubusercontent.com/729697/63231286-b0576800-c219-11e9-87ab-63987af9c7a0.jpg)
