### PR TITLE
Fix smoke-test unless avr-gcc installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,8 +129,10 @@ smoke-test:
 	@md5sum ./build/test.hex
 	tinygo build -size short -o ./build/test.hex -target=circuitplay-express ./examples/ws2812
 	@md5sum ./build/test.hex
+ifneq ($(AVR), 0)
 	tinygo build -size short -o ./build/test.hex -target=digispark ./examples/ws2812
 	@md5sum ./build/test.hex
+endif
 	tinygo build -size short -o ./build/test.hex -target=trinket-m0 ./examples/bme280/main.go
 	@md5sum ./build/test.hex
 	tinygo build -size short -o ./build/test.hex -target=circuitplay-express ./examples/microphone/main.go


### PR DESCRIPTION
This PR resolves #188 

If I'm going to do it the same way as tinygo-org/tinygo, I think I need to be able to add AVR=0.
I think it is reasonable to add the option because not everyone has avr-gcc installed.
Since the testing of ws2812 is done with circuitplay-express, I think this fix is reasonable.

https://github.com/tinygo-org/tinygo/blob/release/Makefile#L318

before: without avr-gcc installed

```
$ make smoke-test 
...
...
tinygo build -size short -o ./build/test.hex -target=digispark ./examples/ws2812
error: failed to build src/runtime/scheduler_avr.S: exec: "avr-gcc": executable file not found in $PATH
make: *** [Makefile:132: smoke-test] エラー 1
```

after: without avr-gcc installed && with `AVR=0`

```
$ make smoke-test AVR=0
...
...
(ok)
```
