### PR TITLE
i2c: switch all i2c drivers definitions to use i2c bus interface type

### DIFF
--- a/adt7410/adt7410.go
+++ b/adt7410/adt7410.go
@@ -1,8 +1,9 @@
 package adt7410 // import "tinygo.org/x/drivers/adt7410"
 
 import (
-	"machine"
 	"time"
+
+	"tinygo.org/x/drivers"
 )
 
 type Error uint8
@@ -21,7 +22,7 @@ func (e Error) Error() string {
 }
 
 type Device struct {
-	bus  *machine.I2C
+	bus  drivers.I2C
 	buf  []byte
 	addr uint8
 }
@@ -31,7 +32,7 @@ type Device struct {
 // can be set using by connecting to the A1 and A0 pins to VDD or GND (for a
 // total of up to 4 devices on a I2C bus).  Also note that 10k pullups are
 // recommended for the SDA and SCL lines.
-func New(i2c *machine.I2C, addressBits uint8) *Device {
+func New(i2c drivers.I2C, addressBits uint8) *Device {
 	return &Device{
 		bus:  i2c,
 		buf:  make([]byte, 2),

--- a/adxl345/adxl345.go
+++ b/adxl345/adxl345.go
@@ -6,9 +6,7 @@
 //
 package adxl345 // import "tinygo.org/x/drivers/adxl345"
 
-import (
-	"machine"
-)
+import "tinygo.org/x/drivers"
 
 type Range uint8
 type Rate uint8
@@ -40,7 +38,7 @@ type bwRate struct {
 
 // Device wraps an I2C connection to a ADXL345 device.
 type Device struct {
-	bus        machine.I2C
+	bus        drivers.I2C
 	Address    uint16
 	powerCtl   powerCtl
 	dataFormat dataFormat
@@ -52,7 +50,7 @@ type Device struct {
 //
 // This function only creates the Device object, it does not init the device.
 // To do that you must call the Configure() method on the Device before using it.
-func New(bus machine.I2C) Device {
+func New(bus drivers.I2C) Device {
 	return Device{
 		bus: bus,
 		powerCtl: powerCtl{

--- a/amg88xx/amg88xx.go
+++ b/amg88xx/amg88xx.go
@@ -5,13 +5,14 @@
 package amg88xx // import "tinygo.org/x/drivers/amg88xx"
 
 import (
-	"machine"
 	"time"
+
+	"tinygo.org/x/drivers"
 )
 
 // Device wraps an I2C connection to a AMG88xx device.
 type Device struct {
-	bus             machine.I2C
+	bus             drivers.I2C
 	Address         uint16
 	data            []uint8
 	interruptMode   InterruptMode
@@ -27,7 +28,7 @@ type Config struct {
 // configured.
 //
 // This function only creates the Device object, it does not touch the device.
-func New(bus machine.I2C) Device {
+func New(bus drivers.I2C) Device {
 	return Device{
 		bus:     bus,
 		Address: AddressHigh,

--- a/at24cx/at24cx.go
+++ b/at24cx/at24cx.go
@@ -6,13 +6,14 @@ package at24cx // import "tinygo.org/x/drivers/at24cx"
 
 import (
 	"errors"
-	"machine"
 	"time"
+
+	"tinygo.org/x/drivers"
 )
 
 // Device wraps an I2C connection to a DS3231 device.
 type Device struct {
-	bus               machine.I2C
+	bus               drivers.I2C
 	Address           uint16
 	pageSize          uint16
 	currentRAMAddress uint16
@@ -30,7 +31,7 @@ type Config struct {
 // configured.
 //
 // This function only creates the Device object, it does not touch the device.
-func New(bus machine.I2C) Device {
+func New(bus drivers.I2C) Device {
 	return Device{
 		bus:     bus,
 		Address: Address,

--- a/bh1750/bh1750.go
+++ b/bh1750/bh1750.go
@@ -8,7 +8,7 @@ package bh1750 // import "tinygo.org/x/drivers/bh1750"
 import (
 	"time"
 
-	"machine"
+	"tinygo.org/x/drivers"
 )
 
 // SamplingMode is the sampling's resolution of the measurement
@@ -16,7 +16,7 @@ type SamplingMode byte
 
 // Device wraps an I2C connection to a bh1750 device.
 type Device struct {
-	bus     machine.I2C
+	bus     drivers.I2C
 	Address uint16
 	mode    SamplingMode
 }
@@ -25,7 +25,7 @@ type Device struct {
 // configured.
 //
 // This function only creates the Device object, it does not touch the device.
-func New(bus machine.I2C) Device {
+func New(bus drivers.I2C) Device {
 	return Device{
 		bus:     bus,
 		Address: Address,

--- a/blinkm/blinkm.go
+++ b/blinkm/blinkm.go
@@ -1,15 +1,14 @@
 // Package blinkm implements a driver for the BlinkM I2C RGB LED.
 //
 // Datasheet: http://thingm.com/fileadmin/thingm/downloads/BlinkM_datasheet.pdf
+//
 package blinkm // import "tinygo.org/x/drivers/blinkm"
 
-import (
-	"machine"
-)
+import "tinygo.org/x/drivers"
 
 // Device wraps an I2C connection to a BlinkM device.
 type Device struct {
-	bus     machine.I2C
+	bus     drivers.I2C
 	Address uint16
 }
 
@@ -17,7 +16,7 @@ type Device struct {
 // configured.
 //
 // This function only creates the Device object, it does not touch the device.
-func New(bus machine.I2C) Device {
+func New(bus drivers.I2C) Device {
 	return Device{bus, Address}
 }
 

--- a/bme280/bme280.go
+++ b/bme280/bme280.go
@@ -7,8 +7,9 @@
 package bme280
 
 import (
-	"machine"
 	"math"
+
+	"tinygo.org/x/drivers"
 )
 
 // calibrationCoefficients reads at startup and stores the calibration coefficients
@@ -35,7 +36,7 @@ type calibrationCoefficients struct {
 
 // Device wraps an I2C connection to a BME280 device.
 type Device struct {
-	bus                     machine.I2C
+	bus                     drivers.I2C
 	Address                 uint16
 	calibrationCoefficients calibrationCoefficients
 }
@@ -44,7 +45,7 @@ type Device struct {
 // configured.
 //
 // This function only creates the Device object, it does not touch the device.
-func New(bus machine.I2C) Device {
+func New(bus drivers.I2C) Device {
 	return Device{
 		bus:     bus,
 		Address: Address,

--- a/bmp180/bmp180.go
+++ b/bmp180/bmp180.go
@@ -9,7 +9,7 @@ package bmp180 // import "tinygo.org/x/drivers/bmp180"
 import (
 	"time"
 
-	"machine"
+	"tinygo.org/x/drivers"
 )
 
 // OversamplingMode is the oversampling ratio of the pressure measurement.
@@ -32,7 +32,7 @@ type calibrationCoefficients struct {
 
 // Device wraps an I2C connection to a BMP180 device.
 type Device struct {
-	bus                     machine.I2C
+	bus                     drivers.I2C
 	Address                 uint16
 	mode                    OversamplingMode
 	calibrationCoefficients calibrationCoefficients
@@ -43,7 +43,7 @@ type Device struct {
 //
 // This function only creates the Device object, it does not initialize the device.
 // You must call Configure() first in order to use the device itself.
-func New(bus machine.I2C) Device {
+func New(bus drivers.I2C) Device {
 	return Device{
 		bus:     bus,
 		Address: Address,

--- a/bmp280/bmp280.go
+++ b/bmp280/bmp280.go
@@ -1,8 +1,9 @@
 package bmp280
 
 import (
-	"machine"
 	"time"
+
+	"tinygo.org/x/drivers"
 )
 
 // OversamplingMode is the oversampling ratio of the temperature or pressure measurement.
@@ -19,7 +20,7 @@ type Filter uint
 
 // Device wraps an I2C connection to a BMP280 device.
 type Device struct {
-	bus         machine.I2C
+	bus         drivers.I2C
 	Address     uint16
 	cali        calibrationCoefficients
 	Temperature Oversampling
@@ -52,7 +53,7 @@ type calibrationCoefficients struct {
 //
 // This function only creates the Device object, it does not initialize the device.
 // You must call Configure() first in order to use the device itself.
-func New(bus machine.I2C) Device {
+func New(bus drivers.I2C) Device {
 	return Device{
 		bus:     bus,
 		Address: Address,

--- a/ds1307/ds1307.go
+++ b/ds1307/ds1307.go
@@ -9,18 +9,18 @@ import (
 	"errors"
 	"time"
 
-	"machine"
+	"tinygo.org/x/drivers"
 )
 
 // Device wraps an I2C connection to a DS1307 device.
 type Device struct {
-	bus         machine.I2C
+	bus         drivers.I2C
 	Address     uint8
 	AddressSRAM uint8
 }
 
 // New creates a new DS1307 connection. I2C bus must be already configured.
-func New(bus machine.I2C) Device {
+func New(bus drivers.I2C) Device {
 	return Device{bus: bus,
 		Address:     uint8(I2CAddress),
 		AddressSRAM: SRAMBeginAddres,

--- a/ds3231/ds3231.go
+++ b/ds3231/ds3231.go
@@ -5,15 +5,16 @@
 package ds3231 // import "tinygo.org/x/drivers/ds3231"
 
 import (
-	"machine"
 	"time"
+
+	"tinygo.org/x/drivers"
 )
 
 type Mode uint8
 
 // Device wraps an I2C connection to a DS3231 device.
 type Device struct {
-	bus     machine.I2C
+	bus     drivers.I2C
 	Address uint16
 }
 
@@ -21,7 +22,7 @@ type Device struct {
 // configured.
 //
 // This function only creates the Device object, it does not touch the device.
-func New(bus machine.I2C) Device {
+func New(bus drivers.I2C) Device {
 	return Device{
 		bus:     bus,
 		Address: Address,

--- a/gps/gps.go
+++ b/gps/gps.go
@@ -7,6 +7,8 @@ import (
 	"machine"
 	"strings"
 	"time"
+
+	"tinygo.org/x/drivers"
 )
 
 var (
@@ -20,7 +22,7 @@ type Device struct {
 	bufIdx   int
 	sentence strings.Builder
 	uart     *machine.UART
-	bus      *machine.I2C
+	bus      drivers.I2C
 	address  uint16
 }
 
@@ -35,7 +37,7 @@ func NewUART(uart *machine.UART) Device {
 }
 
 // NewI2C creates a new I2C GPS connection.
-func NewI2C(bus *machine.I2C) Device {
+func NewI2C(bus drivers.I2C) Device {
 	return Device{
 		bus:      bus,
 		address:  I2C_ADDRESS,

--- a/hd44780i2c/hd44780i2c.go
+++ b/hd44780i2c/hd44780i2c.go
@@ -7,13 +7,14 @@ package hd44780i2c
 
 import (
 	"errors"
-	"machine"
 	"time"
+
+	"tinygo.org/x/drivers"
 )
 
 // Device wraps an I2C connection to a HD44780 I2C LCD with related data.
 type Device struct {
-	bus             machine.I2C
+	bus             drivers.I2C
 	addr            uint8
 	width           uint8
 	height          uint8
@@ -41,7 +42,7 @@ type Config struct {
 // configured.
 //
 // This function only creates the Device object, it does not touch the device.
-func New(bus machine.I2C, addr uint8) Device {
+func New(bus drivers.I2C, addr uint8) Device {
 	if addr == 0 {
 		addr = 0x27
 	}

--- a/lis3dh/lis3dh.go
+++ b/lis3dh/lis3dh.go
@@ -4,13 +4,11 @@
 //
 package lis3dh // import "tinygo.org/x/drivers/lis3dh"
 
-import (
-	"machine"
-)
+import "tinygo.org/x/drivers"
 
 // Device wraps an I2C connection to a LIS3DH device.
 type Device struct {
-	bus     machine.I2C
+	bus     drivers.I2C
 	Address uint16
 	r       Range
 }
@@ -18,7 +16,7 @@ type Device struct {
 // New creates a new LIS3DH connection. The I2C bus must already be configured.
 //
 // This function only creates the Device object, it does not touch the device.
-func New(bus machine.I2C) Device {
+func New(bus drivers.I2C) Device {
 	return Device{bus: bus, Address: Address0}
 }
 

--- a/lsm303agr/lsm303agr.go
+++ b/lsm303agr/lsm303agr.go
@@ -6,13 +6,14 @@
 package lsm303agr // import "tinygo.org/x/drivers/lsm303agr"
 
 import (
-	"machine"
 	"math"
+
+	"tinygo.org/x/drivers"
 )
 
 // Device wraps an I2C connection to a LSM303AGR device.
 type Device struct {
-	bus            machine.I2C
+	bus            drivers.I2C
 	AccelAddress   uint8
 	MagAddress     uint8
 	AccelPowerMode uint8
@@ -37,7 +38,7 @@ type Configuration struct {
 // configured.
 //
 // This function only creates the Device object, it does not touch the device.
-func New(bus machine.I2C) Device {
+func New(bus drivers.I2C) Device {
 	return Device{bus: bus, AccelAddress: ACCEL_ADDRESS, MagAddress: MAG_ADDRESS}
 }
 

--- a/lsm6ds3/lsm6ds3.go
+++ b/lsm6ds3/lsm6ds3.go
@@ -5,9 +5,7 @@
 //
 package lsm6ds3 // import "tinygo.org/x/drivers/lsm6ds3"
 
-import (
-	"machine"
-)
+import "tinygo.org/x/drivers"
 
 type AccelRange uint8
 type AccelSampleRate uint8
@@ -18,7 +16,7 @@ type GyroSampleRate uint8
 
 // Device wraps an I2C connection to a LSM6DS3 device.
 type Device struct {
-	bus             machine.I2C
+	bus             drivers.I2C
 	Address         uint16
 	accelRange      AccelRange
 	accelSampleRate AccelSampleRate
@@ -44,7 +42,7 @@ type Configuration struct {
 // configured.
 //
 // This function only creates the Device object, it does not touch the device.
-func New(bus machine.I2C) Device {
+func New(bus drivers.I2C) Device {
 	return Device{bus: bus, Address: Address}
 }
 

--- a/mag3110/mag3110.go
+++ b/mag3110/mag3110.go
@@ -5,13 +5,11 @@
 //
 package mag3110 // import "tinygo.org/x/drivers/mag3110"
 
-import (
-	"machine"
-)
+import "tinygo.org/x/drivers"
 
 // Device wraps an I2C connection to a MAG3110 device.
 type Device struct {
-	bus     machine.I2C
+	bus     drivers.I2C
 	Address uint16
 }
 
@@ -19,7 +17,7 @@ type Device struct {
 // configured.
 //
 // This function only creates the Device object, it does not touch the device.
-func New(bus machine.I2C) Device {
+func New(bus drivers.I2C) Device {
 	return Device{bus, Address}
 }
 

--- a/mma8653/mma8653.go
+++ b/mma8653/mma8653.go
@@ -6,13 +6,11 @@
 //
 package mma8653 // import "tinygo.org/x/drivers/mma8653"
 
-import (
-	"machine"
-)
+import "tinygo.org/x/drivers"
 
 // Device wraps an I2C connection to a MMA8653 device.
 type Device struct {
-	bus         machine.I2C
+	bus         drivers.I2C
 	Address     uint16
 	sensitivity Sensitivity
 }
@@ -21,7 +19,7 @@ type Device struct {
 // configured.
 //
 // This function only creates the Device object, it does not touch the device.
-func New(bus machine.I2C) Device {
+func New(bus drivers.I2C) Device {
 	return Device{bus, Address, Sensitivity2G}
 }
 

--- a/mpu6050/mpu6050.go
+++ b/mpu6050/mpu6050.go
@@ -7,13 +7,11 @@
 //
 package mpu6050 // import "tinygo.org/x/drivers/mpu6050"
 
-import (
-	"machine"
-)
+import "tinygo.org/x/drivers"
 
 // Device wraps an I2C connection to a MPU6050 device.
 type Device struct {
-	bus     machine.I2C
+	bus     drivers.I2C
 	Address uint16
 }
 
@@ -21,7 +19,7 @@ type Device struct {
 // configured.
 //
 // This function only creates the Device object, it does not touch the device.
-func New(bus machine.I2C) Device {
+func New(bus drivers.I2C) Device {
 	return Device{bus, Address}
 }
 

--- a/sht3x/sht3x.go
+++ b/sht3x/sht3x.go
@@ -7,13 +7,14 @@
 package sht3x // import "tinygo.org/x/drivers/sht3x"
 
 import (
-	"machine"
 	"time"
+
+	"tinygo.org/x/drivers"
 )
 
 // Device wraps an I2C connection to a SHT31 device.
 type Device struct {
-	bus     machine.I2C
+	bus     drivers.I2C
 	Address uint16
 }
 
@@ -22,7 +23,7 @@ type Device struct {
 //
 // This function only creates the Device object, it does not initialize the device.
 // You must call Configure() first in order to use the device itself.
-func New(bus machine.I2C) Device {
+func New(bus drivers.I2C) Device {
 	return Device{
 		bus:     bus,
 		Address: AddressA,

--- a/ssd1306/ssd1306.go
+++ b/ssd1306/ssd1306.go
@@ -9,6 +9,8 @@ import (
 	"image/color"
 	"machine"
 	"time"
+
+	"tinygo.org/x/drivers"
 )
 
 // Device wraps an SPI connection.
@@ -30,7 +32,7 @@ type Config struct {
 }
 
 type I2CBus struct {
-	wire    machine.I2C
+	wire    drivers.I2C
 	Address uint16
 }
 
@@ -50,7 +52,7 @@ type Buser interface {
 type VccMode uint8
 
 // NewI2C creates a new SSD1306 connection. The I2C wire must already be configured.
-func NewI2C(bus machine.I2C) Device {
+func NewI2C(bus drivers.I2C) Device {
 	return Device{
 		bus: &I2CBus{
 			wire:    bus,

--- a/tmp102/tmp102.go
+++ b/tmp102/tmp102.go
@@ -4,13 +4,11 @@
 
 package tmp102 // import "tinygo.org/x/drivers/tmp102"
 
-import (
-	"machine"
-)
+import "tinygo.org/x/drivers"
 
 // Device holds the already configured I2C bus and the address of the sensor.
 type Device struct {
-	bus     machine.I2C
+	bus     drivers.I2C
 	address uint8
 }
 
@@ -20,7 +18,7 @@ type Config struct {
 }
 
 // New creates a new TMP102 connection. The I2C bus must already be configured.
-func New(bus machine.I2C) Device {
+func New(bus drivers.I2C) Device {
 	return Device{
 		bus: bus,
 	}

--- a/veml6070/veml6070.go
+++ b/veml6070/veml6070.go
@@ -11,12 +11,12 @@ package veml6070 // import "tinygo.org/x/drivers/veml6070"
 import (
 	"time"
 
-	"machine"
+	"tinygo.org/x/drivers"
 )
 
 // Device wraps an I2C connection to a VEML6070 device.
 type Device struct {
-	bus         machine.I2C
+	bus         drivers.I2C
 	AddressLow  uint16
 	AddressHigh uint16
 	RSET        uint32
@@ -28,7 +28,7 @@ type Device struct {
 //
 // This function only creates the Device object, it does not initialize the device.
 // You must call Configure() first in order to use the device itself.
-func New(bus machine.I2C) Device {
+func New(bus drivers.I2C) Device {
 	return Device{
 		bus:         bus,
 		AddressLow:  ADDR_L,
@@ -119,7 +119,7 @@ func (d *Device) enable() error {
 
 func (d *Device) readData(address uint16) (byte, error) {
 	data := []byte{0}
-	err := machine.I2C0.Tx(address, []byte{}, data)
+	err := d.bus.Tx(address, []byte{}, data)
 	return data[0], err
 }
 

--- a/vl53l1x/vl53l1x.go
+++ b/vl53l1x/vl53l1x.go
@@ -10,8 +10,9 @@
 package vl53l1x // import "tinygo.org/x/drivers/vl53l1x"
 
 import (
-	"machine"
 	"time"
+
+	"tinygo.org/x/drivers"
 )
 
 type DistanceMode uint8
@@ -35,7 +36,7 @@ type resultBuffer struct {
 
 // Device wraps an I2C connection to a VL53L1X device.
 type Device struct {
-	bus                machine.I2C
+	bus                drivers.I2C
 	Address            uint16
 	mode               DistanceMode
 	timeout            uint32
@@ -52,7 +53,7 @@ type Device struct {
 // configured.
 //
 // This function only creates the Device object, it does not touch the device.
-func New(bus machine.I2C) Device {
+func New(bus drivers.I2C) Device {
 	return Device{
 		bus:     bus,
 		Address: Address,


### PR DESCRIPTION
This PR switches all i2c drivers definitions to use i2c bus interface type instead of machine package concrete type.

Once it is merged into `dev`, then individual drivers can have tests added as time permits.