### PR TITLE
remove stxx default offsets

### DIFF
--- a/st7735/st7735.go
+++ b/st7735/st7735.go
@@ -76,21 +76,8 @@ func (d *Device) Configure(cfg Config) {
 		d.height = 160
 	}
 	d.rotation = cfg.Rotation
-
-	if cfg.RowOffset != 0 {
-		d.rowOffset = cfg.RowOffset
-	} else {
-		d.rowOffset = 1
-	}
-	if cfg.ColumnOffset != 0 {
-		d.columnOffset = cfg.ColumnOffset
-	} else {
-		if d.model == MINI80x160 {
-			d.columnOffset = 26
-		} else {
-			d.columnOffset = 2
-		}
-	}
+	d.rowOffset = cfg.RowOffset
+	d.columnOffset = cfg.ColumnOffset
 
 	d.batchLength = d.width
 	if d.height > d.width {

--- a/st7789/st7789.go
+++ b/st7789/st7789.go
@@ -66,15 +66,8 @@ func (d *Device) Configure(cfg Config) {
 		d.height = 240
 	}
 	d.rotation = cfg.Rotation
-
-	if cfg.RowOffset != 0 {
-		d.rowOffsetCfg = cfg.RowOffset
-	} else {
-		d.rowOffsetCfg = 80
-	}
-	if cfg.ColumnOffset != 0 {
-		d.columnOffsetCfg = cfg.ColumnOffset
-	}
+	d.rowOffsetCfg = cfg.RowOffset
+	d.columnOffsetCfg = cfg.ColumnOffset
 
 	d.batchLength = int32(d.width)
 	if d.height > d.width {


### PR DESCRIPTION
Remove the default offsets (row/column) it's not possible to set them to 0 (needed for pybadge).

