### PR TITLE
espat: implement MQTT subscribe functionality via channels

### DIFF
--- a/espat/mqtt/paho.go
+++ b/espat/mqtt/paho.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/eclipse/paho.mqtt.golang/packets"
 	"tinygo.org/x/drivers/espat"
 )
 
@@ -153,6 +154,18 @@ func (m *message) Payload() []byte {
 
 func (m *message) Ack() {
 	return
+}
+
+func messageFromPublish(p *packets.PublishPacket, ack func()) Message {
+	return &message{
+		duplicate: p.Dup,
+		qos:       p.Qos,
+		retained:  p.Retain,
+		topic:     p.TopicName,
+		messageID: p.MessageID,
+		payload:   p.Payload,
+		ack:       ack,
+	}
 }
 
 // ClientOptionsReader provides an interface for reading ClientOptions after the client has been initialized.

--- a/espat/mqtt/router.go
+++ b/espat/mqtt/router.go
@@ -1,0 +1,182 @@
+// The following code is a slightly modified version of code taken from the Paho MQTT library.
+// It is here until TinyGo can compile the "net" package from the standard library, at which time
+// it can be removed.
+
+/*
+ * Copyright (c) 2013 IBM Corp.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Seth Hoenig
+ *    Allan Stockdill-Mander
+ *    Mike Robertson
+ */
+
+package mqtt
+
+import (
+	"container/list"
+	"strings"
+
+	"github.com/eclipse/paho.mqtt.golang/packets"
+)
+
+// route is a type which associates MQTT Topic strings with a
+// callback to be executed upon the arrival of a message associated
+// with a subscription to that topic.
+type route struct {
+	topic    string
+	callback MessageHandler
+}
+
+// match takes a slice of strings which represent the route being tested having been split on '/'
+// separators, and a slice of strings representing the topic string in the published message, similarly
+// split.
+// The function determines if the topic string matches the route according to the MQTT topic rules
+// and returns a boolean of the outcome
+func match(route []string, topic []string) bool {
+	if len(route) == 0 {
+		if len(topic) == 0 {
+			return true
+		}
+		return false
+	}
+
+	if len(topic) == 0 {
+		if route[0] == "#" {
+			return true
+		}
+		return false
+	}
+
+	if route[0] == "#" {
+		return true
+	}
+
+	if (route[0] == "+") || (route[0] == topic[0]) {
+		return match(route[1:], topic[1:])
+	}
+	return false
+}
+
+func routeIncludesTopic(route, topic string) bool {
+	return match(routeSplit(route), strings.Split(topic, "/"))
+}
+
+// removes $share and sharename when splitting the route to allow
+// shared subscription routes to correctly match the topic
+func routeSplit(route string) []string {
+	var result []string
+	if strings.HasPrefix(route, "$share") {
+		result = strings.Split(route, "/")[2:]
+	} else {
+		result = strings.Split(route, "/")
+	}
+	return result
+}
+
+// match takes the topic string of the published message and does a basic compare to the
+// string of the current Route, if they match it returns true
+func (r *route) match(topic string) bool {
+	return r.topic == topic || routeIncludesTopic(r.topic, topic)
+}
+
+type router struct {
+	//sync.RWMutex
+	routes         *list.List
+	defaultHandler MessageHandler
+	messages       chan *packets.PublishPacket
+	stop           chan bool
+}
+
+// newRouter returns a new instance of a Router and channel which can be used to tell the Router
+// to stop
+func newRouter() (*router, chan bool) {
+	router := &router{routes: list.New(), messages: make(chan *packets.PublishPacket), stop: make(chan bool)}
+	stop := router.stop
+	return router, stop
+}
+
+// addRoute takes a topic string and MessageHandler callback. It looks in the current list of
+// routes to see if there is already a matching Route. If there is it replaces the current
+// callback with the new one. If not it add a new entry to the list of Routes.
+func (r *router) addRoute(topic string, callback MessageHandler) {
+	for e := r.routes.Front(); e != nil; e = e.Next() {
+		if e.Value.(*route).match(topic) {
+			r := e.Value.(*route)
+			r.callback = callback
+			return
+		}
+	}
+	r.routes.PushBack(&route{topic: topic, callback: callback})
+}
+
+// deleteRoute takes a route string, looks for a matching Route in the list of Routes. If
+// found it removes the Route from the list.
+func (r *router) deleteRoute(topic string) {
+	for e := r.routes.Front(); e != nil; e = e.Next() {
+		if e.Value.(*route).match(topic) {
+			r.routes.Remove(e)
+			return
+		}
+	}
+}
+
+// setDefaultHandler assigns a default callback that will be called if no matching Route
+// is found for an incoming Publish.
+func (r *router) setDefaultHandler(handler MessageHandler) {
+	r.defaultHandler = handler
+}
+
+// matchAndDispatch takes a channel of Message pointers as input and starts a go routine that
+// takes messages off the channel, matches them against the internal route list and calls the
+// associated callback (or the defaultHandler, if one exists and no other route matched). If
+// anything is sent down the stop channel the function will end.
+func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order bool, client *mqttclient) {
+	go func() {
+		for {
+			select {
+			case message := <-messages:
+				sent := false
+				m := messageFromPublish(message, client.ackFunc(message))
+				handlers := []MessageHandler{}
+				for e := r.routes.Front(); e != nil; e = e.Next() {
+					if e.Value.(*route).match(message.TopicName) {
+						if order {
+							handlers = append(handlers, e.Value.(*route).callback)
+						} else {
+							hd := e.Value.(*route).callback
+							go func() {
+								hd(client, m)
+								//TODO: m.Ack()
+							}()
+						}
+						sent = true
+					}
+				}
+				if !sent && r.defaultHandler != nil {
+					if order {
+						handlers = append(handlers, r.defaultHandler)
+					} else {
+						go func() {
+							r.defaultHandler(client, m)
+							//TODO: m.Ack()
+						}()
+					}
+				}
+				for _, handler := range handlers {
+					func() {
+						handler(client, m)
+						//TODO: m.Ack()
+					}()
+				}
+			case <-r.stop:
+				return
+			}
+		}
+	}()
+}

