### PR TITLE
gps: improvements and bugfixes

### DIFF
--- a/examples/gps/i2c/main.go
+++ b/examples/gps/i2c/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"fmt"
 	"machine"
+	"time"
 
 	"tinygo.org/x/drivers/gps"
 )
@@ -11,19 +11,32 @@ func main() {
 	println("GPS I2C Example")
 	machine.I2C0.Configure(machine.I2CConfig{})
 	ublox := gps.NewI2C(&machine.I2C0)
-	parser := gps.Parser(ublox)
+	parser := gps.NewParser()
 	var fix gps.Fix
 	for {
-		fix = parser.NextFix()
+		s, err := ublox.NextSentence()
+		if err != nil {
+			println(err)
+			continue
+		}
+
+		fix, err = parser.Parse(s)
+		if err != nil {
+			println(err)
+			continue
+		}
 		if fix.Valid {
 			print(fix.Time.Format("15:04:05"))
-			print(", lat=", fmt.Sprintf("%f", fix.Latitude))
-			print(", long=", fmt.Sprintf("%f", fix.Longitude))
+			print(", lat=")
+			print(fix.Latitude)
+			print(", long=")
+			print(fix.Longitude)
 			print(", altitude:=", fix.Altitude)
 			print(", satellites=", fix.Satellites)
 			println()
 		} else {
 			println("No fix")
 		}
+		time.Sleep(200 * time.Millisecond)
 	}
 }

--- a/examples/gps/i2c/main.go
+++ b/examples/gps/i2c/main.go
@@ -31,7 +31,7 @@ func main() {
 			print(fix.Latitude)
 			print(", long=")
 			print(fix.Longitude)
-			print(", altitude:=", fix.Altitude)
+			print(", altitude=", fix.Altitude)
 			print(", satellites=", fix.Satellites)
 			println()
 		} else {

--- a/examples/gps/uart/main.go
+++ b/examples/gps/uart/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"fmt"
 	"machine"
+	"time"
 
 	"tinygo.org/x/drivers/gps"
 )
@@ -11,19 +11,32 @@ func main() {
 	println("GPS UART Example")
 	machine.UART1.Configure(machine.UARTConfig{BaudRate: 9600})
 	ublox := gps.NewUART(&machine.UART1)
-	parser := gps.Parser(ublox)
+	parser := gps.NewParser()
 	var fix gps.Fix
 	for {
-		fix = parser.NextFix()
+		s, err := ublox.NextSentence()
+		if err != nil {
+			println(err)
+			continue
+		}
+
+		fix, err = parser.Parse(s)
+		if err != nil {
+			println(err)
+			continue
+		}
 		if fix.Valid {
 			print(fix.Time.Format("15:04:05"))
-			print(", lat=", fmt.Sprintf("%f", fix.Latitude))
-			print(", long=", fmt.Sprintf("%f", fix.Longitude))
+			print(", lat=")
+			print(fix.Latitude)
+			print(", long=")
+			print(fix.Longitude)
 			print(", altitude:=", fix.Altitude)
 			print(", satellites=", fix.Satellites)
 			println()
 		} else {
 			println("No fix")
 		}
+		time.Sleep(200 * time.Millisecond)
 	}
 }

