### PR TITLE
all: changeover to eliminate all direct use of master/slave terminology

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Please first open a Github issue. We want to help, and also make sure that there
 
 ## How to use our Github repository
 
-The `master` branch of this repo will always have the latest released version of the TinyGo drivers. All of the active development work for the next release will take place in the `dev` branch. The TinyGo drivers will use semantic versioning and will create a tag/release for each release.
+The `release` branch of this repo will always have the latest released version of the TinyGo drivers. All of the active development work for the next release will take place in the `dev` branch. The TinyGo drivers will use semantic versioning and will create a tag/release for each release.
 
 Here is how to contribute back some code or documentation:
 

--- a/apa102/apa102.go
+++ b/apa102/apa102.go
@@ -42,8 +42,8 @@ func New(b SPI) Device {
 
 // NewSoftwareSPI returns a new APA102 driver that will use a software based
 // implementation of the SPI protocol.
-func NewSoftwareSPI(sckPin, mosiPin machine.Pin, delay uint32) Device {
-	return New(&bbSPI{SCK: sckPin, MOSI: mosiPin, Delay: delay})
+func NewSoftwareSPI(sckPin, sdoPin machine.Pin, delay uint32) Device {
+	return New(&bbSPI{SCK: sckPin, SDO: sdoPin, Delay: delay})
 }
 
 // WriteColors writes the given RGBA color slice out using the APA102 protocol.

--- a/apa102/softspi.go
+++ b/apa102/softspi.go
@@ -9,16 +9,16 @@ import "machine"
 // this more generic and include it in the TinyGo "machine" package instead.
 type bbSPI struct {
 	SCK   machine.Pin
-	MOSI  machine.Pin
+	SDO   machine.Pin
 	Delay uint32
 }
 
-// Configure sets up the SCK and MOSI pins as outputs and sets them low
+// Configure sets up the SCK and SDO pins as outputs and sets them low
 func (s *bbSPI) Configure() {
 	s.SCK.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	s.MOSI.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	s.SDO.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	s.SCK.Low()
-	s.MOSI.Low()
+	s.SDO.Low()
 	if s.Delay == 0 {
 		s.Delay = 1
 	}
@@ -50,11 +50,11 @@ func (s *bbSPI) Transfer(b byte) (byte, error) {
 		s.SCK.High()
 		s.delay()
 
-		// write the value to MOSI (MSB first)
+		// write the value to SDO (MSB first)
 		if b&(1<<(7-i)) == 0 {
-			s.MOSI.Low()
+			s.SDO.Low()
 		} else {
-			s.MOSI.High()
+			s.SDO.High()
 		}
 		s.delay()
 
@@ -62,7 +62,7 @@ func (s *bbSPI) Transfer(b byte) (byte, error) {
 		s.SCK.Low()
 		s.delay()
 
-		// for actual SPI would try to read the MISO value here
+		// for actual SPI would try to read the SDI value here
 		s.delay()
 	}
 

--- a/examples/amg88xx/main.go
+++ b/examples/amg88xx/main.go
@@ -13,8 +13,8 @@ func main() {
 
 	machine.SPI1.Configure(machine.SPIConfig{
 		SCK:       machine.SPI1_SCK_PIN,
-		MOSI:      machine.SPI1_MOSI_PIN,
-		MISO:      machine.SPI1_MISO_PIN,
+		SDO:       machine.SPI1_SDO_PIN,
+		SDI:       machine.SPI1_SDI_PIN,
 		Frequency: 8000000,
 	})
 	machine.I2C0.Configure(machine.I2CConfig{SCL: machine.SCL_PIN, SDA: machine.SDA_PIN})

--- a/examples/flash/console/spi/main.go
+++ b/examples/flash/console/spi/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"machine"
 
-	"tinygo.org/x/drivers/examples/flash/console"
+	console_example "tinygo.org/x/drivers/examples/flash/console"
 	"tinygo.org/x/drivers/flash"
 )
 
@@ -11,8 +11,8 @@ func main() {
 	console_example.RunFor(
 		flash.NewSPI(
 			&machine.SPI1,
-			machine.SPI1_MOSI_PIN,
-			machine.SPI1_MISO_PIN,
+			machine.SPI1_SDO_PIN,
+			machine.SPI1_SDI_PIN,
 			machine.SPI1_SCK_PIN,
 			machine.SPI1_CS_PIN,
 		),

--- a/examples/ili9341/basic/wioterminal.go
+++ b/examples/ili9341/basic/wioterminal.go
@@ -22,8 +22,8 @@ var (
 func init() {
 	machine.SPI3.Configure(machine.SPIConfig{
 		SCK:       machine.LCD_SCK_PIN,
-		MOSI:      machine.LCD_MOSI_PIN,
-		MISO:      machine.LCD_MISO_PIN,
+		SDO:       machine.LCD_SDO_PIN,
+		SDI:       machine.LCD_SDI_PIN,
 		Frequency: 40000000,
 	})
 }

--- a/examples/ili9341/pyportal_boing/wioterminal.go
+++ b/examples/ili9341/pyportal_boing/wioterminal.go
@@ -22,8 +22,8 @@ var (
 func init() {
 	machine.SPI3.Configure(machine.SPIConfig{
 		SCK:       machine.LCD_SCK_PIN,
-		MOSI:      machine.LCD_MOSI_PIN,
-		MISO:      machine.LCD_MISO_PIN,
+		SDO:       machine.LCD_SDO_PIN,
+		SDI:       machine.LCD_SDI_PIN,
 		Frequency: 40000000,
 	})
 }

--- a/examples/ili9341/scroll/wioterminal.go
+++ b/examples/ili9341/scroll/wioterminal.go
@@ -22,8 +22,8 @@ var (
 func init() {
 	machine.SPI3.Configure(machine.SPIConfig{
 		SCK:       machine.LCD_SCK_PIN,
-		MOSI:      machine.LCD_MOSI_PIN,
-		MISO:      machine.LCD_MISO_PIN,
+		SDO:       machine.LCD_SDO_PIN,
+		SDI:       machine.LCD_SDI_PIN,
 		Frequency: 40000000,
 	})
 }

--- a/examples/wifinina/mqttclient/main.go
+++ b/examples/wifinina/mqttclient/main.go
@@ -62,8 +62,8 @@ func main() {
 	// Configure SPI for 8Mhz, Mode 0, MSB First
 	spi.Configure(machine.SPIConfig{
 		Frequency: 8 * 1e6,
-		MOSI:      machine.NINA_MOSI,
-		MISO:      machine.NINA_MISO,
+		SDO:       machine.NINA_SDO,
+		SDI:       machine.NINA_SDI,
 		SCK:       machine.NINA_SCK,
 	})
 

--- a/examples/wifinina/mqttsub/main.go
+++ b/examples/wifinina/mqttsub/main.go
@@ -69,8 +69,8 @@ func main() {
 	// Configure SPI for 8Mhz, Mode 0, MSB First
 	spi.Configure(machine.SPIConfig{
 		Frequency: 8 * 1e6,
-		MOSI:      machine.NINA_MOSI,
-		MISO:      machine.NINA_MISO,
+		SDO:       machine.NINA_SDO,
+		SDI:       machine.NINA_SDI,
 		SCK:       machine.NINA_SCK,
 	})
 

--- a/examples/wifinina/ntpclient/main.go
+++ b/examples/wifinina/ntpclient/main.go
@@ -46,8 +46,8 @@ func main() {
 	// Configure SPI for 8Mhz, Mode 0, MSB First
 	machine.NINA_SPI.Configure(machine.SPIConfig{
 		Frequency: 8 * 1e6,
-		MOSI:      machine.NINA_MOSI,
-		MISO:      machine.NINA_MISO,
+		SDO:       machine.NINA_SDO,
+		SDI:       machine.NINA_SDI,
 		SCK:       machine.NINA_SCK,
 	})
 	adaptor.Configure()

--- a/examples/wifinina/tcpclient/main.go
+++ b/examples/wifinina/tcpclient/main.go
@@ -55,8 +55,8 @@ func main() {
 	// Configure SPI for 8Mhz, Mode 0, MSB First
 	spi.Configure(machine.SPIConfig{
 		Frequency: 8 * 1e6,
-		MOSI:      machine.NINA_MOSI,
-		MISO:      machine.NINA_MISO,
+		SDO:       machine.NINA_SDO,
+		SDI:       machine.NINA_SDI,
 		SCK:       machine.NINA_SCK,
 	})
 

--- a/examples/wifinina/udpstation/main.go
+++ b/examples/wifinina/udpstation/main.go
@@ -43,8 +43,8 @@ func main() {
 	// Configure SPI for 8Mhz, Mode 0, MSB First
 	machine.NINA_SPI.Configure(machine.SPIConfig{
 		Frequency: 8 * 1e6,
-		MOSI:      machine.NINA_MOSI,
-		MISO:      machine.NINA_MISO,
+		SDO:       machine.NINA_SDO,
+		SDI:       machine.NINA_SDI,
 		SCK:       machine.NINA_SCK,
 	})
 	adaptor.Configure()

--- a/examples/wifinina/webclient/main.go
+++ b/examples/wifinina/webclient/main.go
@@ -56,8 +56,8 @@ func main() {
 	// Configure SPI for 8Mhz, Mode 0, MSB First
 	spi.Configure(machine.SPIConfig{
 		Frequency: 8 * 1e6,
-		MOSI:      machine.NINA_MOSI,
-		MISO:      machine.NINA_MISO,
+		SDO:       machine.NINA_SDO,
+		SDI:       machine.NINA_SDI,
 		SCK:       machine.NINA_SCK,
 	})
 

--- a/flash/transport_spi.go
+++ b/flash/transport_spi.go
@@ -16,24 +16,24 @@ type transport interface {
 
 // NewSPI returns a pointer to a flash device that uses a SPI peripheral to
 // communicate with a serial memory chip.
-func NewSPI(spi *machine.SPI, mosi, miso, sck, cs machine.Pin) *Device {
+func NewSPI(spi *machine.SPI, sdo, sdi, sck, cs machine.Pin) *Device {
 	return &Device{
 		trans: &spiTransport{
-			spi:  spi,
-			mosi: mosi,
-			miso: miso,
-			sck:  sck,
-			ss:   cs,
+			spi: spi,
+			sdo: sdo,
+			sdi: sdi,
+			sck: sck,
+			ss:  cs,
 		},
 	}
 }
 
 type spiTransport struct {
-	spi  *machine.SPI
-	mosi machine.Pin
-	miso machine.Pin
-	sck  machine.Pin
-	ss   machine.Pin
+	spi *machine.SPI
+	sdo machine.Pin
+	sdi machine.Pin
+	sck machine.Pin
+	ss  machine.Pin
 }
 
 func (tr *spiTransport) configure(config *DeviceConfig) {
@@ -53,8 +53,8 @@ func (tr *spiTransport) setClockSpeed(hz uint32) error {
 	}
 	tr.spi.Configure(machine.SPIConfig{
 		Frequency: hz,
-		MISO:      tr.miso,
-		MOSI:      tr.mosi,
+		SDI:       tr.sdi,
+		SDO:       tr.sdo,
 		SCK:       tr.sck,
 		LSBFirst:  false,
 		Mode:      0,

--- a/mpu6050/registers.go
+++ b/mpu6050/registers.go
@@ -91,11 +91,11 @@ const (
 	EXT_SENS_DATA_22 = 0x5F
 	EXT_SENS_DATA_23 = 0x60
 
-	// I2C slave data out
-	I2C_SLV0_DO      = 0x63
-	I2C_SLV1_DO      = 0x64
-	I2C_SLV2_DO      = 0x65
-	I2C_SLV3_DO      = 0x66
+	// I2C peripheral data out
+	I2C_PER0_DO      = 0x63
+	I2C_PER1_DO      = 0x64
+	I2C_PER2_DO      = 0x65
+	I2C_PER3_DO      = 0x66
 	I2C_MST_DELAY_CT = 0x67
 
 	SIGNAL_PATH_RES = 0x68 // Signal path reset


### PR DESCRIPTION
This PR is to changeover to eliminate all direct use of master/slave terminology.

It is intended to match https://github.com/tinygo-org/tinygo/pull/1216 in the main TinyGo repo. Once that PR has been merged, then the tests for this PR will pass again.

See https://www.oshwa.org/a-resolution-to-redefine-spi-signal-names

We will also need to change the master branch name to release, and change the default branch in Github.