--- a/espat/mqtt/token.go
+++ b/espat/mqtt/token.go
@@ -1,0 +1,19 @@
+package mqtt
+
+import "time"
+
+type mqtttoken struct {
+	err error
+}
+
+func (t *mqtttoken) Wait() bool {
+	return true
+}
+
+func (t *mqtttoken) WaitTimeout(time.Duration) bool {
+	return true
+}
+
+func (t *mqtttoken) Error() error {
+	return t.err
+}

--- a/espat/wifi.go
+++ b/espat/wifi.go
@@ -16,7 +16,7 @@ const (
 )
 
 // GetWifiMode returns the ESP8266/ESP32 wifi mode.
-func (d *Device) GetWifiMode() []byte {
+func (d *Device) GetWifiMode() ([]byte, error) {
 	d.Query(WifiMode)
 	return d.Response(100)
 }
@@ -25,14 +25,14 @@ func (d *Device) GetWifiMode() []byte {
 func (d *Device) SetWifiMode(mode int) error {
 	val := strconv.Itoa(mode)
 	d.Set(WifiMode, val)
-	d.Response(pause)
-	return nil
+	_, err := d.Response(pause)
+	return err
 }
 
 // Wifi Client
 
 // GetConnectedAP returns the ESP8266/ESP32 is currently connected to as a client.
-func (d *Device) GetConnectedAP() []byte {
+func (d *Device) GetConnectedAP() ([]byte, error) {
 	d.Query(ConnectAP)
 	return d.Response(100)
 }
@@ -42,37 +42,43 @@ func (d *Device) GetConnectedAP() []byte {
 func (d *Device) ConnectToAP(ssid, pwd string, ws int) error {
 	val := "\"" + ssid + "\",\"" + pwd + "\""
 	d.Set(ConnectAP, val)
-	d.Response(ws * 1000)
+
+	_, err := d.Response(ws * 1000)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
 // DisconnectFromAP disconnects the ESP8266/ESP32 from the current access point.
 func (d *Device) DisconnectFromAP() error {
 	d.Execute(Disconnect)
-	d.Response(1000)
-	return nil
+	_, err := d.Response(1000)
+	return err
 }
 
 // GetClientIP returns the ESP8266/ESP32 current client IP addess when connected to an Access Point.
-func (d *Device) GetClientIP() string {
+func (d *Device) GetClientIP() (string, error) {
 	d.Query(SetStationIP)
-	return string(d.Response(100))
+	r, err := d.Response(1000)
+	return string(r), err
 }
 
 // SetClientIP sets the ESP8266/ESP32 current client IP addess when connected to an Access Point.
-func (d *Device) SetClientIP(ipaddr string) []byte {
+func (d *Device) SetClientIP(ipaddr string) error {
 	val := "\"" + ipaddr + "\""
 	d.Set(ConnectAP, val)
-	d.Response(500)
-	return nil
+	_, err := d.Response(500)
+	return err
 }
 
 // Access Point
 
 // GetAPConfig returns the ESP8266/ESP32 current configuration when acting as an Access Point.
-func (d *Device) GetAPConfig() string {
+func (d *Device) GetAPConfig() (string, error) {
 	d.Query(SoftAPConfigCurrent)
-	return string(d.Response(100))
+	r, err := d.Response(100)
+	return string(r), err
 }
 
 // SetAPConfig sets the ESP8266/ESP32 current configuration when acting as an Access Point.
@@ -83,35 +89,38 @@ func (d *Device) SetAPConfig(ssid, pwd string, ch, security int) error {
 	ecnval := strconv.Itoa(security)
 	val := "\"" + ssid + "\",\"" + pwd + "\"," + chval + "," + ecnval
 	d.Set(SoftAPConfigCurrent, val)
-	d.Response(1000)
-	return nil
+	_, err := d.Response(1000)
+	return err
 }
 
 // GetAPClients returns the ESP8266/ESP32 current clients when acting as an Access Point.
-func (d *Device) GetAPClients() string {
+func (d *Device) GetAPClients() (string, error) {
 	d.Query(ListConnectedIP)
-	return string(d.Response(100))
+	r, err := d.Response(100)
+	return string(r), err
 }
 
 // GetAPIP returns the ESP8266/ESP32 current IP addess when configured as an Access Point.
-func (d *Device) GetAPIP() string {
+func (d *Device) GetAPIP() (string, error) {
 	d.Query(SetSoftAPIPCurrent)
-	return string(d.Response(100))
+	r, err := d.Response(100)
+	return string(r), err
 }
 
 // SetAPIP sets the ESP8266/ESP32 current IP addess when configured as an Access Point.
 func (d *Device) SetAPIP(ipaddr string) error {
 	val := "\"" + ipaddr + "\""
 	d.Set(SetSoftAPIPCurrent, val)
-	d.Response(500)
-	return nil
+	_, err := d.Response(500)
+	return err
 }
 
 // GetAPConfigFlash returns the ESP8266/ESP32 current configuration acting as an Access Point
 // from flash storage. These settings are those used after a reset.
-func (d *Device) GetAPConfigFlash() string {
+func (d *Device) GetAPConfigFlash() (string, error) {
 	d.Query(SoftAPConfigFlash)
-	return string(d.Response(100))
+	r, err := d.Response(100)
+	return string(r), err
 }
 
 // SetAPConfigFlash sets the ESP8266/ESP32 current configuration acting as an Access Point,
@@ -123,15 +132,16 @@ func (d *Device) SetAPConfigFlash(ssid, pwd string, ch, security int) error {
 	ecnval := strconv.Itoa(security)
 	val := "\"" + ssid + "\",\"" + pwd + "\"," + chval + "," + ecnval
 	d.Set(SoftAPConfigFlash, val)
-	d.Response(1000)
-	return nil
+	_, err := d.Response(1000)
+	return err
 }
 
 // GetAPIPFlash returns the ESP8266/ESP32 IP address as saved to flash storage.
 // This is the IP address that will be used after a reset.
-func (d *Device) GetAPIPFlash() string {
+func (d *Device) GetAPIPFlash() (string, error) {
 	d.Query(SetSoftAPIPFlash)
-	return string(d.Response(100))
+	r, err := d.Response(100)
+	return string(r), err
 }
 
 // SetAPIPFlash sets the ESP8266/ESP32 current IP addess when configured as an Access Point.
@@ -139,6 +149,6 @@ func (d *Device) GetAPIPFlash() string {
 func (d *Device) SetAPIPFlash(ipaddr string) error {
 	val := "\"" + ipaddr + "\""
 	d.Set(SetSoftAPIPFlash, val)
-	d.Response(500)
-	return nil
+	_, err := d.Response(500)
+	return err
 }

--- a/examples/espat/esphub/main.go
+++ b/examples/espat/esphub/main.go
@@ -24,7 +24,7 @@ const pass = "YOURPASS"
 // these are the default pins for the Arduino Nano33 IoT.
 // change these to connect to a different UART or pins for the ESP8266/ESP32
 var (
-	uart = machine.UART2
+	uart = machine.UART1
 	tx   = machine.PA22
 	rx   = machine.PA23
 
@@ -43,17 +43,14 @@ func main() {
 	readyled.High()
 
 	// first check if connected
-	if adaptor.Connected() {
+	if connectToESP() {
 		println("Connected to wifi adaptor.")
 		adaptor.Echo(false)
 
-		if actAsAP {
-			provideAP()
-		} else {
-			connectToAP()
-		}
+		connectToAP()
 	} else {
-		println("Unable to connect to wifi adaptor.")
+		println("")
+		failMessage("Unable to connect to wifi adaptor.")
 		return
 	}
 
@@ -86,21 +83,47 @@ func main() {
 	println("Done.")
 }
 
+// connect to ESP8266/ESP32
+func connectToESP() bool {
+	for i := 0; i < 5; i++ {
+		println("Connecting to wifi adaptor...")
+		if adaptor.Connected() {
+			return true
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return false
+}
+
 // connect to access point
 func connectToAP() {
-	println("Connecting to wifi network...")
+	println("Connecting to wifi network '" + ssid + "'")
+
 	adaptor.SetWifiMode(espat.WifiModeClient)
 	adaptor.ConnectToAP(ssid, pass, 10)
+
 	println("Connected.")
-	println(adaptor.GetClientIP())
+	ip, err := adaptor.GetClientIP()
+	if err != nil {
+		failMessage(err.Error())
+	}
+
+	println(ip)
 }
 
 // provide access point
 func provideAP() {
-	println("Starting wifi network as access point:")
-	println(ssid)
+	println("Starting wifi network as access point '" + ssid + "'...")
 	adaptor.SetWifiMode(espat.WifiModeAP)
 	adaptor.SetAPConfig(ssid, pass, 7, espat.WifiAPSecurityWPA2_PSK)
 	println("Ready.")
-	println(adaptor.GetAPIP())
+	ip, _ := adaptor.GetAPIP()
+	println(ip)
+}
+
+func failMessage(msg string) {
+	for {
+		println(msg)
+		time.Sleep(1 * time.Second)
+	}
 }

--- a/examples/espat/espstation/main.go
+++ b/examples/espat/espstation/main.go
@@ -24,7 +24,7 @@ const hubIP = "0.0.0.0"
 // these are the default pins for the Arduino Nano33 IoT.
 // change these to connect to a different UART or pins for the ESP8266/ESP32
 var (
-	uart = machine.UART2
+	uart = machine.UART1
 	tx   = machine.PA22
 	rx   = machine.PA23
 
@@ -39,13 +39,14 @@ func main() {
 	adaptor.Configure()
 
 	// first check if connected
-	if adaptor.Connected() {
+	if connectToESP() {
 		println("Connected to wifi adaptor.")
 		adaptor.Echo(false)
 
 		connectToAP()
 	} else {
-		println("Unable to connect to wifi adaptor.")
+		println("")
+		failMessage("Unable to connect to wifi adaptor.")
 		return
 	}
 
@@ -71,11 +72,37 @@ func main() {
 	println("Done.")
 }
 
+// connect to ESP8266/ESP32
+func connectToESP() bool {
+	for i := 0; i < 5; i++ {
+		println("Connecting to wifi adaptor...")
+		if adaptor.Connected() {
+			return true
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return false
+}
+
 // connect to access point
 func connectToAP() {
-	println("Connecting to wifi network...")
+	println("Connecting to wifi network '" + ssid + "'")
+
 	adaptor.SetWifiMode(espat.WifiModeClient)
 	adaptor.ConnectToAP(ssid, pass, 10)
+
 	println("Connected.")
-	println(adaptor.GetClientIP())
+	ip, err := adaptor.GetClientIP()
+	if err != nil {
+		failMessage(err.Error())
+	}
+
+	println(ip)
+}
+
+func failMessage(msg string) {
+	for {
+		println(msg)
+		time.Sleep(1 * time.Second)
+	}
 }

--- a/examples/espat/tcpclient/main.go
+++ b/examples/espat/tcpclient/main.go
@@ -24,7 +24,7 @@ const serverIP = "0.0.0.0"
 // these are the default pins for the Arduino Nano33 IoT.
 // change these to connect to a different UART or pins for the ESP8266/ESP32
 var (
-	uart = machine.UART2
+	uart = machine.UART1
 	tx   = machine.PA22
 	rx   = machine.PA23
 
@@ -39,13 +39,14 @@ func main() {
 	adaptor.Configure()
 
 	// first check if connected
-	if adaptor.Connected() {
+	if connectToESP() {
 		println("Connected to wifi adaptor.")
 		adaptor.Echo(false)
 
 		connectToAP()
 	} else {
-		println("Unable to connect to wifi adaptor.")
+		println("")
+		failMessage("Unable to connect to wifi adaptor.")
 		return
 	}
 
@@ -55,7 +56,10 @@ func main() {
 	laddr := &net.TCPAddr{Port: 8080}
 
 	println("Dialing TCP connection...")
-	conn, _ := net.DialTCP("tcp", laddr, raddr)
+	conn, err := net.DialTCP("tcp", laddr, raddr)
+	if err != nil {
+		failMessage(err.Error())
+	}
 
 	for {
 		// send data
@@ -71,11 +75,37 @@ func main() {
 	println("Done.")
 }
 
+// connect to ESP8266/ESP32
+func connectToESP() bool {
+	for i := 0; i < 5; i++ {
+		println("Connecting to wifi adaptor...")
+		if adaptor.Connected() {
+			return true
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return false
+}
+
 // connect to access point
 func connectToAP() {
-	println("Connecting to wifi network...")
+	println("Connecting to wifi network '" + ssid + "'")
+
 	adaptor.SetWifiMode(espat.WifiModeClient)
 	adaptor.ConnectToAP(ssid, pass, 10)
+
 	println("Connected.")
-	println(adaptor.GetClientIP())
+	ip, err := adaptor.GetClientIP()
+	if err != nil {
+		failMessage(err.Error())
+	}
+
+	println(ip)
+}
+
+func failMessage(msg string) {
+	for {
+		println(msg)
+		time.Sleep(1 * time.Second)
+	}
 }


### PR DESCRIPTION
This PR implements the `Subscribe()` method using channels. It also refactors response processing for greater speed and efficiency.