### PR TITLE
test: add tester package for mocking of I2C bus/devices

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module tinygo.org/x/drivers
 
 go 1.14
 
-require github.com/eclipse/paho.mqtt.golang v1.2.0
+require (
+	github.com/eclipse/paho.mqtt.golang v1.2.0
+	github.com/frankban/quicktest v1.10.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,13 @@
 github.com/eclipse/paho.mqtt.golang v1.2.0 h1:1F8mhG9+aO5/xpdtFkW4SxOJB67ukuDC3t2y2qayIX0=
 github.com/eclipse/paho.mqtt.golang v1.2.0/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7joQ8SYLhZwfeOo6Ts=
+github.com/frankban/quicktest v1.10.2 h1:19ARM85nVi4xH7xPXuc5eM/udya5ieh7b/Sv+d844Tk=
+github.com/frankban/quicktest v1.10.2/go.mod h1:K+q6oSqb0W0Ininfk863uOk1lMy69l/P6txr3mVT54s=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/i2c.go
+++ b/i2c.go
@@ -1,0 +1,9 @@
+package drivers
+
+// I2C represents an I2C bus. It is notably implemented by the
+// machine.I2C type.
+type I2C interface {
+	ReadRegister(addr uint8, r uint8, buf []byte) error
+	WriteRegister(addr uint8, r uint8, buf []byte) error
+	Tx(addr uint16, w, r []byte) error
+}

--- a/lis2mdl/lis2mdl.go
+++ b/lis2mdl/lis2mdl.go
@@ -6,14 +6,15 @@
 package lis2mdl // import "tinygo.org/x/drivers/lis2mdl"
 
 import (
-	"machine"
 	"math"
 	"time"
+
+	"tinygo.org/x/drivers"
 )
 
 // Device wraps an I2C connection to a LIS2MDL device.
 type Device struct {
-	bus        machine.I2C
+	bus        drivers.I2C
 	Address    uint8
 	PowerMode  uint8
 	SystemMode uint8
@@ -31,7 +32,7 @@ type Configuration struct {
 // configured.
 //
 // This function only creates the Device object, it does not touch the device.
-func New(bus machine.I2C) Device {
+func New(bus drivers.I2C) Device {
 	return Device{bus: bus, Address: MAG_ADDRESS}
 }
 

--- a/lis2mdl/lis2mdl.go
+++ b/lis2mdl/lis2mdl.go
@@ -1,7 +1,7 @@
 // Package lis2mdl implements a driver for the LIS2MDL,
 // a magnetic sensor which is included on BBC micro:bit v1.5.
 //
-// Datasheet: https://www.st.com/resource/en/datasheet/lsm303agr.pdf
+// Datasheet: https://www.st.com/resource/en/datasheet/lis2mdl.pdf
 //
 package lis2mdl // import "tinygo.org/x/drivers/lis2mdl"
 
@@ -33,13 +33,13 @@ type Configuration struct {
 //
 // This function only creates the Device object, it does not touch the device.
 func New(bus drivers.I2C) Device {
-	return Device{bus: bus, Address: MAG_ADDRESS}
+	return Device{bus: bus, Address: ADDRESS}
 }
 
 // Connected returns whether LIS2MDL sensor has been found.
 func (d *Device) Connected() bool {
 	data := []byte{0}
-	d.bus.ReadRegister(uint8(d.Address), MAG_WHO_AM_I, data)
+	d.bus.ReadRegister(uint8(d.Address), WHO_AM_I, data)
 	return data[0] == 0x40
 }
 
@@ -48,44 +48,44 @@ func (d *Device) Configure(cfg Configuration) {
 	if cfg.PowerMode != 0 {
 		d.PowerMode = cfg.PowerMode
 	} else {
-		d.PowerMode = MAG_POWER_NORMAL
+		d.PowerMode = POWER_NORMAL
 	}
 
 	if cfg.DataRate != 0 {
 		d.DataRate = cfg.DataRate
 	} else {
-		d.DataRate = MAG_DATARATE_100HZ
+		d.DataRate = DATARATE_100HZ
 	}
 
 	if cfg.SystemMode != 0 {
 		d.SystemMode = cfg.SystemMode
 	} else {
-		d.SystemMode = MAG_SYSTEM_CONTINUOUS
+		d.SystemMode = SYSTEM_CONTINUOUS
 	}
 
 	cmd := []byte{0}
 
 	// reset
 	cmd[0] = byte(1 << 5)
-	d.bus.WriteRegister(uint8(d.Address), MAG_MR_CFG_REG_A, cmd)
+	d.bus.WriteRegister(uint8(d.Address), CFG_REG_A, cmd)
 	time.Sleep(100 * time.Millisecond)
 
 	// reboot
 	cmd[0] = byte(1 << 6)
-	d.bus.WriteRegister(uint8(d.Address), MAG_MR_CFG_REG_A, cmd)
+	d.bus.WriteRegister(uint8(d.Address), CFG_REG_A, cmd)
 	time.Sleep(100 * time.Millisecond)
 
 	// bdu
 	cmd[0] = byte(1 << 4)
-	d.bus.WriteRegister(uint8(d.Address), MAG_MR_CFG_REG_C, cmd)
+	d.bus.WriteRegister(uint8(d.Address), CFG_REG_C, cmd)
 
 	// Temperature compensation is on for magnetic sensor (0x80)
 	cmd[0] = byte(0x80)
-	d.bus.WriteRegister(uint8(d.Address), MAG_MR_CFG_REG_A, cmd)
+	d.bus.WriteRegister(uint8(d.Address), CFG_REG_A, cmd)
 
 	// speed
 	cmd[0] = byte(0x80 | d.DataRate)
-	d.bus.WriteRegister(uint8(d.Address), MAG_MR_CFG_REG_A, cmd)
+	d.bus.WriteRegister(uint8(d.Address), CFG_REG_A, cmd)
 }
 
 // ReadMagneticField reads the current magnetic field from the device and returns
@@ -94,11 +94,11 @@ func (d *Device) ReadMagneticField() (x int32, y int32, z int32) {
 	// turn back on read mode, even though it is supposed to be continuous?
 	cmd := []byte{0}
 	cmd[0] = byte(0x80 | d.PowerMode<<4 | d.DataRate<<2 | d.SystemMode)
-	d.bus.WriteRegister(uint8(d.Address), MAG_MR_CFG_REG_A, cmd)
+	d.bus.WriteRegister(uint8(d.Address), CFG_REG_A, cmd)
 	time.Sleep(10 * time.Millisecond)
 
 	data := make([]byte, 6)
-	d.bus.ReadRegister(uint8(d.Address), MAG_OUT_X_L_M, data)
+	d.bus.ReadRegister(uint8(d.Address), OUTX_L_REG, data)
 
 	x = int32(int16((uint16(data[0]) << 8) | uint16(data[1])))
 	y = int32(int16((uint16(data[2]) << 8) | uint16(data[3])))

--- a/lis2mdl/lis2mdl_test.go
+++ b/lis2mdl/lis2mdl_test.go
@@ -11,22 +11,49 @@ func TestDefaultI2CAddress(t *testing.T) {
 	c := qt.New(t)
 	bus := tester.NewI2CBus(c)
 	dev := New(bus)
-	c.Assert(dev.Address, qt.Equals, uint8(MAG_ADDRESS))
+	c.Assert(dev.Address, qt.Equals, uint8(ADDRESS))
 }
 
 func TestWhoAmI(t *testing.T) {
 	c := qt.New(t)
 	bus := tester.NewI2CBus(c)
-	fake := tester.NewI2CDevice(c, MAG_ADDRESS)
+	fake := tester.NewI2CDevice(c, ADDRESS)
+	fake.SetupRegisters(defaultRegisters())
 	bus.AddDevice(fake)
 
 	dev := New(bus)
-
-	fake.SetupRegisters([]uint8{
-		0x4F: 0x40,
-	})
 	c.Assert(dev.Connected(), qt.Equals, true)
 
-	fake.SetupRegister(0x4F, 0x99)
+	fake.SetupRegister(WHO_AM_I, 0x99)
 	c.Assert(dev.Connected(), qt.Equals, false)
+}
+
+// defaultRegisters returns the default values for all of the device's registers.
+// see table 22 on page 27 of the datasheet.
+func defaultRegisters() []uint8 {
+	return []uint8{
+		OFFSET_X_REG_L: 0,
+		OFFSET_X_REG_H: 0,
+		OFFSET_Y_REG_L: 0,
+		OFFSET_Y_REG_H: 0,
+		OFFSET_Z_REG_L: 0,
+		OFFSET_Z_REG_H: 0,
+		WHO_AM_I:       0x40,
+		CFG_REG_A:      0x03,
+		CFG_REG_B:      0,
+		CFG_REG_C:      0,
+		INT_CRTL_REG:   0xE0,
+		INT_SOURCE_REG: 0,
+		INT_THS_L_REG:  0,
+		INT_THS_H_REG:  0,
+		STATUS_REG:     0,
+		OUTX_L_REG:     0,
+		OUTX_H_REG:     0,
+		OUTY_L_REG:     0,
+		OUTY_H_REG:     0,
+		OUTZ_L_REG:     0,
+		OUTZ_H_REG:     0,
+		TEMP_OUT_L_REG: 0,
+		TEMP_OUT_H_REG: 0,
+	}
 }

--- a/lis2mdl/lis2mdl_test.go
+++ b/lis2mdl/lis2mdl_test.go
@@ -1,0 +1,15 @@
+package lis2mdl
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"tinygo.org/x/drivers/tester"
+)
+
+func TestI2CAddress(t *testing.T) {
+	c := qt.New(t)
+	bus := tester.NewI2CBus(c)
+	dev := New(bus)
+	c.Assert(dev.Address, qt.Equals, uint8(MAG_ADDRESS))
+}

--- a/lis2mdl/lis2mdl_test.go
+++ b/lis2mdl/lis2mdl_test.go
@@ -7,9 +7,26 @@ import (
 	"tinygo.org/x/drivers/tester"
 )
 
-func TestI2CAddress(t *testing.T) {
+func TestDefaultI2CAddress(t *testing.T) {
 	c := qt.New(t)
 	bus := tester.NewI2CBus(c)
 	dev := New(bus)
 	c.Assert(dev.Address, qt.Equals, uint8(MAG_ADDRESS))
+}
+
+func TestWhoAmI(t *testing.T) {
+	c := qt.New(t)
+	bus := tester.NewI2CBus(c)
+	fake := tester.NewI2CDevice(c, MAG_ADDRESS)
+	bus.AddDevice(fake)
+
+	dev := New(bus)
+
+	fake.SetupRegisters([]uint8{
+		0x4F: 0x40,
+	})
+	c.Assert(dev.Connected(), qt.Equals, true)
+
+	fake.SetupRegister(0x4F, 0x99)
+	c.Assert(dev.Connected(), qt.Equals, false)
 }

--- a/lis2mdl/registers.go
+++ b/lis2mdl/registers.go
@@ -2,31 +2,44 @@ package lis2mdl
 
 const (
 	// Constants/addresses used for I2C.
-	MAG_ADDRESS = 0x1E
+	ADDRESS = 0x1E
 
 	// magnetic sensor registers.
-	MAG_WHO_AM_I     = 0x4F
-	MAG_MR_CFG_REG_A = 0x60
-	MAG_MR_CFG_REG_B = 0x61
-	MAG_MR_CFG_REG_C = 0x62
-	MAG_OUT_X_L_M    = 0x68
-	MAG_OUT_X_H_M    = 0x69
-	MAG_OUT_Y_L_M    = 0x6A
-	MAG_OUT_Y_H_M    = 0x6B
-	MAG_OUT_Z_L_M    = 0x6C
-	MAG_OUT_Z_H_M    = 0x6D
+	OFFSET_X_REG_L = 0x45
+	OFFSET_X_REG_H = 0x46
+	OFFSET_Y_REG_L = 0x47
+	OFFSET_Y_REG_H = 0x48
+	OFFSET_Z_REG_L = 0x49
+	OFFSET_Z_REG_H = 0x4A
+	WHO_AM_I       = 0x4F
+	CFG_REG_A      = 0x60
+	CFG_REG_B      = 0x61
+	CFG_REG_C      = 0x62
+	INT_CRTL_REG   = 0x63
+	INT_SOURCE_REG = 0x64
+	INT_THS_L_REG  = 0x65
+	INT_THS_H_REG  = 0x66
+	STATUS_REG     = 0x67
+	OUTX_L_REG     = 0x68
+	OUTX_H_REG     = 0x69
+	OUTY_L_REG     = 0x6A
+	OUTY_H_REG     = 0x6B
+	OUTZ_L_REG     = 0x6C
+	OUTZ_H_REG     = 0x6D
+	TEMP_OUT_L_REG = 0x6E
+	TEMP_OUT_H_REG = 0x6F
 
 	// magnetic sensor power mode.
-	MAG_POWER_NORMAL = 0x00 // default
-	MAG_POWER_LOW    = 0x01
+	POWER_NORMAL = 0x00 // default
+	POWER_LOW    = 0x01
 
 	// magnetic sensor operate mode.
-	MAG_SYSTEM_CONTINUOUS = 0x00 // default
-	MAG_SYSTEM_SINGLE     = 0x01
+	SYSTEM_CONTINUOUS = 0x00 // default
+	SYSTEM_SINGLE     = 0x01
 
 	// magnetic sensor data rate
-	MAG_DATARATE_10HZ  = 0x00 // default
-	MAG_DATARATE_20HZ  = 0x01
-	MAG_DATARATE_50HZ  = 0x02
-	MAG_DATARATE_100HZ = 0x03
+	DATARATE_10HZ  = 0x00 // default
+	DATARATE_20HZ  = 0x01
+	DATARATE_50HZ  = 0x02
+	DATARATE_100HZ = 0x03
 )

--- a/tester/device.go
+++ b/tester/device.go
@@ -1,0 +1,58 @@
+package tester
+
+import (
+	qt "github.com/frankban/quicktest"
+)
+
+const maxRegisters = 200
+
+// I2CDevice represents a mock I2C device on a mock I2C bus.
+type I2CDevice struct {
+	C    *qt.C
+	Addr uint8
+	// Registers holds the device registers. It can be inspected
+	// or changed as desired for testing.
+	Registers [maxRegisters]uint8
+	// If Err is non-nil, it will be returned as the error from the
+	// I2C methods.
+	Err error
+}
+
+// NewI2CDevice returns a new mock I2C device.
+func NewI2CDevice(c *qt.C, addr uint8) *I2CDevice {
+	return &I2CDevice{
+		C:    c,
+		Addr: addr,
+	}
+}
+
+// ReadRegister implements I2C.ReadRegister.
+func (d *I2CDevice) ReadRegister(r uint8, buf []byte) error {
+	if d.Err != nil {
+		return d.Err
+	}
+	d.AssertRegisterRange(r, buf)
+	copy(buf, d.Registers[r:])
+	return nil
+}
+
+// WriteRegister implements I2C.WriteRegister.
+func (d *I2CDevice) WriteRegister(r uint8, buf []byte) error {
+	if d.Err != nil {
+		return d.Err
+	}
+	d.AssertRegisterRange(r, buf)
+	copy(d.Registers[r:], buf)
+	return nil
+}
+
+// AssertRegisterRange asserts that reading or writing the given
+// register and subsequent registers is in range of the available registers.
+func (d *I2CDevice) AssertRegisterRange(r uint8, buf []byte) {
+	if int(r) >= len(d.Registers) {
+		d.C.Fatalf("register read/write [%#x, %#x] start out of range", r, int(r)+len(buf))
+	}
+	if int(r)+len(buf) > len(d.Registers) {
+		d.C.Fatalf("register read/write [%#x, %#x] end out of range", r, int(r)+len(buf))
+	}
+}

--- a/tester/device.go
+++ b/tester/device.go
@@ -1,29 +1,54 @@
 package tester
 
-import (
-	qt "github.com/frankban/quicktest"
-)
-
-const maxRegisters = 200
+// MaxRegisters is the maximum number of registers supported for a Device.
+const MaxRegisters = 200
 
 // I2CDevice represents a mock I2C device on a mock I2C bus.
 type I2CDevice struct {
-	C    *qt.C
-	Addr uint8
+	c Failer
+	// addr is the i2c device address.
+	addr uint8
 	// Registers holds the device registers. It can be inspected
 	// or changed as desired for testing.
-	Registers [maxRegisters]uint8
+	registers [MaxRegisters]uint8
 	// If Err is non-nil, it will be returned as the error from the
 	// I2C methods.
 	Err error
 }
 
 // NewI2CDevice returns a new mock I2C device.
-func NewI2CDevice(c *qt.C, addr uint8) *I2CDevice {
+func NewI2CDevice(c Failer, addr uint8) *I2CDevice {
 	return &I2CDevice{
-		C:    c,
-		Addr: addr,
+		c:    c,
+		addr: addr,
 	}
+}
+
+// Addr returns the Device address.
+func (d *I2CDevice) Addr() uint8 {
+	return d.addr
+}
+
+// SetupRegisters sets all of the Device registers.
+// It is intended to be used when setting up a fake device
+// for testing expected vs. actual values.
+func (d *I2CDevice) SetupRegisters(regs []uint8) {
+	if len(regs) > MaxRegisters {
+		panic("exceeded maximum number of registers for fake device")
+	}
+	for k, v := range regs {
+		d.registers[k] = v
+	}
+}
+
+// SetupRegister sets one of the Device registers.
+// It is intended to be used when setting up a fake device
+// for testing expected vs. actual values.
+func (d *I2CDevice) SetupRegister(r, v uint8) {
+	if r > MaxRegisters {
+		panic("exceeded maximum number of registers for fake device")
+	}
+	d.registers[r] = v
 }
 
 // ReadRegister implements I2C.ReadRegister.
@@ -32,7 +57,7 @@ func (d *I2CDevice) ReadRegister(r uint8, buf []byte) error {
 		return d.Err
 	}
 	d.AssertRegisterRange(r, buf)
-	copy(buf, d.Registers[r:])
+	copy(buf, d.registers[r:])
 	return nil
 }
 
@@ -42,17 +67,17 @@ func (d *I2CDevice) WriteRegister(r uint8, buf []byte) error {
 		return d.Err
 	}
 	d.AssertRegisterRange(r, buf)
-	copy(d.Registers[r:], buf)
+	copy(d.registers[r:], buf)
 	return nil
 }
 
 // AssertRegisterRange asserts that reading or writing the given
 // register and subsequent registers is in range of the available registers.
 func (d *I2CDevice) AssertRegisterRange(r uint8, buf []byte) {
-	if int(r) >= len(d.Registers) {
-		d.C.Fatalf("register read/write [%#x, %#x] start out of range", r, int(r)+len(buf))
+	if int(r) >= len(d.registers) {
+		d.c.Fatalf("register read/write [%#x, %#x] start out of range", r, int(r)+len(buf))
 	}
-	if int(r)+len(buf) > len(d.Registers) {
-		d.C.Fatalf("register read/write [%#x, %#x] end out of range", r, int(r)+len(buf))
+	if int(r)+len(buf) > len(d.registers) {
+		d.c.Fatalf("register read/write [%#x, %#x] end out of range", r, int(r)+len(buf))
 	}
 }

--- a/tester/i2c.go
+++ b/tester/i2c.go
@@ -1,0 +1,52 @@
+package tester
+
+import (
+	qt "github.com/frankban/quicktest"
+)
+
+// I2CBus implements the I2C interface in memory for testing.
+type I2CBus struct {
+	C       *qt.C
+	Devices []*I2CDevice
+}
+
+// NewI2CBus returns an I2CBus mock I2C instance that uses c to flag errors
+// if they happen. After creating a I2C instance, add devices
+// to it with addDevice before using NewI2CBus interface.
+func NewI2CBus(c *qt.C) *I2CBus {
+	return &I2CBus{
+		C: c,
+	}
+}
+
+// AddDevice adds a new mock device to the mock I2C bus.
+func (bus *I2CBus) AddDevice(d *I2CDevice) {
+	bus.Devices = append(bus.Devices, d)
+}
+
+// ReadRegister implements I2C.ReadRegister.
+func (bus *I2CBus) ReadRegister(addr uint8, r uint8, buf []byte) error {
+	return bus.FindDevice(addr).ReadRegister(r, buf)
+}
+
+// WriteRegister implements I2C.WriteRegister.
+func (bus *I2CBus) WriteRegister(addr uint8, r uint8, buf []byte) error {
+	return bus.FindDevice(addr).WriteRegister(r, buf)
+}
+
+// Tx implements I2C.Tx.
+func (bus *I2CBus) Tx(addr uint16, input, output []byte) error {
+	// TODO: implement this
+	return nil
+}
+
+// FindDevice returns the device with the given address.
+func (bus *I2CBus) FindDevice(addr uint8) *I2CDevice {
+	for _, dev := range bus.Devices {
+		if dev.Addr == addr {
+			return dev
+		}
+	}
+	bus.C.Fatalf("invalid device addr %#x passed to i2c bus", addr)
+	panic("unreachable")
+}

--- a/tester/i2c.go
+++ b/tester/i2c.go
@@ -1,27 +1,23 @@
 package tester
 
-import (
-	qt "github.com/frankban/quicktest"
-)
-
 // I2CBus implements the I2C interface in memory for testing.
 type I2CBus struct {
-	C       *qt.C
-	Devices []*I2CDevice
+	c       Failer
+	devices []*I2CDevice
 }
 
 // NewI2CBus returns an I2CBus mock I2C instance that uses c to flag errors
 // if they happen. After creating a I2C instance, add devices
 // to it with addDevice before using NewI2CBus interface.
-func NewI2CBus(c *qt.C) *I2CBus {
+func NewI2CBus(c Failer) *I2CBus {
 	return &I2CBus{
-		C: c,
+		c: c,
 	}
 }
 
 // AddDevice adds a new mock device to the mock I2C bus.
 func (bus *I2CBus) AddDevice(d *I2CDevice) {
-	bus.Devices = append(bus.Devices, d)
+	bus.devices = append(bus.devices, d)
 }
 
 // ReadRegister implements I2C.ReadRegister.
@@ -42,11 +38,11 @@ func (bus *I2CBus) Tx(addr uint16, input, output []byte) error {
 
 // FindDevice returns the device with the given address.
 func (bus *I2CBus) FindDevice(addr uint8) *I2CDevice {
-	for _, dev := range bus.Devices {
-		if dev.Addr == addr {
+	for _, dev := range bus.devices {
+		if dev.Addr() == addr {
 			return dev
 		}
 	}
-	bus.C.Fatalf("invalid device addr %#x passed to i2c bus", addr)
+	bus.c.Fatalf("invalid device addr %#x passed to i2c bus", addr)
 	panic("unreachable")
 }

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -3,3 +3,11 @@
 // TODO: info on how to use this.
 //
 package tester // import "tinygo.org/x/drivers/tester"
+
+// Failer is used by the I2CDevice type to abort when it's used in
+// unexpected ways, such as reading an out-of-range register.
+type Failer interface {
+	// Fatalf prints the Printf-formatted message and exits the current
+	// goroutine.
+	Fatalf(f string, a ...interface{})
+}

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -1,0 +1,5 @@
+// Package tester contains mock structs to make it easier to test I2C devices.
+//
+// TODO: info on how to use this.
+//
+package tester // import "tinygo.org/x/drivers/tester"


### PR DESCRIPTION
This PR adds a `tester` package that contains I2CBus and I2CDevice mocks for use in writing unit tests for I2C devices.

Making this PR as draft, it is intended to serve as a starting point for conversation.