### PR TITLE
Renamed NewSpi() to NewSPI() in accordance with Go naming conventions

### DIFF
--- a/examples/ili9341/basic/atsamd21.go
+++ b/examples/ili9341/basic/atsamd21.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	display = ili9341.NewSpi(
+	display = ili9341.NewSPI(
 		machine.SPI0,
 		machine.D0,
 		machine.D1,

--- a/examples/ili9341/basic/wioterminal.go
+++ b/examples/ili9341/basic/wioterminal.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	display = ili9341.NewSpi(
+	display = ili9341.NewSPI(
 		machine.SPI3,
 		machine.LCD_DC,
 		machine.LCD_SS_PIN,

--- a/examples/ili9341/pyportal_boing/wioterminal.go
+++ b/examples/ili9341/pyportal_boing/wioterminal.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	display = ili9341.NewSpi(
+	display = ili9341.NewSPI(
 		machine.SPI3,
 		machine.LCD_DC,
 		machine.LCD_SS_PIN,

--- a/examples/ili9341/scroll/atsamd21.go
+++ b/examples/ili9341/scroll/atsamd21.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	display = ili9341.NewSpi(
+	display = ili9341.NewSPI(
 		machine.SPI0,
 		machine.D0,
 		machine.D1,

--- a/examples/ili9341/scroll/wioterminal.go
+++ b/examples/ili9341/scroll/wioterminal.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	display = ili9341.NewSpi(
+	display = ili9341.NewSPI(
 		machine.SPI3,
 		machine.LCD_DC,
 		machine.LCD_SS_PIN,

--- a/ili9341/spi_atsamd21.go
+++ b/ili9341/spi_atsamd21.go
@@ -11,7 +11,7 @@ type spiDriver struct {
 	bus machine.SPI
 }
 
-func NewSpi(bus machine.SPI, dc, cs, rst machine.Pin) *Device {
+func NewSPI(bus machine.SPI, dc, cs, rst machine.Pin) *Device {
 	return &Device{
 		dc:  dc,
 		cs:  cs,

--- a/ili9341/spi_atsamd51.go
+++ b/ili9341/spi_atsamd51.go
@@ -11,7 +11,7 @@ type spiDriver struct {
 	bus machine.SPI
 }
 
-func NewSpi(bus machine.SPI, dc, cs, rst machine.Pin) *Device {
+func NewSPI(bus machine.SPI, dc, cs, rst machine.Pin) *Device {
 	return &Device{
 		dc:  dc,
 		cs:  cs,


### PR DESCRIPTION
This change renames the NewSpi() constructors for the ILI9341 driver to better follow Go naming conventions, as pointed out in https://github.com/tinygo-org/drivers/pull/196#discussion_r483991299

This is technically a breaking change but I think the disruption should be minimal as the current names have only been a released version of the drivers for about a month.  @sago35 what do you think?