### PR TITLE
ILI9341: Fix for RAMWR bug + cosmetic changes to comments

### DIFF
--- a/ili9341/ili9341.go
+++ b/ili9341/ili9341.go
@@ -20,7 +20,7 @@ type Device struct {
 	driver   driver
 
 	x0, x1 int16 // cached address window; prevents useless/expensive
-	y0, y1 int16 // syscalls to PASET, CASET, and RAMWR
+	y0, y1 int16 // syscalls to PASET and CASET
 
 	dc  machine.Pin
 	cs  machine.Pin
@@ -28,6 +28,7 @@ type Device struct {
 	rd  machine.Pin
 }
 
+// Configure prepares display for use
 func (d *Device) Configure(config Config) {
 
 	if config.Width == 0 {
@@ -145,6 +146,7 @@ func (d *Device) Display() error {
 	return nil
 }
 
+// DrawRGBBitmap copies an RGB bitmap to the internal buffer at given coordinates
 func (d *Device) DrawRGBBitmap(x, y int16, data []uint16, w, h int16) error {
 	k, i := d.Size()
 	if x < 0 || y < 0 || w <= 0 || h <= 0 ||
@@ -158,7 +160,7 @@ func (d *Device) DrawRGBBitmap(x, y int16, data []uint16, w, h int16) error {
 	return nil
 }
 
-// FillRectangle fills a rectangle at a given coordinates with a color
+// FillRectangle fills a rectangle at given coordinates with a color
 func (d *Device) FillRectangle(x, y, width, height int16, c color.RGBA) error {
 	k, i := d.Size()
 	if x < 0 || y < 0 || width <= 0 || height <= 0 ||
@@ -173,7 +175,7 @@ func (d *Device) FillRectangle(x, y, width, height int16, c color.RGBA) error {
 	return nil
 }
 
-// DrawRectangle fills a rectangle at a given coordinates with a color
+// DrawRectangle draws a rectangle at given coordinates with a color
 func (d *Device) DrawRectangle(x, y, w, h int16, c color.RGBA) error {
 	if err := d.DrawFastHLine(x, x+w-1, y, c); err != nil {
 		return err
@@ -215,6 +217,7 @@ func (d *Device) FillScreen(c color.RGBA) {
 	}
 }
 
+// GetRotation returns the current rotation of the device
 func (d *Device) GetRotation() Rotation {
 	return d.rotation
 }
@@ -236,7 +239,8 @@ func (d *Device) SetRotation(rotation Rotation) {
 	d.rotation = rotation
 }
 
-// SetScrollWindow sets an area to scroll with fixed top and bottom parts of the display
+// SetScrollArea sets an area to scroll with fixed top/bottom or left/right parts of the display
+// Rotation affects scroll direction
 func (d *Device) SetScrollArea(topFixedArea, bottomFixedArea int16) {
 	d.sendCommand(VSCRDEF, []uint8{
 		uint8(topFixedArea >> 8), uint8(topFixedArea),
@@ -251,7 +255,7 @@ func (d *Device) SetScroll(line int16) {
 	d.sendCommand(VSCRSADD, []uint8{uint8(line >> 8), uint8(line)})
 }
 
-// SpotScroll returns the display to its normal state
+// StopScroll returns the display to its normal state
 func (d *Device) StopScroll() {
 	d.sendCommand(NORON, nil)
 }
@@ -260,10 +264,8 @@ func (d *Device) StopScroll() {
 func (d *Device) setWindow(x, y, w, h int16) {
 	//x += d.columnOffset
 	//y += d.rowOffset
-	wr := false
 	x1 := x + w - 1
 	if x != d.x0 || x1 != d.x1 {
-		wr = true
 		d.sendCommand(CASET, []uint8{
 			uint8(x >> 8), uint8(x), uint8(x1 >> 8), uint8(x1),
 		})
@@ -271,15 +273,12 @@ func (d *Device) setWindow(x, y, w, h int16) {
 	}
 	y1 := y + h - 1
 	if y != d.y0 || y1 != d.y1 {
-		wr = true
 		d.sendCommand(PASET, []uint8{
 			uint8(y >> 8), uint8(y), uint8(y1 >> 8), uint8(y1),
 		})
 		d.y0, d.y1 = y, y1
 	}
-	if wr {
-		d.sendCommand(RAMWR, nil)
-	}
+	d.sendCommand(RAMWR, nil)
 }
 
 //go:inline


### PR DESCRIPTION
RAMWR can not be skipped as you may call setwindow even if device is not ready for data write to buffer.
Data can only be written if last command was Memory Write or Write Memory Continue which was not guaranteed
There's no performance loss as having the exact same window on a consecutive call is extremely unlikely

Also fixed some typos and added a few missing comments to please go-lint