### PR TITLE
apa102: avoid creating garbage

### DIFF
--- a/apa102/softspi.go
+++ b/apa102/softspi.go
@@ -41,8 +41,9 @@ func (s *bbSPI) delay() {
 	}
 }
 
-// Transfer is used to send a single byte.
-func (s *bbSPI) Transfer(b byte) {
+// Transfer matches signature of machine.SPI.Transfer() and is used to send a
+// single byte. The received data is ignored and no error will ever be returned.
+func (s *bbSPI) Transfer(b byte) (byte, error) {
 	for i := uint8(0); i < 8; i++ {
 
 		// half clock cycle high to start
@@ -63,6 +64,7 @@ func (s *bbSPI) Transfer(b byte) {
 
 		// for actual SPI would try to read the MISO value here
 		s.delay()
-
 	}
+
+	return 0, nil
 }


### PR DESCRIPTION
Avoid creating unnecessary garbage in the following ways:

  * Use the `Transfer` method instead of the `Tx` method for single byte transfers.
  * Use a statically allocated buffer for the fixed start-of-frame sequence.

Running this for a few minutes did not cause the garbage collector to run. Previously, it would run every second or so in a persistence-of-vision application, which was clearly visible.

---

Context: I want to build something like [this thing](https://lighttoys.cz/store/vpoi/V4/), which is seriously awesome.