### PR TITLE
wifinina: update docs and add Dockerfile to build firmware

### DIFF
--- a/wifinina/Dockerfile
+++ b/wifinina/Dockerfile
@@ -1,0 +1,28 @@
+# docker build -t wifinina .
+# docker run wifinina -v "../build/wifinina:/src/build"
+
+FROM debian:stable-slim AS esp
+WORKDIR /src
+
+RUN apt-get clean && apt-get update && \
+    apt-get install -y sudo wget gcc git wget libncurses-dev flex bison gperf build-essential \
+    python python-pip python-setuptools python-serial python-cryptography python-future python-pyparsing make
+
+RUN mkdir /src/wifinina && \
+	cd /src/wifinina && \
+	wget https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz && \
+	mkdir -p /src/esp && \
+	cd /src/esp && \
+	tar -xzf /src/wifinina/xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz
+
+RUN cd /src/esp && \
+    git clone --branch v3.3.1 --recursive https://github.com/espressif/esp-idf.git
+
+FROM esp AS nina
+
+RUN cd /src/esp && \
+    git clone https://github.com/arduino/nina-fw.git
+
+COPY ./firmware.sh /src
+RUN chmod +x /src/firmware.sh
+ENTRYPOINT ["/src/firmware.sh"]

--- a/wifinina/README.md
+++ b/wifinina/README.md
@@ -4,26 +4,55 @@ This package provides a driver to use a separate connected WiFi processor ESP32 
 
 The way this driver works is by using the SPI interface of your microcontroller to communicate with the WiFi chip using the Arduino SPI command set.
 
+## Using the WiFiNINA Driver
+
+For information on how to use this driver, please take a look at the examples located in the [examples/wifinina](../examples/wifinina) directory.
+
 ## WiFiNINA Firmware Installation
 
-In order to use this driver, you must have the WiFiNINA firmware installed on the ESP32 chip.
+**PLEASE NOTE: New Arduino Nano33 IoT boards already have the WiFiNINA firmware pre-installed, so you should not need to install the firmware yourself.**
+
+In order to use this driver, you must have the WiFiNINA firmware installed on the ESP32 chip. If it is already installed, you can just use it. You do not need to build and flash the firmware again.
+
+### Building the WifiNINA firmware
+
+We have provided a Dockerfile that can build the needed firmware.
+
+```shell
+docker build -t wifinina ./wifinina/
+docker run -v "$(pwd)/build:/src/build" wifinina
+```
+
+This will put the firmware files into the `build` directory. Now you can flash them to the ESP32 chip.
+
+### Installing esptool to flash WifiNINA firmware
+
+In order to flash the firmware, you need to use Python to install the `esptool` package.
+
+```shell
+pip install esptool
+```
+
+Once you have installed `esptool` you can follow the correct procedure for flashing your board.
 
 ### Installing on Arduino Nano33 IoT
 
-In order to install the needed firmware on the Arduino Nano33 IoT board's built-in NINA W102 chip, you will need to use this firmware:
+The Arduino Nano33 IoT board has the WiFiNINA firmware flashed onto the onboard NINA-W102 chip out of the box.
 
-https://github.com/arduino/nina-fw
+Flashing the firmware is only necessary on the Arduino Nano33 IoT in order to upgrade or if other firmware was installed previously.
 
-To flash this firmware on the Arduino Nano33 IoT you will need to follow the following procedure:
+If you do want to install the firmware on the Arduino Nano33 IoT board's built-in NINA-W102 chip, you will need to first build the firmware as described above.
+
+To flash this firmware on the Arduino Nano33 IoT you will need to follow the following procedure using the Arduino IDE software:
 
 - Install _Arduino SAMD Boards_ from the Boards Manager.
 - Install _WiFiNINA_ from the Library Manager.
 - Using the normal Arduino software, load the `SerialNINAPassthrough` sketch on to the board (in File -> Examples -> WiFiNINA-> Tools).
-- Build the NINA 102 firmware using the `make firmware` command in the https://github.com/arduino/nina-fwt repo.
-- Flash the WifiNINA firmware using the `esptool` script:
 
-    ```shell
-    python esptool.py --chip esp32 --port /dev/ttyACM0 --baud 115200 --before no_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size detect 0x1000 /home/ron/Development/nina-fw/build/bootloader/bootloader.bin 0xf000 /home/ron/Development/nina-fw/build/phy_init_data.bin 0x30000 /home/ron/Development/nina-fw/build/nina-fw.bin 0x8000 /home/ron/Development/nina-fw/build/partitions.bin
-    ```
+Now you can flash the WifiNINA firmware using the `esptool` script:
+
+```shell
+python esptool.py --chip esp32 --port /dev/ttyACM0 --baud 115200 --before no_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size detect 0x1000 build/bootloader.bin 0xf000 build/phy_init_data.bin 0x30000 build/nina-fw.bin 0x8000 build/partitions.bin
+```
 
 You only need to do this one time, and then the correct WiFiNINA firmware will be on the NINA chip, and you can just flash the Arduino Nano33 IoT board using TinyGo. We should be able to remove some of these steps in a future release of this software.

--- a/wifinina/firmware.sh
+++ b/wifinina/firmware.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+cd /src/esp/nina-fw
+export PATH=/src/esp/xtensa-esp32-elf/bin:$PATH
+export IDF_PATH=/src/esp/esp-idf
+make firmware
+cp /src/esp/nina-fw/build/bootloader/bootloader.bin /src/build/
+cp /src/esp/nina-fw/build/phy_init_data.bin /src/build/
+cp /src/esp/nina-fw/build/nina-fw.bin /src/build/
+cp /src/esp/nina-fw/build/partitions.bin /src/build/
+cd -


### PR DESCRIPTION
This PR provides instructions and a Dockerfile to build the WifiNINA firmware needed to use the Arduino Nano33 IoT and other boards with the Arduino official firmware.