### PR TITLE
ws2812: add support for simulation

### DIFF
--- a/ws2812/ws2812_generic.go
+++ b/ws2812/ws2812_generic.go
@@ -1,0 +1,16 @@
+// +build !baremetal
+
+package ws2812
+
+// This file implements the WS2812 protocol for simulation.
+
+import "machine"
+
+// Send a single byte using the WS2812 protocol.
+func (d Device) WriteByte(c byte) error {
+	writeByte(d.Pin, c)
+	return nil
+}
+
+//go:export __tinygo_ws2812_write_byte
+func writeByte(pin machine.Pin, c byte)

--- a/ws2812/ws2812_m0_48m.go
+++ b/ws2812/ws2812_m0_48m.go
@@ -1,4 +1,4 @@
-// +build circuitplay_express itsybitsy_m0 arduino_nano33 feather_m0 trinket_m0
+// +build atsamd21
 
 package ws2812
 


### PR DESCRIPTION
Call a special `__tinygo_ws2812_write_byte` function to send a single byte. It is implemented in the playground with the following PR: https://github.com/tinygo-org/playground/pull/6