### PR TITLE
l293x: added support for h-bridge motor driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,5 +103,9 @@ smoke-test:
 	@md5sum ./build/test.hex
 	tinygo build -size short -o ./build/test.hex -target=trinket-m0 ./examples/veml6070/main.go
 	@md5sum ./build/test.hex
+	tinygo build -size short -o ./build/test.hex -target=arduino-nano33 ./examples/l293x/simple/main.go
+	@md5sum ./build/test.hex
+	tinygo build -size short -o ./build/test.hex -target=arduino-nano33 ./examples/l293x/speed/main.go
+	@md5sum ./build/test.hex
 
 test: clean fmt-check smoke-test

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ func main() {
 
 ## Currently supported devices
 
-The following 35 devices are supported.
+The following 36 devices are supported.
 
 | Device Name | Interface Type |
 |----------|-------------|
@@ -72,6 +72,7 @@ The following 35 devices are supported.
 | [ESP8266/ESP32 AT Command set for WiFi/TCP/UDP](https://github.com/espressif/esp32-at) | UART |
 | [GPS module](https://www.u-blox.com/en/product/neo-6-series) | I2C/UART |
 | [HUB75 RGB led matrix](https://cdn-learn.adafruit.com/downloads/pdf/32x16-32x32-rgb-led-matrix.pdf) | SPI |
+| [L293x motor driver](https://www.ti.com/lit/ds/symlink/l293d.pdf) | GPIO/PWM |
 | [LIS3DH accelerometer](https://www.st.com/resource/en/datasheet/lis3dh.pdf) | I2C |
 | [LSM6DS3 accelerometer](https://www.st.com/resource/en/datasheet/lsm6ds3.pdf) | I2C |
 | [MAG3110 magnetometer](https://www.nxp.com/docs/en/data-sheet/MAG3110.pdf) | I2C |

--- a/examples/l293x/simple/main.go
+++ b/examples/l293x/simple/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"machine"
+	"time"
+
+	"tinygo.org/x/drivers/l293x"
+)
+
+func main() {
+	wheel := l293x.New(machine.D10, machine.D11, machine.D12)
+	wheel.Configure()
+
+	for i := 0; i <= 10; i++ {
+		println("Forward")
+		wheel.Forward()
+		time.Sleep(time.Millisecond * 1000)
+
+		println("Stop")
+		wheel.Stop()
+		time.Sleep(time.Millisecond * 1000)
+
+		println("Backward")
+		wheel.Backward()
+		time.Sleep(time.Millisecond * 1000)
+
+		println("Stop")
+		wheel.Stop()
+		time.Sleep(time.Millisecond * 1000)
+	}
+
+	println("Stop")
+	wheel.Stop()
+}

--- a/examples/l293x/speed/main.go
+++ b/examples/l293x/speed/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"machine"
+	"time"
+
+	"tinygo.org/x/drivers/l293x"
+)
+
+const (
+	maxSpeed = 30000
+)
+
+func main() {
+	machine.InitPWM()
+
+	wheel := l293x.NewWithSpeed(machine.D10, machine.D11, machine.PWM{machine.D12})
+	wheel.Configure()
+
+	for i := 0; i <= 10; i++ {
+		println("Forward")
+		var i uint16
+		for i = 0; i < maxSpeed; i += 1000 {
+			wheel.Forward(i)
+			time.Sleep(time.Millisecond * 100)
+		}
+
+		println("Stop")
+		wheel.Stop()
+		time.Sleep(time.Millisecond * 1000)
+
+		println("Backward")
+		for i = 0; i < maxSpeed; i += 1000 {
+			wheel.Backward(i)
+			time.Sleep(time.Millisecond * 100)
+		}
+
+		println("Stop")
+		wheel.Stop()
+		time.Sleep(time.Millisecond * 1000)
+	}
+
+	println("Stop")
+	wheel.Stop()
+}

--- a/l293x/l293x.go
+++ b/l293x/l293x.go
@@ -1,0 +1,104 @@
+// Package l293x provides a driver to the L293/L293D H-bridge chip
+// typically used to control DC motors.
+//
+// Datasheet: https://www.ti.com/lit/ds/symlink/l293d.pdf
+//
+package l293x // import "tinygo.org/x/drivers/l293x"
+
+import (
+	"machine"
+)
+
+// Device is a motor without speed control.
+// a1 and a2 are the directional pins.
+// en is the pin turns the motor on/off.
+type Device struct {
+	a1, a2 machine.Pin
+	en     machine.Pin
+}
+
+// New returns a new Motor driver for GPIO-only operation.
+func New(direction1, direction2, enablePin machine.Pin) Device {
+	return Device{
+		a1: direction1,
+		a2: direction2,
+		en: enablePin,
+	}
+}
+
+// Configure configures the Device.
+func (d *Device) Configure() {
+	d.a1.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	d.a2.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	d.en.Configure(machine.PinConfig{Mode: machine.PinOutput})
+
+	d.Stop()
+}
+
+// Forward turns motor on in forward direction.
+func (d *Device) Forward() {
+	d.a1.High()
+	d.a2.Low()
+	d.en.High()
+}
+
+// Backward turns motor on in backward direction.
+func (d *Device) Backward() {
+	d.a1.Low()
+	d.a2.High()
+	d.en.High()
+}
+
+// Stop turns motor off.
+func (d *Device) Stop() {
+	d.a1.Low()
+	d.a2.Low()
+	d.en.Low()
+}
+
+// PWMDevice is a motor with speed control.
+// a1 and a2 are the directional GPIO pins.
+// en is the PWM pin that controls the motor speed.
+type PWMDevice struct {
+	a1, a2 machine.Pin
+	en     machine.PWM
+}
+
+// NewWithSpeed returns a new PWMMotor driver that uses a PWM pin to control speed.
+func NewWithSpeed(direction1, direction2 machine.Pin, speedPin machine.PWM) PWMDevice {
+	return PWMDevice{
+		a1: direction1,
+		a2: direction2,
+		en: speedPin,
+	}
+}
+
+// Configure configures the PWMDevice.
+func (d *PWMDevice) Configure() {
+	d.a1.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	d.a2.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	d.en.Configure()
+
+	d.Stop()
+}
+
+// Forward turns motor on in forward direction at specific speed.
+func (d *PWMDevice) Forward(speed uint16) {
+	d.a1.High()
+	d.a2.Low()
+	d.en.Set(speed)
+}
+
+// Backward turns motor on in backward direction at specific speed.
+func (d *PWMDevice) Backward(speed uint16) {
+	d.a1.Low()
+	d.a2.High()
+	d.en.Set(speed)
+}
+
+// Stop turns motor off.
+func (d *PWMDevice) Stop() {
+	d.a1.Low()
+	d.a2.Low()
+	d.en.Set(0)
+}


### PR DESCRIPTION
This PR adds support for the L293/L293D/L293N family of H-bridge motor drivers.