### PR TITLE
Adding driver for four-wire resistive touchscreen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,8 @@ smoke-test:
 	@md5sum ./build/test.hex
 	tinygo build -size short -o ./build/test.hex -target=pyportal ./examples/touch/resistive/fourwire/main.go
 	@md5sum ./build/test.hex
+	tinygo build -size short -o ./build/test.hex -target=pyportal ./examples/touch/resistive/pyportal_touchpaint/main.go
+	@md5sum ./build/test.hex
 	tinygo build -size short -o ./build/test.hex -target=itsybitsy-m0 ./examples/vl53l1x/main.go
 	@md5sum ./build/test.hex
 	tinygo build -size short -o ./build/test.hex -target=microbit ./examples/waveshare-epd/epd2in13/main.go

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,8 @@ smoke-test:
 	@md5sum ./build/test.hex
 	tinygo build -size short -o ./build/test.hex -target=circuitplay-express ./examples/thermistor/main.go
 	@md5sum ./build/test.hex
+	tinygo build -size short -o ./build/test.hex -target=pyportal ./examples/touch/resistive/fourwire/main.go
+	@md5sum ./build/test.hex
 	tinygo build -size short -o ./build/test.hex -target=itsybitsy-m0 ./examples/vl53l1x/main.go
 	@md5sum ./build/test.hex
 	tinygo build -size short -o ./build/test.hex -target=microbit ./examples/waveshare-epd/epd2in13/main.go

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The following 37 devices are supported.
 | [MMA8653 accelerometer](https://www.nxp.com/docs/en/data-sheet/MMA8653FC.pdf) | I2C |
 | [MPU6050 accelerometer/gyroscope](https://store.invensense.com/datasheets/invensense/MPU-6050_DataSheet_V3%204.pdf) | I2C |
 | [PCD8544 display](http://eia.udg.edu/~forest/PCD8544_1.pdf) | SPI |
+| [Resistive Touchscreen (4-wire)](http://ww1.microchip.com/downloads/en/Appnotes/doc8091.pdf) | GPIO |
 | [Shift register](https://en.wikipedia.org/wiki/Shift_register#Parallel-in_serial-out_\(PISO\)) | GPIO |
 | [SHT3x Digital Humidity Sensor](https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/0_Datasheets/Humidity/Sensirion_Humidity_Sensors_SHT3x_Datasheet_digital.pdf) | I2C |
 | [SSD1306 OLED display](https://cdn-shop.adafruit.com/datasheets/SSD1306.pdf) | I2C / SPI |

--- a/examples/touch/resistive/fourwire/main.go
+++ b/examples/touch/resistive/fourwire/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	resistiveTouch = new(resistive.FourWireTouchscreen)
+	resistiveTouch = new(resistive.FourWire)
 )
 
 const (
@@ -40,11 +40,10 @@ func main() {
 
 		point := resistiveTouch.ReadTouchPoint()
 		touch := touch.Point{}
-		if point.Z > 100 {
-			touch = point
-			//			touch.X = mapval(point.X, Xmin, Xmax, 0, 240)
-			//			touch.Y = mapval(point.Y, Ymin, Ymax, 0, 320)
-			//			touch.Z = point.Z / 100
+		if point.Z>>6 > 100 {
+			touch.X = mapval(point.X>>6, Xmin, Xmax, 0, 240)
+			touch.Y = mapval(point.Y>>6, Ymin, Ymax, 0, 320)
+			touch.Z = point.Z >> 6 / 100
 		} else {
 			touch.X = 0
 			touch.Y = 0

--- a/examples/touch/resistive/fourwire/main.go
+++ b/examples/touch/resistive/fourwire/main.go
@@ -44,11 +44,9 @@ func main() {
 		point := resistiveTouch.GetTouchPoint()
 		touch := touch.Point{}
 		if point.Z > 100 {
-			rawX := mapval(point.X, Xmin, Xmax, 0, 240)
-			rawY := mapval(point.Y, Ymin, Ymax, 0, 320)
-			touch.X = rawX
-			touch.Y = rawY
-			touch.Z = 1
+			touch.X = mapval(point.X, Xmin, Xmax, 0, 240)
+			touch.Y = mapval(point.Y, Ymin, Ymax, 0, 320)
+			touch.Z = point.Z / 100
 		} else {
 			touch.X = 0
 			touch.Y = 0

--- a/examples/touch/resistive/fourwire/main.go
+++ b/examples/touch/resistive/fourwire/main.go
@@ -11,12 +11,7 @@ import (
 )
 
 var (
-	resistiveTouch = resistive.FourWireTouchscreen{
-		YP: machine.TOUCH_YD, // y+
-		YM: machine.TOUCH_YU, // y-
-		XP: machine.TOUCH_XR, // x+
-		XM: machine.TOUCH_XL, // x-
-	}
+	resistiveTouch = new(resistive.FourWireTouchscreen)
 )
 
 const (
@@ -28,12 +23,14 @@ const (
 
 func main() {
 
-	// configure backlight
-	machine.TFT_BACKLIGHT.Configure(machine.PinConfig{machine.PinOutput})
-
 	// configure touchscreen
 	machine.InitADC()
-	resistiveTouch.Configure()
+	resistiveTouch.Configure(&resistive.FourWireConfig{
+		YP: machine.TOUCH_YD, // y+
+		YM: machine.TOUCH_YU, // y-
+		XP: machine.TOUCH_XR, // x+
+		XM: machine.TOUCH_XL, // x-
+	})
 
 	last := touch.Point{}
 
@@ -41,12 +38,13 @@ func main() {
 	debounce := 0
 	for {
 
-		point := resistiveTouch.GetTouchPoint()
+		point := resistiveTouch.ReadTouchPoint()
 		touch := touch.Point{}
 		if point.Z > 100 {
-			touch.X = mapval(point.X, Xmin, Xmax, 0, 240)
-			touch.Y = mapval(point.Y, Ymin, Ymax, 0, 320)
-			touch.Z = point.Z / 100
+			touch = point
+			//			touch.X = mapval(point.X, Xmin, Xmax, 0, 240)
+			//			touch.Y = mapval(point.Y, Ymin, Ymax, 0, 320)
+			//			touch.Z = point.Z / 100
 		} else {
 			touch.X = 0
 			touch.Y = 0

--- a/examples/touch/resistive/fourwire/main.go
+++ b/examples/touch/resistive/fourwire/main.go
@@ -1,0 +1,85 @@
+// demo of 4-wire touchscreen as described in app note:
+// http://ww1.microchip.com/downloads/en/Appnotes/doc8091.pdf
+package main
+
+import (
+	"machine"
+	"math"
+
+	"tinygo.org/x/drivers/touch"
+	"tinygo.org/x/drivers/touch/resistive"
+)
+
+var (
+	resistiveTouch = resistive.FourWireTouchscreen{
+		YP: machine.TOUCH_YD, // y+
+		YM: machine.TOUCH_YU, // y-
+		XP: machine.TOUCH_XR, // x+
+		XM: machine.TOUCH_XL, // x-
+	}
+)
+
+const (
+	Xmin = 750
+	Xmax = 325
+	Ymin = 840
+	Ymax = 240
+)
+
+func main() {
+
+	// configure backlight
+	machine.TFT_BACKLIGHT.Configure(machine.PinConfig{machine.PinOutput})
+
+	// configure touchscreen
+	machine.InitADC()
+	resistiveTouch.Configure()
+
+	last := touch.Point{}
+
+	// loop and poll for touches, including performing debouncing
+	debounce := 0
+	for {
+
+		point := resistiveTouch.GetTouchPoint()
+		touch := touch.Point{}
+		if point.Z > 100 {
+			rawX := mapval(point.X, Xmin, Xmax, 0, 240)
+			rawY := mapval(point.Y, Ymin, Ymax, 0, 320)
+			touch.X = rawX
+			touch.Y = rawY
+			touch.Z = 1
+		} else {
+			touch.X = 0
+			touch.Y = 0
+			touch.Z = 0
+		}
+
+		if last.Z != touch.Z {
+			debounce = 0
+			last = touch
+		} else if math.Abs(float64(touch.X-last.X)) > 4 ||
+			math.Abs(float64(touch.Y-last.Y)) > 4 {
+			debounce = 0
+			last = touch
+		} else if debounce > 1 {
+			debounce = 0
+			HandleTouch(last)
+		} else if touch.Z > 0 {
+			debounce++
+		} else {
+			last = touch
+			debounce = 0
+		}
+
+	}
+}
+
+// based on Arduino's "map" function
+func mapval(x int, inMin int, inMax int, outMin int, outMax int) int {
+	return (x-inMin)*(outMax-outMin)/(inMax-inMin) + outMin
+}
+
+func HandleTouch(touch touch.Point) {
+	println("touch point:", touch.X, touch.Y, touch.Z)
+}

--- a/examples/touch/resistive/pyportal_touchpaint/main.go
+++ b/examples/touch/resistive/pyportal_touchpaint/main.go
@@ -11,12 +11,7 @@ import (
 )
 
 var (
-	resistiveTouch = resistive.FourWireTouchscreen{
-		YP: machine.TOUCH_YD,
-		YM: machine.TOUCH_YU,
-		XP: machine.TOUCH_XR,
-		XM: machine.TOUCH_XL,
-	}
+	resistiveTouch = &resistive.FourWireTouchscreen{}
 
 	display = ili9341.NewParallel(
 		machine.LCD_DATA0,
@@ -57,7 +52,12 @@ func main() {
 
 	// configure touchscreen
 	machine.InitADC()
-	resistiveTouch.Configure()
+	resistiveTouch.Configure(&resistive.FourWireConfig{
+		YP: machine.TOUCH_YD,
+		YM: machine.TOUCH_YU,
+		XP: machine.TOUCH_XR,
+		XM: machine.TOUCH_XL,
+	})
 
 	// configure display
 	display.Configure(ili9341.Config{})

--- a/examples/touch/resistive/pyportal_touchpaint/main.go
+++ b/examples/touch/resistive/pyportal_touchpaint/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	resistiveTouch = &resistive.FourWireTouchscreen{}
+	resistiveTouch = &resistive.FourWire{}
 
 	display = ili9341.NewParallel(
 		machine.LCD_DATA0,
@@ -88,11 +88,11 @@ func main() {
 	debounce := 0
 	for {
 
-		point := resistiveTouch.GetTouchPoint()
+		point := resistiveTouch.ReadTouchPoint()
 		touch := touch.Point{}
-		if point.Z > 100 {
-			rawX := mapval(point.X, Xmin, Xmax, 0, 240)
-			rawY := mapval(point.Y, Ymin, Ymax, 0, 320)
+		if point.Z>>6 > 100 {
+			rawX := mapval(point.X>>6, Xmin, Xmax, 0, 240)
+			rawY := mapval(point.Y>>6, Ymin, Ymax, 0, 320)
 			touch.X = rawX
 			touch.Y = rawY
 			touch.Z = 1
@@ -155,8 +155,7 @@ func HandleTouch(touch touch.Point) {
 			return
 		}
 
-		display.DrawRectangle(
-			int16((x/boxSize)*boxSize), 0, boxSize, boxSize, white)
+		display.DrawRectangle((x/boxSize)*boxSize, 0, boxSize, boxSize, white)
 		switch oldColor {
 		case red:
 			x = 0
@@ -184,5 +183,3 @@ func HandleTouch(touch touch.Point) {
 			int16(touch.X), int16(touch.Y), penRadius*2, penRadius*2, currentColor)
 	}
 }
-
-/**** End of Touchpaint demo ************************************************/

--- a/examples/touch/resistive/pyportal_touchpaint/main.go
+++ b/examples/touch/resistive/pyportal_touchpaint/main.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"image/color"
+	"machine"
+	"math"
+
+	"tinygo.org/x/drivers/ili9341"
+	"tinygo.org/x/drivers/touch"
+	"tinygo.org/x/drivers/touch/resistive"
+)
+
+var (
+	resistiveTouch = resistive.FourWireTouchscreen{
+		YP: machine.TOUCH_YD,
+		YM: machine.TOUCH_YU,
+		XP: machine.TOUCH_XR,
+		XM: machine.TOUCH_XL,
+	}
+
+	display = ili9341.NewParallel(
+		machine.LCD_DATA0,
+		machine.TFT_WR,
+		machine.TFT_DC,
+		machine.TFT_CS,
+		machine.TFT_RESET,
+		machine.TFT_RD,
+	)
+
+	white   = color.RGBA{255, 255, 255, 255}
+	black   = color.RGBA{0, 0, 0, 255}
+	red     = color.RGBA{255, 0, 0, 255}
+	green   = color.RGBA{0, 255, 0, 255}
+	blue    = color.RGBA{0, 0, 255, 255}
+	magenta = color.RGBA{255, 0, 255, 255}
+	yellow  = color.RGBA{255, 255, 0, 255}
+	cyan    = color.RGBA{0, 255, 255, 255}
+
+	oldColor     color.RGBA
+	currentColor color.RGBA
+)
+
+const (
+	penRadius = 3
+	boxSize   = 30
+
+	Xmin = 750
+	Xmax = 325
+	Ymin = 840
+	Ymax = 240
+)
+
+func main() {
+
+	// configure backlight
+	machine.TFT_BACKLIGHT.Configure(machine.PinConfig{machine.PinOutput})
+
+	// configure touchscreen
+	machine.InitADC()
+	resistiveTouch.Configure()
+
+	// configure display
+	display.Configure(ili9341.Config{})
+
+	// fill the background and activate the backlight
+	width, height := display.Size()
+	display.FillRectangle(0, 0, width, height, black)
+	machine.TFT_BACKLIGHT.High()
+
+	// make color selection boxes
+	display.FillRectangle(0, 0, boxSize, boxSize, red)
+	display.FillRectangle(boxSize, 0, boxSize, boxSize, yellow)
+	display.FillRectangle(boxSize*2, 0, boxSize, boxSize, green)
+	display.FillRectangle(boxSize*3, 0, boxSize, boxSize, cyan)
+	display.FillRectangle(boxSize*4, 0, boxSize, boxSize, blue)
+	display.FillRectangle(boxSize*5, 0, boxSize, boxSize, magenta)
+	display.FillRectangle(boxSize*6, 0, boxSize, boxSize, black)
+	display.FillRectangle(boxSize*7, 0, boxSize, boxSize, white)
+
+	// set the initial color to red and draw a box to highlight it
+	oldColor = red
+	currentColor = red
+	display.DrawRectangle(0, 0, boxSize, boxSize, white)
+
+	last := touch.Point{}
+
+	// loop and poll for touches, including performing debouncing
+	debounce := 0
+	for {
+
+		point := resistiveTouch.GetTouchPoint()
+		touch := touch.Point{}
+		if point.Z > 100 {
+			rawX := mapval(point.X, Xmin, Xmax, 0, 240)
+			rawY := mapval(point.Y, Ymin, Ymax, 0, 320)
+			touch.X = rawX
+			touch.Y = rawY
+			touch.Z = 1
+		} else {
+			touch.X = 0
+			touch.Y = 0
+			touch.Z = 0
+		}
+
+		if last.Z != touch.Z {
+			debounce = 0
+			last = touch
+		} else if math.Abs(float64(touch.X-last.X)) > 4 ||
+			math.Abs(float64(touch.Y-last.Y)) > 4 {
+			debounce = 0
+			last = touch
+		} else if debounce > 1 {
+			debounce = 0
+			HandleTouch(last)
+		} else if touch.Z > 0 {
+			debounce++
+		} else {
+			last = touch
+			debounce = 0
+		}
+
+	}
+}
+
+// based on Arduino's "map" function
+func mapval(x int, inMin int, inMax int, outMin int, outMax int) int {
+	return (x-inMin)*(outMax-outMin)/(inMax-inMin) + outMin
+}
+
+func HandleTouch(touch touch.Point) {
+
+	if int16(touch.Y) < boxSize {
+		oldColor = currentColor
+		x := int16(touch.X)
+		switch {
+		case x < boxSize:
+			currentColor = red
+		case x < boxSize*2:
+			currentColor = yellow
+		case x < boxSize*3:
+			currentColor = green
+		case x < boxSize*4:
+			currentColor = cyan
+		case x < boxSize*5:
+			currentColor = blue
+		case x < boxSize*6:
+			currentColor = magenta
+		case x < boxSize*7:
+			currentColor = black
+		case x < boxSize*8:
+			currentColor = white
+		}
+
+		if oldColor == currentColor {
+			return
+		}
+
+		display.DrawRectangle(
+			int16((x/boxSize)*boxSize), 0, boxSize, boxSize, white)
+		switch oldColor {
+		case red:
+			x = 0
+		case yellow:
+			x = boxSize
+		case green:
+			x = boxSize * 2
+		case cyan:
+			x = boxSize * 3
+		case blue:
+			x = boxSize * 4
+		case magenta:
+			x = boxSize * 5
+		case black:
+			x = boxSize * 6
+		case white:
+			x = boxSize * 7
+		}
+		display.FillRectangle(int16(x), 0, boxSize, boxSize, oldColor)
+
+	}
+
+	if (int16(touch.Y) - penRadius) > boxSize {
+		display.FillRectangle(
+			int16(touch.X), int16(touch.Y), penRadius*2, penRadius*2, currentColor)
+	}
+}
+
+/**** End of Touchpaint demo ************************************************/

--- a/touch/point.go
+++ b/touch/point.go
@@ -1,9 +1,14 @@
 package touch
 
 type Pointer interface {
-	GetTouchPoint() Point
+	ReadTouchPoint() Point
 }
 
+// Point represents the result of reading a single touch point from a screen.
+// X and Y are the horizontal and vertical coordinates of the touch, while Z
+// represents the touch pressure.  In general, client code will want to inspect
+// the value of Z to see if it is above some threshold to determine if a touch
+// is detected at all.
 type Point struct {
 	X int
 	Y int

--- a/touch/point.go
+++ b/touch/point.go
@@ -1,0 +1,11 @@
+package touch
+
+type Pointer interface {
+	GetTouchPoint() Point
+}
+
+type Point struct {
+	X int
+	Y int
+	Z int
+}

--- a/touch/point.go
+++ b/touch/point.go
@@ -1,5 +1,6 @@
 package touch
 
+// Pointer is a device that is capable of reading a single touch point
 type Pointer interface {
 	ReadTouchPoint() Point
 }

--- a/touch/resistive/fourwire.go
+++ b/touch/resistive/fourwire.go
@@ -13,7 +13,7 @@ type FourWireTouchscreen struct {
 	XM machine.Pin
 
 	yp machine.ADC
-	ym machine.ADC
+	xm machine.ADC
 	xp machine.ADC
 
 	samples []uint16
@@ -21,7 +21,7 @@ type FourWireTouchscreen struct {
 
 func (res *FourWireTouchscreen) Configure() {
 	res.yp = machine.ADC{res.YP}
-	res.ym = machine.ADC{res.YM}
+	res.xm = machine.ADC{res.XM}
 	res.xp = machine.ADC{res.XP}
 	res.samples = make([]uint16, 2)
 }
@@ -66,20 +66,17 @@ func (res *FourWireTouchscreen) ReadY() uint16 {
 }
 
 func (res *FourWireTouchscreen) ReadZ() uint16 {
-	// set x- to ground
-	res.XM.Configure(machine.PinConfig{machine.PinOutput})
-	res.XM.Low()
+	res.XP.Configure(machine.PinConfig{machine.PinOutput})
+	res.XP.Low()
 
-	// set y+ to VCC
-	res.YP.Configure(machine.PinConfig{machine.PinOutput})
-	res.YP.High()
+	res.YM.Configure(machine.PinConfig{machine.PinOutput})
+	res.YM.High()
 
-	// Hi-Z x+ and y-
-	res.xp.Configure()
-	res.ym.Configure()
+	res.xm.Configure()
+	res.yp.Configure()
 
-	z1 := res.xp.Get()
-	z2 := res.yp.Get() // ??? this is weird
+	z1 := res.xm.Get()
+	z2 := res.yp.Get()
 
 	return (1023 - (z2>>6 - z1>>6))
 }

--- a/touch/resistive/fourwire.go
+++ b/touch/resistive/fourwire.go
@@ -1,0 +1,85 @@
+package resistive
+
+import (
+	"machine"
+
+	"tinygo.org/x/drivers/touch"
+)
+
+type FourWireTouchscreen struct {
+	YP machine.Pin
+	YM machine.Pin
+	XP machine.Pin
+	XM machine.Pin
+
+	yp machine.ADC
+	ym machine.ADC
+	xp machine.ADC
+
+	samples []uint16
+}
+
+func (res *FourWireTouchscreen) Configure() {
+	res.yp = machine.ADC{res.YP}
+	res.ym = machine.ADC{res.YM}
+	res.xp = machine.ADC{res.XP}
+	res.samples = make([]uint16, 2)
+}
+
+func (res *FourWireTouchscreen) GetTouchPoint() (p touch.Point) {
+	p.X = int(res.ReadX())
+	p.Y = int(res.ReadY())
+	p.Z = int(res.ReadZ())
+	return
+}
+
+func (res *FourWireTouchscreen) ReadX() uint16 {
+	res.YM.Configure(machine.PinConfig{machine.PinInput})
+	res.YM.Low()
+
+	res.XP.Configure(machine.PinConfig{machine.PinOutput})
+	res.XM.Configure(machine.PinConfig{machine.PinOutput})
+	res.XP.High()
+	res.XM.Low()
+
+	res.yp.Configure()
+
+	res.samples[0] = res.yp.Get() >> 2
+	res.samples[1] = res.yp.Get() >> 2
+	return 1023 - (((res.samples[0] + res.samples[1]) / 2) >> 4)
+}
+
+func (res *FourWireTouchscreen) ReadY() uint16 {
+	res.XM.Configure(machine.PinConfig{machine.PinInput})
+	res.XM.Low()
+
+	res.YP.Configure(machine.PinConfig{machine.PinOutput})
+	res.YM.Configure(machine.PinConfig{machine.PinOutput})
+	res.YP.High()
+	res.YM.Low()
+
+	res.xp.Configure()
+
+	res.samples[0] = res.xp.Get() >> 2
+	res.samples[1] = res.xp.Get() >> 2
+	return 1023 - (((res.samples[0] + res.samples[1]) / 2) >> 4)
+}
+
+func (res *FourWireTouchscreen) ReadZ() uint16 {
+	// set x- to ground
+	res.XM.Configure(machine.PinConfig{machine.PinOutput})
+	res.XM.Low()
+
+	// set y+ to VCC
+	res.YP.Configure(machine.PinConfig{machine.PinOutput})
+	res.YP.High()
+
+	// Hi-Z x+ and y-
+	res.xp.Configure()
+	res.ym.Configure()
+
+	z1 := res.xp.Get()
+	z2 := res.yp.Get() // ??? this is weird
+
+	return (1023 - (z2>>6 - z1>>6))
+}


### PR DESCRIPTION
This is a driver for a simple resistive four-wire touchscreen like the one found on PyPortal and many inexpensive displays.

The code works but this PR is still WIP as I am doing some final testing I still need to:

Update README
Add example(s)
Validate the logic

Also I would like to get some feedback on the package layout and interface.  It might be premature for a "standard" interface but I added on called "Pointer" in the touch package.