### PR TITLE
ci: support Go modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ jobs:
   build:
     docker:
       - image: tinygo/tinygo-dev
-    working_directory: /usr/local/go/src/vendor/tinygo.org/x/drivers
     steps:
       - checkout
       - run: tinygo version

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module tinygo.org/x/drivers
+
+go 1.13


### PR DESCRIPTION
Since TinyGo started supporting Go modules, there was an error in CI. The commit 7967e82fed423c98e913fc340b5369edc0c4489c tries to fix that, but I think the underlying issue is that we're checking out in `GOROOT`, which is definitely not a supported configuration.

I think the best solution is to just switch to using Go modules, by adding a go.mod file in the root. I've set it to Go version 1.13 as that is the first Go version that supports number literals, but it could be set to any supported Go version (1.11-1.14).

Since we use Go modules, the location of the drivers checkout should not matter so I've removed it. This fixes the error on CircleCI.