### PR TITLE
adt7410: add connection test + connection method

### DIFF
--- a/adt7410/adt7410.go
+++ b/adt7410/adt7410.go
@@ -1,3 +1,7 @@
+// Package adt7410 provides a driver for the adt7410 I2C Temperature Sensor.
+//
+// Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/ADT7410.pdf
+//
 package adt7410 // import "tinygo.org/x/drivers/adt7410"
 
 import (
@@ -22,40 +26,37 @@ func (e Error) Error() string {
 }
 
 type Device struct {
-	bus  drivers.I2C
-	buf  []byte
-	addr uint8
+	bus     drivers.I2C
+	buf     []byte
+	Address uint8
 }
 
-// New returns ADT7410 device for the provided I2C bus and address. The ADT7410
-// has a default address of 0x48 (1001000).  The last 2 bits of the address
+// New returns ADT7410 device for the provided I2C bus using default address.
+// of 0x48 (1001000).  To use multiple ADT7410 devices, the last 2 bits of the address
 // can be set using by connecting to the A1 and A0 pins to VDD or GND (for a
 // total of up to 4 devices on a I2C bus).  Also note that 10k pullups are
 // recommended for the SDA and SCL lines.
-func New(i2c drivers.I2C, addressBits uint8) *Device {
+func New(i2c drivers.I2C) *Device {
 	return &Device{
-		bus:  i2c,
-		buf:  make([]byte, 2),
-		addr: Address | (addressBits & 0x3),
+		bus:     i2c,
+		buf:     make([]byte, 2),
+		Address: Address,
 	}
 }
 
-func (dev *Device) Configure() (err error) {
-
-	// verify the chip ID
-	// TODO: According to datasheet, the check below should work; however
-	//       this does not seem to be working right, but is not exactly
-	//       necessary, so can revisit later to see if there is a bug
-	//id := dev.ReadByte(RegID) & 0xF8
-	//if id != 0xC8 {
-	//	err = ErrInvalidID
-	//}
-
+// Configure the ADT7410 device.
+func (d *Device) Configure() (err error) {
 	// reset the chip
-	dev.writeByte(RegReset, 0xFF)
+	d.writeByte(RegReset, 0xFF)
 	time.Sleep(10 * time.Millisecond)
 	return
+}
 
+// Connected returns whether sensor has been found.
+func (d *Device) Connected() bool {
+	data := []byte{0}
+	d.bus.ReadRegister(uint8(d.Address), RegID, data)
+	return data[0]&0xF8 == 0xC8
 }
 
 // ReadTemperature returns the temperature in celsius milli degrees (°C/1000)
@@ -63,13 +64,13 @@ func (d *Device) ReadTemperature() (temperature int32, err error) {
 	return (int32(d.readUint16(RegTempValueMSB)) * 1000) / 128, nil
 }
 
-// ReadTempC returns the value in the temperature value register, in Celcius
+// ReadTempC returns the value in the temperature value register, in Celsius.
 func (d *Device) ReadTempC() float32 {
 	t := d.readUint16(RegTempValueMSB)
 	return float32(int(t)) / 128.0
 }
 
-// ReadTempF returns the value in the temperature value register, in Fahrenheit
+// ReadTempF returns the value in the temperature value register, in Fahrenheit.
 func (d *Device) ReadTempF() float32 {
 	return d.ReadTempC()*1.8 + 32.0
 }
@@ -77,15 +78,15 @@ func (d *Device) ReadTempF() float32 {
 func (d *Device) writeByte(reg uint8, data byte) {
 	d.buf[0] = reg
 	d.buf[1] = data
-	d.bus.Tx(uint16(d.addr), d.buf, nil)
+	d.bus.Tx(uint16(d.Address), d.buf, nil)
 }
 
 func (d *Device) readByte(reg uint8) byte {
-	d.bus.ReadRegister(d.addr, reg, d.buf)
+	d.bus.ReadRegister(d.Address, reg, d.buf)
 	return d.buf[0]
 }
 
 func (d *Device) readUint16(reg uint8) uint16 {
-	d.bus.ReadRegister(d.addr, reg, d.buf)
+	d.bus.ReadRegister(d.Address, reg, d.buf)
 	return uint16(d.buf[0])<<8 | uint16(d.buf[1])
 }

--- a/adt7410/adt7410_test.go
+++ b/adt7410/adt7410_test.go
@@ -1,0 +1,49 @@
+package adt7410
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"tinygo.org/x/drivers/tester"
+)
+
+func TestDefaultI2CAddress(t *testing.T) {
+	c := qt.New(t)
+	bus := tester.NewI2CBus(c)
+	dev := New(bus)
+	c.Assert(dev.Address, qt.Equals, uint8(Address))
+}
+
+func TestWhoAmI(t *testing.T) {
+	c := qt.New(t)
+	bus := tester.NewI2CBus(c)
+	fake := tester.NewI2CDevice(c, Address)
+	fake.SetupRegisters(defaultRegisters())
+	bus.AddDevice(fake)
+
+	dev := New(bus)
+	c.Assert(dev.Connected(), qt.Equals, true)
+
+	fake.SetupRegister(RegID, 0x99)
+	c.Assert(dev.Connected(), qt.Equals, false)
+}
+
+// defaultRegisters returns the default values for all of the device's registers.
+// see table 22 on page 27 of the datasheet.
+func defaultRegisters() []uint8 {
+	return []uint8{
+		RegTempValueMSB: 0,
+		RegTempValueLSB: 0,
+		RegStatus:       0,
+		RegConfig:       0,
+		RegTHIGHMsbReg:  0x20,
+		RegTHIGHLsbReg:  0,
+		RegTLOWMsbReg:   0x05,
+		RegTLOWLsbReg:   0,
+		RegTCRITMsbReg:  0x49,
+		RegTCRITLsbReg:  0x80,
+		RegTHYSTReg:     0x05,
+		RegID:           0xC8,
+		RegReset:        0,
+	}
+}

--- a/adt7410/registers.go
+++ b/adt7410/registers.go
@@ -1,8 +1,33 @@
 package adt7410
 
+// 0x00 Temperature value most significant byte 0x00
+// 0x01 Temperature value least significant byte 0x00
+// 0x02 Status 0x00
+// 0x03 Configuration 0x00
+// 0x04 THIGH setpoint most significant byte 0x20 (64°C)
+// 0x05 THIGH setpoint least significant byte 0x00 (64°C)
+// 0x06 TLOW setpoint most significant byte 0x05 (10°C)
+// 0x07 TLOW setpoint least significant byte 0x00 (10°C)
+// 0x08 TCRIT setpoint most significant byte 0x49 (147°C)
+// 0x09 TCRIT setpoint least significant byte 0x80 (147°C)
+// 0x0A THYST setpoint 0x05 (5°C)
+// 0x0B ID 0xCX
+// 0x0C Reserved 0xXX
+// 0x0D Reserved 0xXX
+// 0x2E Reserved 0xXX
+// 0x2F Software reset 0xXX
+
 const (
-	// Default I2C address
+	// Address is default I2C address.
 	Address = 0x48
+	// Address1 is for first device, aka the default.
+	Address1 = Address
+	// Address2 is for second device.
+	Address2 = 0x49
+	// Address3 is for third device.
+	Address3 = 0x4A
+	// Address4 is for fourth device.
+	Address4 = 0x4B
 
 	// Temperature Value MSB Register
 	RegTempValueMSB = 0x0
@@ -16,7 +41,28 @@ const (
 	// Config Register
 	RegConfig = 0x3
 
-	// ID Register
+	// THIGH setpoint most significant byte 0x20 (64°C)
+	RegTHIGHMsbReg = 0x4
+
+	// THIGH setpoint least significant byte 0x00 (64°C)
+	RegTHIGHLsbReg = 0x5
+
+	// TLOW setpoint most significant byte 0x05 (10°C)
+	RegTLOWMsbReg = 0x6
+
+	// TLOW setpoint least significant byte 0x00 (10°C)
+	RegTLOWLsbReg = 0x7
+
+	// TCRIT setpoint most significant byte 0x49 (147°C)
+	RegTCRITMsbReg = 0x8
+
+	// TCRIT setpoint least significant byte 0x80 (147°C)
+	RegTCRITLsbReg = 0x9
+
+	// THYST setpoint 0x05 (5°C)
+	RegTHYSTReg = 0xA
+
+	// ID Register (0xCx)
 	RegID = 0x0B
 
 	// Software Reset Register

--- a/examples/adt7410/main.go
+++ b/examples/adt7410/main.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	i2c    = &machine.I2C0
-	sensor = adt7410.New(i2c, 0)
+	sensor = adt7410.New(i2c)
 )
 
 func main() {


### PR DESCRIPTION
This PR improves the ADT7410 driver by adding `Connected()`, adding tests, and improving the docs.