### PR TITLE
Fix DrawFastHLine for ST77xx, SSD1331 and SSD1351

### DIFF
--- a/ssd1331/ssd1331.go
+++ b/ssd1331/ssd1331.go
@@ -220,7 +220,7 @@ func (d *Device) DrawFastHLine(x0, x1, y int16, c color.RGBA) {
 	if x0 > x1 {
 		x0, x1 = x1, x0
 	}
-	d.FillRectangle(x0, y, x1-x0+1, y, c)
+	d.FillRectangle(x0, y, x1-x0+1, 1, c)
 }
 
 // FillScreen fills the screen with a given color

--- a/ssd1351/ssd1351.go
+++ b/ssd1351/ssd1351.go
@@ -251,7 +251,7 @@ func (d *Device) DrawFastHLine(x0, x1, y int16, c color.RGBA) {
 	if x0 > x1 {
 		x0, x1 = x1, x0
 	}
-	d.FillRectangle(x0, y, x1-x0+1, y, c)
+	d.FillRectangle(x0, y, x1-x0+1, 1, c)
 }
 
 // FillScreen fills the screen with a given color

--- a/st7735/st7735.go
+++ b/st7735/st7735.go
@@ -323,7 +323,7 @@ func (d *Device) DrawFastHLine(x0, x1, y int16, c color.RGBA) {
 	if x0 > x1 {
 		x0, x1 = x1, x0
 	}
-	d.FillRectangle(x0, y, x1-x0+1, y, c)
+	d.FillRectangle(x0, y, x1-x0+1, 1, c)
 }
 
 // FillScreen fills the screen with a given color

--- a/st7789/st7789.go
+++ b/st7789/st7789.go
@@ -207,7 +207,7 @@ func (d *Device) DrawFastHLine(x0, x1, y int16, c color.RGBA) {
 	if x0 > x1 {
 		x0, x1 = x1, x0
 	}
-	d.FillRectangle(x0, y, x1-x0+1, y, c)
+	d.FillRectangle(x0, y, x1-x0+1, 1, c)
 }
 
 // FillScreen fills the screen with a given color


### PR DESCRIPTION
DrawFastHLine internally uses FillRectangle(x,y,width,height,c), so height must be 1 to draw a horizontal line

I detected it trying my new 1,44" 128x128 TFT LCD with ST7735 driver, but fixed it in the other drivers, too.

Thank you for your fine work.