### PR TITLE
core: add Version() function for support purposes

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,0 +1,5 @@
+package drivers
+
+// Version returns a user-readable string showing the version of the drivers package for support purposes.
+// Update this value before release of new version of software.
+const Version = "0.7.0-dev"


### PR DESCRIPTION
This PR adds a `Version()` function for support purposes. This was it is easier to report at runtime which version of the drivers package is being used.