--- a/examples/gps/uart/main.go
+++ b/examples/gps/uart/main.go
@@ -31,7 +31,7 @@ func main() {
 			print(fix.Latitude)
 			print(", long=")
 			print(fix.Longitude)
-			print(", altitude:=", fix.Altitude)
+			print(", altitude=", fix.Altitude)
 			print(", satellites=", fix.Satellites)
 			println()
 		} else {

--- a/gps/gpsparser.go
+++ b/gps/gpsparser.go
@@ -15,10 +15,11 @@ var (
 	errUnknownNMEASentence = errors.New("unknown NMEA sentence type")
 )
 
+// Parser for GPS NMEA sentences.
 type Parser struct {
 }
 
-// fix is a GPS location fix
+// Fix is a GPS location fix
 type Fix struct {
 	Valid      bool
 	Time       time.Time
@@ -28,6 +29,7 @@ type Fix struct {
 	Satellites int16
 }
 
+// NewParser returns a GPS NMEA Parser.
 func NewParser() Parser {
 	return Parser{}
 }
@@ -46,7 +48,7 @@ func (parser *Parser) Parse(sentence string) (fix Fix, err error) {
 		fix.Satellites = findSatellites(ggaFields)
 		fix.Longitude = findLongitude(ggaFields)
 		fix.Latitude = findLatitude(ggaFields)
-		//fix.Time = findTime(ggaFields) // TODO: fix time
+		fix.Time = findTime(ggaFields)
 		fix.Valid = (fix.Altitude != -99999) && (fix.Satellites > 0)
 	case "RMC":
 		err = errRMCNotSupportedYet
@@ -66,13 +68,12 @@ func findTime(ggaFields []string) time.Time {
 	if len(ggaFields) < 1 || len(ggaFields[1]) < 6 {
 		return time.Time{}
 	}
-	ts := strings.Builder{}
-	ts.WriteString(ggaFields[1][0:2])
-	ts.WriteString(":")
-	ts.WriteString(ggaFields[1][2:4])
-	ts.WriteString(":")
-	ts.WriteString(ggaFields[1][4:6])
-	var t, _ = time.Parse("15:04:05", ts.String())
+
+	h, _ := strconv.ParseInt(ggaFields[1][0:2], 10, 8)
+	m, _ := strconv.ParseInt(ggaFields[1][2:4], 10, 8)
+	s, _ := strconv.ParseInt(ggaFields[1][4:6], 10, 8)
+	ms, _ := strconv.ParseInt(ggaFields[1][7:10], 10, 16)
+	t := time.Date(0, 0, 0, int(h), int(m), int(s), int(ms), time.UTC)
 
 	return t
 }

--- a/gps/registers.go
+++ b/gps/registers.go
@@ -13,5 +13,5 @@ const (
 )
 
 const (
-	bufferSize = 32
+	bufferSize = 100
 )

--- a/gps/ublox.go
+++ b/gps/ublox.go
@@ -24,25 +24,25 @@ var cfg_gnss_cmd = [...]byte{
 	0x01, 0x01, 0x06, 0x08, 0x0E, 0x00, 0x00, 0x00,
 	0x01, 0x01, 0xFC, 0x11}
 
-func FlightMode(gpsDevice GPSDevice) (err error) {
-	err = sendCommand(gpsDevice, flight_mode_cmd[:])
+func FlightMode(d Device) (err error) {
+	err = sendCommand(d, flight_mode_cmd[:])
 	return err
 }
 
-func SetCfgGNSS(gpsDevice GPSDevice) (err error) {
-	err = sendCommand(gpsDevice, cfg_gnss_cmd[:])
+func SetCfgGNSS(d Device) (err error) {
+	err = sendCommand(d, cfg_gnss_cmd[:])
 	return err
 }
 
-func sendCommand(gpsDevice GPSDevice, command []byte) (err error) {
-	gpsDevice.WriteBytes(command)
+func sendCommand(d Device, command []byte) (err error) {
+	d.WriteBytes(command)
 	start := time.Now()
 	for time.Now().Sub(start) < 1000 {
-		if gpsDevice.readNextByte() == '\n' {
-			if gpsDevice.readNextByte() == 0xB5 {
-				gpsDevice.readNextByte()
-				if gpsDevice.readNextByte() == 0x05 {
-					if gpsDevice.readNextByte() == 0x01 {
+		if d.readNextByte() == '\n' {
+			if d.readNextByte() == 0xB5 {
+				d.readNextByte()
+				if d.readNextByte() == 0x05 {
+					if d.readNextByte() == 0x01 {
 						return
 					}
 				}


### PR DESCRIPTION
This PR add improvements to the GPS driver, by separating the dependencies between the `Driver` and `Parser`. It fixes some issues with performance by removing the reflection. Lastly, it adds support for the RMC NMEA sentence, which is the "other" sentence besides GGA that includes LAt/Long data.