### PR TITLE
l9110x: add support for L9110x h-bridge motor driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,5 +107,9 @@ smoke-test:
 	@md5sum ./build/test.hex
 	tinygo build -size short -o ./build/test.hex -target=arduino-nano33 ./examples/l293x/speed/main.go
 	@md5sum ./build/test.hex
+	tinygo build -size short -o ./build/test.hex -target=arduino-nano33 ./examples/l9110x/simple/main.go
+	@md5sum ./build/test.hex
+	tinygo build -size short -o ./build/test.hex -target=arduino-nano33 ./examples/l9110x/speed/main.go
+	@md5sum ./build/test.hex
 
 test: clean fmt-check smoke-test

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ func main() {
 
 ## Currently supported devices
 
-The following 36 devices are supported.
+The following 37 devices are supported.
 
 | Device Name | Interface Type |
 |----------|-------------|
@@ -73,6 +73,7 @@ The following 36 devices are supported.
 | [GPS module](https://www.u-blox.com/en/product/neo-6-series) | I2C/UART |
 | [HUB75 RGB led matrix](https://cdn-learn.adafruit.com/downloads/pdf/32x16-32x32-rgb-led-matrix.pdf) | SPI |
 | [L293x motor driver](https://www.ti.com/lit/ds/symlink/l293d.pdf) | GPIO/PWM |
+| [L9110x motor driver](https://www.elecrow.com/download/datasheet-l9110.pdf) | GPIO/PWM |
 | [LIS3DH accelerometer](https://www.st.com/resource/en/datasheet/lis3dh.pdf) | I2C |
 | [LSM6DS3 accelerometer](https://www.st.com/resource/en/datasheet/lsm6ds3.pdf) | I2C |
 | [MAG3110 magnetometer](https://www.nxp.com/docs/en/data-sheet/MAG3110.pdf) | I2C |

--- a/examples/l9110x/simple/main.go
+++ b/examples/l9110x/simple/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"machine"
+	"time"
+
+	"tinygo.org/x/drivers/l9110x"
+)
+
+func main() {
+	wheel := l9110x.New(machine.D10, machine.D11)
+	wheel.Configure()
+
+	for i := 0; i <= 10; i++ {
+		println("Forward")
+		wheel.Forward()
+		time.Sleep(time.Millisecond * 1000)
+
+		println("Stop")
+		wheel.Stop()
+		time.Sleep(time.Millisecond * 1000)
+
+		println("Backward")
+		wheel.Backward()
+		time.Sleep(time.Millisecond * 1000)
+
+		println("Stop")
+		wheel.Stop()
+		time.Sleep(time.Millisecond * 1000)
+	}
+
+	println("Stop")
+	wheel.Stop()
+}

--- a/examples/l9110x/speed/main.go
+++ b/examples/l9110x/speed/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"machine"
+	"time"
+
+	"tinygo.org/x/drivers/l9110x"
+)
+
+const (
+	maxSpeed = 30000
+)
+
+func main() {
+	machine.InitPWM()
+
+	wheel := l9110x.NewWithSpeed(machine.PWM{machine.D11}, machine.PWM{machine.D12})
+	wheel.Configure()
+
+	for i := 0; i <= 10; i++ {
+		println("Forward")
+		var i uint16
+		for i = 0; i < maxSpeed; i += 1000 {
+			wheel.Forward(i)
+			time.Sleep(time.Millisecond * 100)
+		}
+
+		println("Stop")
+		wheel.Stop()
+		time.Sleep(time.Millisecond * 1000)
+
+		println("Backward")
+		for i = 0; i < maxSpeed; i += 1000 {
+			wheel.Backward(i)
+			time.Sleep(time.Millisecond * 100)
+		}
+
+		println("Stop")
+		wheel.Stop()
+		time.Sleep(time.Millisecond * 1000)
+	}
+
+	println("Stop")
+	wheel.Stop()
+}

--- a/l9110x/l9110x.go
+++ b/l9110x/l9110x.go
@@ -1,0 +1,90 @@
+// Package l9110x provides a driver to the L9110/L9110S H-bridge chip
+// typically used to control DC motors.
+//
+// Datasheet: https://www.elecrow.com/download/datasheet-l9110.pdf
+//
+package l9110x // import "tinygo.org/x/drivers/l9110x"
+
+import (
+	"machine"
+)
+
+// Device is a motor without speed control.
+// ia and ib are the directional pins.
+type Device struct {
+	ia, ib machine.Pin
+}
+
+// New returns a new Motor driver for GPIO-only operation.
+func New(direction1, direction2 machine.Pin) Device {
+	return Device{
+		ia: direction1,
+		ib: direction2,
+	}
+}
+
+// Configure configures the Device.
+func (d *Device) Configure() {
+	d.ia.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	d.ib.Configure(machine.PinConfig{Mode: machine.PinOutput})
+
+	d.Stop()
+}
+
+// Forward turns motor on in forward direction.
+func (d *Device) Forward() {
+	d.ia.High()
+	d.ib.Low()
+}
+
+// Backward turns motor on in backward direction.
+func (d *Device) Backward() {
+	d.ia.Low()
+	d.ib.High()
+}
+
+// Stop turns motor off.
+func (d *Device) Stop() {
+	d.ia.Low()
+	d.ib.Low()
+}
+
+// PWMDevice is a motor with speed control.
+// ia and ib are the directional/speed PWM pins.
+type PWMDevice struct {
+	ia, ib machine.PWM
+}
+
+// NewWithSpeed returns a new PWMMotor driver that uses 2 PWM pins to control both direction and speed.
+func NewWithSpeed(direction1, direction2 machine.PWM) PWMDevice {
+	return PWMDevice{
+		ia: direction1,
+		ib: direction2,
+	}
+}
+
+// Configure configures the PWMDevice.
+func (d *PWMDevice) Configure() {
+	d.ia.Configure()
+	d.ib.Configure()
+
+	d.Stop()
+}
+
+// Forward turns motor on in forward direction at specific speed.
+func (d *PWMDevice) Forward(speed uint16) {
+	d.ia.Set(speed)
+	d.ib.Set(0)
+}
+
+// Backward turns motor on in backward direction at specific speed.
+func (d *PWMDevice) Backward(speed uint16) {
+	d.ia.Set(0)
+	d.ib.Set(speed)
+}
+
+// Stop turns motor off.
+func (d *PWMDevice) Stop() {
+	d.ia.Set(0)
+	d.ib.Set(0)
+}


### PR DESCRIPTION
This PR adds support for the L9110/L9110S motor driver using the same interface as that used by the L293x motor driver.