### PR TITLE
Add driver for TMP102 low-power digital temperature sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ func main() {
 
 ## Currently supported devices
 
-The following 45 devices are supported.
+The following 46 devices are supported.
 
 | Device Name | Interface Type |
 |----------|-------------|
@@ -101,6 +101,7 @@ The following 45 devices are supported.
 | [Waveshare 2.13" e-paper display](https://www.waveshare.com/w/upload/e/e6/2.13inch_e-Paper_Datasheet.pdf) | SPI |
 | [Waveshare 2.13" (B & C) e-paper display](https://www.waveshare.com/w/upload/d/d3/2.13inch-e-paper-b-Specification.pdf) | SPI |
 | [WS2812 RGB LED](https://cdn-shop.adafruit.com/datasheets/WS2812.pdf) | GPIO |
+| [TMP102 I2C Temperature Sensor](https://download.mikroe.com/documents/datasheets/tmp102-data-sheet.pdf) | I2C |
 
 ## Contributing
 

--- a/examples/tmp102/main.go
+++ b/examples/tmp102/main.go
@@ -14,13 +14,13 @@ func main() {
 	})
 
 	thermo := tmp102.New(machine.I2C0)
-	thermo.Configure(tmp102.Config{
-		Address: 0x48,
-		Unit:    tmp102.UNIT_CELSIUS,
-	})
+	thermo.Configure(tmp102.Config{})
 
 	for {
-		print(fmt.Sprintf("%.2f°C\r\n", thermo.ReadTemperature()))
+
+		temp, _ := thermo.ReadTemperature()
+
+		print(fmt.Sprintf("%.2f°C\r\n", float32(temp)/1000.0))
 
 		time.Sleep(time.Millisecond * 1000)
 	}

--- a/examples/tmp102/main.go
+++ b/examples/tmp102/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"machine"
+	"time"
+
+	"tinygo.org/x/drivers/tmp102"
+)
+
+func main() {
+	machine.I2C0.Configure(machine.I2CConfig{
+		Frequency: machine.TWI_FREQ_400KHZ,
+	})
+
+	thermo := tmp102.New(machine.I2C0)
+	thermo.Configure(tmp102.Config{
+		Address: 0x48,
+		Unit:    tmp102.UNIT_CELSIUS,
+	})
+
+	for {
+		print(fmt.Sprintf("%.2f°C\r\n", thermo.ReadTemperature()))
+
+		time.Sleep(time.Millisecond * 1000)
+	}
+
+}

--- a/tmp102/registers.go
+++ b/tmp102/registers.go
@@ -1,0 +1,18 @@
+package tmp102
+
+const (
+	// Default I2C address
+	Address = 0x48
+
+	// Temperature register address
+	RegTemperature = 0x00
+
+	// Configuration register address
+	RegConfiguration = 0x01
+
+	// Low limit register address
+	RegLimitLow = 0x02
+
+	// High limit register address
+	RegLimitHigh = 0x03
+)

--- a/tmp102/tmp102.go
+++ b/tmp102/tmp102.go
@@ -1,0 +1,73 @@
+// Package tmp102 implements a driver for the TMP102 digital temperature sensor.
+//
+// Datasheet: https://download.mikroe.com/documents/datasheets/tmp102-data-sheet.pdf
+
+package tmp102 // import "tinygo.org/x/drivers/tmp102"
+
+import (
+	"machine"
+)
+
+type TemperatureUnit int
+
+const (
+	UNIT_CELSIUS TemperatureUnit = iota
+	UNIT_FARENHEIT
+)
+
+// Device holds the already configured I2C bus, the I2C
+// address of the TMP102 and the temperature unit.
+type Device struct {
+	bus     machine.I2C
+	address uint8
+	unit    TemperatureUnit
+}
+
+// Config is the configuration for the TMP102.
+type Config struct {
+	Address uint8
+	Unit    TemperatureUnit
+}
+
+// New creates a new TMP102 connection. The I2C bus must already be configured.
+func New(bus machine.I2C) Device {
+	return Device{
+		bus: bus,
+	}
+}
+
+// Configure initializes the sensor with the given parameters.
+func (d *Device) Configure(cfg Config) {
+	if cfg.Unit == 0 {
+		cfg.Unit = UNIT_CELSIUS
+	}
+
+	if cfg.Address == 0 {
+		cfg.Address = 0x48
+	}
+
+	d.address = cfg.Address
+	d.unit = cfg.Unit
+}
+
+// Reads the temperature from the sensor and returns it in the configured temperature unit.
+func (d *Device) ReadTemperature() float32 {
+
+	tmpData := make([]byte, 2)
+
+	d.bus.ReadRegister(d.address, 0x0, tmpData)
+
+	temperatureSum := int((int16(tmpData[0])<<8 | int16(tmpData[1])) >> 4)
+
+	if (temperatureSum & int(1<<11)) == int(1<<11) {
+		temperatureSum |= int(0xf800)
+	}
+
+	temperature := float32(temperatureSum) * 0.0625
+
+	if d.unit == UNIT_FARENHEIT {
+		temperature = temperature*9.0/5.0 + 32
+	}
+
+	return temperature
+}

--- a/tmp102/tmp102.go
+++ b/tmp102/tmp102.go
@@ -8,25 +8,15 @@ import (
 	"machine"
 )
 
-type TemperatureUnit int
-
-const (
-	UNIT_CELSIUS TemperatureUnit = iota
-	UNIT_FARENHEIT
-)
-
-// Device holds the already configured I2C bus, the I2C
-// address of the TMP102 and the temperature unit.
+// Device holds the already configured I2C bus and the address of the sensor.
 type Device struct {
 	bus     machine.I2C
 	address uint8
-	unit    TemperatureUnit
 }
 
 // Config is the configuration for the TMP102.
 type Config struct {
 	Address uint8
-	Unit    TemperatureUnit
 }
 
 // New creates a new TMP102 connection. The I2C bus must already be configured.
@@ -38,36 +28,31 @@ func New(bus machine.I2C) Device {
 
 // Configure initializes the sensor with the given parameters.
 func (d *Device) Configure(cfg Config) {
-	if cfg.Unit == 0 {
-		cfg.Unit = UNIT_CELSIUS
-	}
-
 	if cfg.Address == 0 {
-		cfg.Address = 0x48
+		cfg.Address = Address
 	}
 
 	d.address = cfg.Address
-	d.unit = cfg.Unit
 }
 
-// Reads the temperature from the sensor and returns it in the configured temperature unit.
-func (d *Device) ReadTemperature() float32 {
+// Reads the temperature from the sensor and returns it in celsius milli degrees (°C/1000).
+func (d *Device) ReadTemperature() (temperature int32, err error) {
 
 	tmpData := make([]byte, 2)
 
-	d.bus.ReadRegister(d.address, 0x0, tmpData)
+	err = d.bus.ReadRegister(d.address, RegTemperature, tmpData)
 
-	temperatureSum := int((int16(tmpData[0])<<8 | int16(tmpData[1])) >> 4)
-
-	if (temperatureSum & int(1<<11)) == int(1<<11) {
-		temperatureSum |= int(0xf800)
+	if err != nil {
+		return
 	}
 
-	temperature := float32(temperatureSum) * 0.0625
+	temperatureSum := int32((int16(tmpData[0])<<8 | int16(tmpData[1])) >> 4)
 
-	if d.unit == UNIT_FARENHEIT {
-		temperature = temperature*9.0/5.0 + 32
+	if (temperatureSum & int32(1<<11)) == int32(1<<11) {
+		temperatureSum |= int32(0xf800)
 	}
 
-	return temperature
+	temperature = temperatureSum * 625
+
+	return temperature / 10, nil
 }


### PR DESCRIPTION
This adds a driver for the [TMP102](https://download.mikroe.com/documents/datasheets/tmp102-data-sheet.pdf) low-power digital temperature sensor.

Tested on the HiFive1 Rev B with the example code.