### PR TITLE
shifter: simplify API surface for PyBadge

### DIFF
--- a/examples/shifter/main.go
+++ b/examples/shifter/main.go
@@ -13,7 +13,7 @@ func main() {
 
 	for {
 		// Update the pins state, to later be returned by .Get()
-		buttons.Read8Input()
+		buttons.ReadInput()
 
 		if buttons.Pins[shifter.BUTTON_LEFT].Get() {
 			println("Button LEFT pressed")

--- a/examples/shifter/main.go
+++ b/examples/shifter/main.go
@@ -1,53 +1,42 @@
+// This example is designed to implement the button shifter for a PyBadge.
 package main
 
 import (
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers/shifter"
 )
 
-const (
-	BUTTON_LEFT = iota
-	BUTTON_UP
-	BUTTON_DOWN
-	BUTTON_RIGHT
-	BUTTON_SELECT
-	BUTTON_START
-	BUTTON_A
-	BUTTON_B
-)
-
 func main() {
-	buttons := shifter.New(shifter.EIGHT_BITS, machine.BUTTON_LATCH, machine.BUTTON_CLK, machine.BUTTON_OUT)
+	buttons := shifter.NewButtons()
 	buttons.Configure()
 
 	for {
 		// Update the pins state, to later be returned by .Get()
 		buttons.Read8Input()
 
-		if buttons.Pins[BUTTON_LEFT].Get() {
+		if buttons.Pins[shifter.BUTTON_LEFT].Get() {
 			println("Button LEFT pressed")
 		}
-		if buttons.Pins[BUTTON_UP].Get() {
+		if buttons.Pins[shifter.BUTTON_UP].Get() {
 			println("Button UP pressed")
 		}
-		if buttons.Pins[BUTTON_DOWN].Get() {
+		if buttons.Pins[shifter.BUTTON_DOWN].Get() {
 			println("Button DOWN pressed")
 		}
-		if buttons.Pins[BUTTON_RIGHT].Get() {
+		if buttons.Pins[shifter.BUTTON_RIGHT].Get() {
 			println("Button RIGHT pressed")
 		}
-		if buttons.Pins[BUTTON_SELECT].Get() {
+		if buttons.Pins[shifter.BUTTON_SELECT].Get() {
 			println("Button SELECT pressed")
 		}
-		if buttons.Pins[BUTTON_START].Get() {
+		if buttons.Pins[shifter.BUTTON_START].Get() {
 			println("Button START pressed")
 		}
-		if buttons.Pins[BUTTON_A].Get() {
+		if buttons.Pins[shifter.BUTTON_A].Get() {
 			println("Button A pressed")
 		}
-		if buttons.Pins[BUTTON_B].Get() {
+		if buttons.Pins[shifter.BUTTON_B].Get() {
 			println("Button B pressed")
 		}
 		time.Sleep(100 * time.Millisecond)

--- a/shifter/pybadge.go
+++ b/shifter/pybadge.go
@@ -25,3 +25,8 @@ func NewButtons() Device {
 		bits:  EIGHT_BITS,
 	}
 }
+
+// ReadInput returns the latest input readings from the PyBadge.
+func (d *Device) ReadInput() (uint8, error) {
+	return d.Read8Input()
+}

--- a/shifter/pybadge.go
+++ b/shifter/pybadge.go
@@ -1,0 +1,27 @@
+// +build pybadge
+
+package shifter
+
+import "machine"
+
+const (
+	BUTTON_LEFT   = 0
+	BUTTON_UP     = 1
+	BUTTON_DOWN   = 2
+	BUTTON_RIGHT  = 3
+	BUTTON_SELECT = 4
+	BUTTON_START  = 5
+	BUTTON_A      = 6
+	BUTTON_B      = 7
+)
+
+// NewButtons returns a new shifter device for the buttons on an AdaFruit PyBadge
+func NewButtons() Device {
+	return Device{
+		latch: machine.BUTTON_LATCH,
+		clk:   machine.BUTTON_CLK,
+		out:   machine.BUTTON_OUT,
+		Pins:  make([]ShiftPin, int(EIGHT_BITS)),
+		bits:  EIGHT_BITS,
+	}
+}

--- a/shifter/shifter.go
+++ b/shifter/shifter.go
@@ -30,7 +30,7 @@ type ShiftPin struct {
 	pressed bool
 }
 
-// New returns a new thermistor driver given an ADC pin.
+// New returns a new shifter driver given the correct pins.
 func New(numBits NumberBit, latch, clk, out machine.Pin) Device {
 	return Device{
 		latch: latch,


### PR DESCRIPTION
This PR is intended to simplify API surface and use build directive to directly match the PyBadge.