### PR TITLE
lis2mdl: add LIS2MDL magnetometer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,5 +151,7 @@ smoke-test:
 	@md5sum ./build/test.hex
 	tinygo build -size short -o ./build/test.hex -target=hifive1b ./examples/ssd1351/main.go
 	@md5sum ./build/test.hex
+	tinygo build -size short -o ./build/test.hex -target=circuitplay-express ./examples/lis2mdl/main.go
+	@md5sum ./build/test.hex
 
 test: clean fmt-check smoke-test

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ func main() {
 
 ## Currently supported devices
 
-The following 51 devices are supported.
+The following 52 devices are supported.
 
 | Device Name | Interface Type |
 |----------|-------------|
@@ -80,6 +80,7 @@ The following 51 devices are supported.
 | [ILI9341 TFT color display](https://cdn-shop.adafruit.com/datasheets/ILI9341.pdf) | SPI |
 | [L293x motor driver](https://www.ti.com/lit/ds/symlink/l293d.pdf) | GPIO/PWM |
 | [L9110x motor driver](https://www.elecrow.com/download/datasheet-l9110.pdf) | GPIO/PWM |
+| [LIS2MDL magnetometer](https://www.st.com/resource/en/datasheet/lis2mdl.pdf) | I2C |
 | [LIS3DH accelerometer](https://www.st.com/resource/en/datasheet/lis3dh.pdf) | I2C |
 | [LSM6DS3 accelerometer](https://www.st.com/resource/en/datasheet/lsm6ds3.pdf) | I2C |
 | [MAG3110 magnetometer](https://www.nxp.com/docs/en/data-sheet/MAG3110.pdf) | I2C |

--- a/examples/lis2mdl/main.go
+++ b/examples/lis2mdl/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"machine"
+	"time"
+
+	"tinygo.org/x/drivers/lis2mdl"
+)
+
+func main() {
+	machine.I2C0.Configure(machine.I2CConfig{})
+	compass := lis2mdl.New(machine.I2C0)
+
+	if !compass.Connected() {
+		for {
+			println("LIS2MDL not connected!")
+			time.Sleep(1 * time.Second)
+		}
+	}
+
+	compass.Configure(lis2mdl.Configuration{}) //default settings
+
+	for {
+		heading := compass.ReadCompass()
+		println("Heading:", heading)
+
+		time.Sleep(time.Millisecond * 100)
+	}
+}

--- a/lis2mdl/registers.go
+++ b/lis2mdl/registers.go
@@ -1,0 +1,32 @@
+package lis2mdl
+
+const (
+	// Constants/addresses used for I2C.
+	MAG_ADDRESS = 0x1E
+
+	// magnetic sensor registers.
+	MAG_WHO_AM_I     = 0x4F
+	MAG_MR_CFG_REG_A = 0x60
+	MAG_MR_CFG_REG_B = 0x61
+	MAG_MR_CFG_REG_C = 0x62
+	MAG_OUT_X_L_M    = 0x68
+	MAG_OUT_X_H_M    = 0x69
+	MAG_OUT_Y_L_M    = 0x6A
+	MAG_OUT_Y_H_M    = 0x6B
+	MAG_OUT_Z_L_M    = 0x6C
+	MAG_OUT_Z_H_M    = 0x6D
+
+	// magnetic sensor power mode.
+	MAG_POWER_NORMAL = 0x00 // default
+	MAG_POWER_LOW    = 0x01
+
+	// magnetic sensor operate mode.
+	MAG_SYSTEM_CONTINUOUS = 0x00 // default
+	MAG_SYSTEM_SINGLE     = 0x01
+
+	// magnetic sensor data rate
+	MAG_DATARATE_10HZ  = 0x00 // default
+	MAG_DATARATE_20HZ  = 0x01
+	MAG_DATARATE_50HZ  = 0x02
+	MAG_DATARATE_100HZ = 0x03
+)


### PR DESCRIPTION
This PR move the functionality for the LIS2MDL magnetometer into a separate driver for clarity. A future PR will remove the duplication from the current LSM303AGR driver. Thanks @alankrantas for having done most of the work on this already.