### PR TITLE
Added nrf52840 tag to ws2812

### DIFF
--- a/ws2812/ws2812_m4_64m.go
+++ b/ws2812/ws2812_m4_64m.go
@@ -1,4 +1,4 @@
-// +build nrf52
+// +build nrf52 nrf52840
 
 package ws2812
 


### PR DESCRIPTION
This adds the nrf52840 tag to the WS2812 driver to support boards like Circuit Playground Bluefruit