### PR TITLE
Fix WS2812 build tag to include Arduino Nano

### DIFF
--- a/ws2812/ws2812_avr_16m.go
+++ b/ws2812/ws2812_avr_16m.go
@@ -1,4 +1,4 @@
-// +build arduino
+// +build atmega328p
 
 package ws2812
 


### PR DESCRIPTION
Using the tag ```arduino-nano``` doesn't seem to work. And as far as I know anything made with Atmega328p are either Uno or Nano clones.