### PR TITLE
drv883x: add drv8838 device

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The following 53 devices are supported.
 | [BMP180 barometer](https://cdn-shop.adafruit.com/datasheets/BST-BMP180-DS000-09.pdf) | I2C |
 | [BMP280 temperature/barometer](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmp280-ds001.pdf) | I2C |
 | [Buzzer](https://en.wikipedia.org/wiki/Buzzer#Piezoelectric) | GPIO |
+| [DRV8838 motor driver](https://www.ti.com/lit/ds/symlink/drv8838.pdf) | GPIO |
 | [DS1307 real time clock](https://datasheets.maximintegrated.com/en/ds/DS1307.pdf) | I2C |
 | [DS3231 real time clock](https://datasheets.maximintegrated.com/en/ds/DS3231.pdf) | I2C |
 | [ESP32 as WiFi Coprocessor with Arduino nina-fw](https://github.com/arduino/nina-fw) | SPI |

--- a/drv8838/drv8838.go
+++ b/drv8838/drv8838.go
@@ -1,0 +1,74 @@
+// Package drv8838 provides a driver to the DRV8838 Low-Voltage H-Bridge Driver
+// typically used to control DC motors.
+//
+// Datasheet: https://www.ti.com/lit/ds/symlink/drv8838.pdf
+//
+package drv8838 // import "tinygo.org/x/drivers/drv8838"
+
+import (
+	"machine"
+)
+
+const (
+	DIRECTION_FORWARD  = false
+	DIRECTION_BACKWARD = true
+)
+
+// Device is a motor with direction (phase), speed (enable) and sleep controlled by a DRV8838
+type Device struct {
+	enable machine.PWM
+	phase  machine.Pin
+	sleep  machine.Pin // Optional
+}
+
+// Device returns a new motor device
+func NewDevice(enable machine.PWM, phase machine.Pin, sleep machine.Pin) Device {
+	return Device{
+		enable: enable,
+		phase:  phase,
+		sleep:  sleep,
+	}
+}
+
+// Configure configures the Device.
+func (d *Device) Configure() {
+	d.enable.Configure()
+	d.phase.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	if d.sleep != machine.NoPin {
+		d.sleep.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	}
+}
+
+// Forward turns motor on in forward direction at specific speed.
+func (d *Device) Forward(speed uint16) {
+	d.phase.Set(DIRECTION_FORWARD)
+	d.enable.Set(speed)
+}
+
+// Backward turns motor on in forward direction at specific speed.
+func (d *Device) Backward(speed uint16) {
+	d.phase.Set(DIRECTION_BACKWARD)
+	d.enable.Set(speed)
+}
+
+// Enable sets the speed of the motor
+func (d *Device) Enable(speed uint16) {
+	d.enable.Set(speed)
+}
+
+// Phase sets the direction of the motor
+func (d *Device) Phase(direction bool) {
+	d.phase.Set(direction)
+}
+
+// Sleep sets sleep mode, which allows the motor to coast.
+func (d *Device) Sleep(sleep bool) {
+	if d.sleep != machine.NoPin {
+		d.sleep.Set(sleep)
+	}
+}
+
+// Stop turns motor off.
+func (d *Device) Stop() {
+	d.enable.Set(0)
+}


### PR DESCRIPTION
Some questions:

- I called it PhaseEnableDevice as that's what's in the pdf, is there a better name?

- I have only added the 8838 and not the 8837 as I don't have one of those. But it seems simple enough, is it ok to add without actually testing it?

<img width="871" alt="image" src="https://user-images.githubusercontent.com/622455/97793020-1e7b2580-1c3a-11eb-9159-b6850a65ed2c.png">

https://www.ti.com/lit/ds/symlink/drv8838.pdf