### PR TITLE
mqtt: use buffered channels for incoming messages to handle bursts

### DIFF
--- a/net/mqtt/mqtt.go
+++ b/net/mqtt/mqtt.go
@@ -77,9 +77,9 @@ func (c *mqttclient) Connect() Token {
 	}
 
 	c.mid = 1
-	c.inbound = make(chan packets.ControlPacket)
+	c.inbound = make(chan packets.ControlPacket, 10)
 	c.stop = make(chan struct{})
-	c.incomingPubChan = make(chan *packets.PublishPacket)
+	c.incomingPubChan = make(chan *packets.PublishPacket, 10)
 	c.msgRouter.matchAndDispatch(c.incomingPubChan, c.opts.Order, c)
 
 	// send the MQTT connect message
@@ -98,7 +98,7 @@ func (c *mqttclient) Connect() Token {
 	connectPkt.ClientIdentifier = c.opts.ClientID
 	connectPkt.ProtocolVersion = byte(c.opts.ProtocolVersion)
 	connectPkt.ProtocolName = "MQTT"
-	connectPkt.Keepalive = 30
+	connectPkt.Keepalive = 60
 
 	err = connectPkt.Write(c.conn)
 	if err != nil {


### PR DESCRIPTION
This PR makes it so the mqtt driver uses buffered channels for incoming messages to handle bursts. 

This appears to improve concurrency for receiving a larger numbers of mqtt subscription events per second then without the buffering.