### PR TITLE
Add I2C driver for STUSB4500 (USB Type-C Power Delivery Sink Controller)

### DIFF
--- a/examples/stusb4500/main.go
+++ b/examples/stusb4500/main.go
@@ -1,0 +1,163 @@
+// This example demonstrates how to use the STUSB4500 driver to monitor cable
+// attach/detach, read the USB PD source capabilities, and negotiate different
+// power profiles.
+//
+// An external button is used to cycle through each of the power profiles
+// discovered.
+//
+// An LED is used to indicate USB PD negotiation activity.
+//
+// Note that your STUSB4500 should be powered via VBUS, which is connected to
+// the USB Type-C cable itself, and NOT via VSYS/VCC (which should be connected
+// to ground).
+package main
+
+import (
+	"machine"
+	"runtime"
+	"time"
+
+	"tinygo.org/x/drivers/stusb4500"
+	"tinygo.org/x/drivers/stusb4500/conf"
+)
+
+// STUSB4500 auxiliary pins
+const (
+	// not connecting these pins is possible (with reduced functionality) if the
+	// connection is managed manually, but the Monitor function will be disabled.
+	resetPin  = machine.D6 // GPIO output
+	alertPin  = machine.D5 // GPIO input pullup (with external interrupt)
+	attachPin = machine.D4 // GPIO input pullup (with external interrupt)
+)
+
+// Other pins for demo program functionality
+const (
+	// the LED will turn on the instant a new power profile is requested and will
+	// turn off once the new power contract is negotiated (successfully or not).
+	//
+	// there is no way to verify the PD source is actually providing the requested
+	// power; we can only verify it was accepted. you must use a voltage meter of
+	// some sort (e.g. handheld digital multimeter, voltage/current sensor IC, or
+	// something else...? just don't try using an ADC on your MCU for this, unless
+	// you're absolutely 100% positive it is +20V tolerant (it isn't)).
+	ledPin    = machine.LED // GPIO output
+	buttonPin = machine.D10 // GPIO input pullup (with external interrupt)
+)
+
+// declare our device globally for easy reference from the callback routines
+var usbpd *stusb4500.Device
+
+func main() {
+
+	// register at most 1 button press per second
+	const buttonBounceDuration = time.Second
+
+	// state variables associated with button debounce logic
+	var (
+		isButtonPressed  bool
+		wasButtonPressed bool
+		whenButtonReady  time.Time
+	)
+
+	// configure the GPIO pins connected to the LED and external button
+	ledPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	buttonPin.Configure(machine.PinConfig{Mode: machine.PinInputPullUp})
+	buttonPin.SetInterrupt(machine.PinFalling,
+		func(machine.Pin) { isButtonPressed = true })
+
+	println("-- initializing STUSB4500 on I2C1")
+
+	// configure the I2C interface
+	machine.I2C1.Configure(machine.I2CConfig{
+		Frequency: machine.TWI_FREQ_400KHZ,
+		SDA:       machine.I2C1_SDA_PIN,
+		SCL:       machine.I2C1_SCL_PIN,
+	})
+
+	// configure the auxiliary STUSB4500 pins
+	resetPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	alertPin.Configure(machine.PinConfig{Mode: machine.PinInputPullUp})
+	attachPin.Configure(machine.PinConfig{Mode: machine.PinInputPullUp})
+
+	// create and initialize the STUSB4500 device connection
+	usbpd = stusb4500.New(machine.I2C1).Configure(conf.Configuration{
+		// register the GPIO pins for auxiliary connections
+		ResetPin:  resetPin,
+		AlertPin:  alertPin,
+		AttachPin: attachPin,
+		// install callback functions
+		OnInitFail:     deviceError,
+		OnResetFail:    deviceError,
+		OnConnect:      deviceConnected,
+		OnConnectFail:  deviceError,
+		OnError:        deviceError,
+		OnCableAttach:  cableAttached,
+		OnCableDetach:  cableDetached,
+		OnCapabilities: capabilitiesReceived,
+	})
+
+	// watch indefinitely for button presses
+	go func(dev *stusb4500.Device) {
+		// index of the currently selected power profile
+		pdoIndex := 0
+		for {
+			if !wasButtonPressed && isButtonPressed {
+				wasButtonPressed = true
+				whenButtonReady = time.Now().Add(buttonBounceDuration)
+
+				// turn on the LED to indicate a new power profile is being requested
+				ledPin.High()
+
+				// select the next power profile
+				if pdoCount := len(dev.SrcPDO); pdoCount > 0 {
+					pdoIndex = (pdoIndex + 1) % pdoCount
+					println("-- requesting new power profile")
+					println("      " + dev.SrcPDO[pdoIndex].String())
+					dev.SetPower(dev.SrcPDO[pdoIndex].Voltage, dev.SrcPDO[pdoIndex].Current)
+				} else {
+					println("!! no USB PD source capabilities received")
+				}
+
+			} else if wasButtonPressed && time.Now().After(whenButtonReady) {
+				wasButtonPressed = false
+				isButtonPressed = false
+			}
+			// yield to the monitor goroutine
+			runtime.Gosched()
+		}
+	}(usbpd)
+
+	println("-- starting USB PD monitor")
+
+	// `Monitor` does not return until `StopMonitor` is called from another
+	// goroutine. See its godoc comments for usage details.
+	usbpd.Monitor()
+}
+
+func deviceError(err error) {
+	if nil != err {
+		println("!! " + err.Error())
+	}
+}
+
+func deviceConnected() { println("-- connected!") }
+func cableAttached()   { println("-- cable attached") }
+func cableDetached()   { println("-- cable detached") }
+
+func capabilitiesReceived() {
+	println("-- source capabilities received")
+
+	// turn off the LED once we've received source capabilities again, which will
+	// occur after we have set a new power profile.
+	ledPin.Low()
+
+	println("   source PDOs:")
+	for _, pdo := range usbpd.SrcPDO {
+		println("      " + pdo.String())
+	}
+
+	println("   sink PDOs:")
+	for _, pdo := range usbpd.SnkPDO {
+		println("      " + pdo.String())
+	}
+}

--- a/examples/stusb4500/main.go
+++ b/examples/stusb4500/main.go
@@ -61,26 +61,26 @@ func main() {
 
 	// configure the GPIO pins connected to the LED and external button
 	ledPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	buttonPin.Configure(machine.PinConfig{Mode: machine.PinInputPullUp})
+	buttonPin.Configure(machine.PinConfig{Mode: machine.PinInputPullup})
 	buttonPin.SetInterrupt(machine.PinFalling,
 		func(machine.Pin) { isButtonPressed = true })
 
-	println("-- initializing STUSB4500 on I2C1")
+	println("-- initializing STUSB4500 on I2C0")
 
 	// configure the I2C interface
-	machine.I2C1.Configure(machine.I2CConfig{
+	machine.I2C0.Configure(machine.I2CConfig{
 		Frequency: machine.TWI_FREQ_400KHZ,
-		SDA:       machine.I2C1_SDA_PIN,
-		SCL:       machine.I2C1_SCL_PIN,
+		SDA:       machine.SDA_PIN,
+		SCL:       machine.SCL_PIN,
 	})
 
 	// configure the auxiliary STUSB4500 pins
 	resetPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	alertPin.Configure(machine.PinConfig{Mode: machine.PinInputPullUp})
-	attachPin.Configure(machine.PinConfig{Mode: machine.PinInputPullUp})
+	alertPin.Configure(machine.PinConfig{Mode: machine.PinInputPullup})
+	attachPin.Configure(machine.PinConfig{Mode: machine.PinInputPullup})
 
 	// create and initialize the STUSB4500 device connection
-	usbpd = stusb4500.New(machine.I2C1).Configure(conf.Configuration{
+	usbpd = stusb4500.New(machine.I2C0).Configure(conf.Configuration{
 		// register the GPIO pins for auxiliary connections
 		ResetPin:  resetPin,
 		AlertPin:  alertPin,

--- a/stusb4500/conf/conf.go
+++ b/stusb4500/conf/conf.go
@@ -1,0 +1,30 @@
+// Package conf provides the interface used to modify STUSB4500 configuration.
+package conf // import "tinygo.org/x/drivers/stusb4500/conf"
+
+import (
+	"machine"
+)
+
+type EventCallback func()
+type ErrorCallback func(error)
+
+type Configuration struct {
+	ResetPin  machine.Pin
+	AlertPin  machine.Pin
+	AttachPin machine.Pin
+
+	OnInitFail     ErrorCallback // I2C initialization failure
+	OnResetFail    ErrorCallback // I2C reconnection to STUSB4500 failed
+	OnConnect      EventCallback // I2C connection to STUSB4500 succeeded
+	OnConnectFail  ErrorCallback // I2C connection to STUSB4500 failed
+	OnError        ErrorCallback // I2C or STUSB4500 runtime error
+	OnCableAttach  EventCallback // USB Type-C cable connected
+	OnCableDetach  EventCallback // USB Type-C cable disconnected
+	OnCapabilities EventCallback // USB PD capabilities received from source
+
+	USBPDTimeout int // -1 = unlimited (never timeout)
+}
+
+const (
+	DefaultUSBPDTimeout = 200 // messages sent
+)

--- a/stusb4500/device.go
+++ b/stusb4500/device.go
@@ -1,0 +1,807 @@
+// Package stusb4500 provides a driver for the STUSB4500 USB PD sink controller
+// by STMicroelectronics.
+//
+// Datasheet: https://www.st.com/resource/en/datasheet/stusb4500.pdf
+package stusb4500 // import "tinygo.org/x/drivers/stusb4500"
+
+import (
+	"errors"
+	"machine"
+	"runtime/volatile"
+	"time"
+
+	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/stusb4500/conf"
+)
+
+var (
+	ErrDeviceNotConfigured = errors.New("stusb4500: device not configured")
+	ErrDeviceNotFound      = errors.New("stusb4500: device not found")
+	ErrInvalidNumPDO       = errors.New("stusb4500: invalid number of PDO")
+	ErrUndefinedRDO        = errors.New("stusb4500: undefined RDO")
+	ErrCableDisconnected   = errors.New("stusb4500: cable is disconnected")
+	ErrByteCountPDHeader   = errors.New("stusb4500: invalid byte count in USB PD message header")
+	ErrSourcePDOTimeout    = errors.New("stusb4500: timeout requesting source capabilities")
+	ErrMonitorStarted      = errors.New("stusb4500: monitor already started")
+	ErrMonitorNotStarted   = errors.New("stusb4500: monitor not yet started")
+	ErrMonitorResetUndef   = errors.New("stusb4500: reset pin not defined for monitor")
+	ErrMonitorAlertUndef   = errors.New("stusb4500: alert pin not defined for monitor")
+	ErrMonitorAttachUndef  = errors.New("stusb4500: attach pin not defined for monitor")
+)
+
+// Address is the default I2C peripheral address of the STUSB4500 used when
+// creating a new connection. Use the GetAddress method to get the peripheral
+// address of a connected Device.
+var Address uint8 = 0x28
+
+// CableStatus represents the connection status of a USB Type-C cable.
+type CableStatus uint8
+
+const (
+	Disconnected CableStatus = 0 // no cable attached to the USB Type-C port
+	ConnectedCC1 CableStatus = 1 // cable attached (normal/unflipped orientation)
+	ConnectedCC2 CableStatus = 2 // cable attached (twisted/flipped orientation)
+	CableInvalid CableStatus = 0xFF
+)
+
+const (
+	// negotiationDuration defines the maximum time required for the STUSB4500 to
+	// negotiate a USB PD explicit contract after connecting to a source.
+	//
+	// After this amount of time has elapsed, the device will have initialized its
+	// registers, finished loading from NVM, established a power setting with the
+	// source, and is able to respond over the I2C bus.
+	//
+	// However, the negotiated power setting may not yet be stabilized. The most
+	// reliable way to detect this condition is by measuring VBUS externally.
+	//
+	//   | At the connection, the STUSB4500 connects first in USB-C mode before
+	//   | negotiating any USB PD contract. In order to know the final connection
+	//   | status (USB-C or USB PD explicit contract), it is recommended to wait
+	//   | 500 ms after ATTACH event.
+	//   + -- The STUSB4500 software programming guide (UM2650), Ch 1.7, Pg 4
+	negotiationDuration = 500 * time.Millisecond
+
+	hardResetDuration     = 250 * time.Millisecond
+	softResetDuration     = 250 * time.Millisecond
+	attachBounceDuration  = 27 * time.Millisecond
+	reconnectWaitDuration = 5 * time.Millisecond
+)
+
+// maximum number of sink PDOs
+const pdoSnkMax = 3
+
+const (
+	pdoVoltageUnits = 50 // step size of PDO voltage (50 mV)
+	pdoCurrentUnits = 10 // step size of PDO current (10 mA)
+)
+
+// Device wraps the I2C connection to an STUSB4500 device.
+type Device struct {
+	bus     drivers.I2C
+	address uint8
+	config  conf.Configuration
+
+	ready   bool        // whether or not the device has been configured
+	monitor monitorLock // whether or not the monitor is running
+
+	// most recent PDOs advertised from source.
+	SnkRDO PDO
+	SnkPDO []PDO
+	SrcPDO []PDO
+
+	status deviceStatus
+	fsm    deviceState
+}
+
+// device register info kept in application memory
+type deviceStatus struct {
+	reset    bool
+	hwFault  regStatusHWFault  // 0x13
+	typeCMon regStatusTypeCMon // 0x10
+	ccDetect regStatusCCDetect // 0x0E
+	cc       regStatusCC       // 0x11
+	prt      regStatusPRT      // 0x16
+	phy      regStatusPHY      // 0x17
+	rdo      regStatusRDO      // 0x91-0x94
+	snk      []regStatusSnkPDO // 0x85-0x90
+	src      []regStatusSrcPDO
+}
+
+// USB PD state machine
+type deviceState struct {
+	alert     volatile.Register8
+	attach    volatile.Register8
+	request   volatile.Register8
+	receive   volatile.Register8
+	cable     CableStatus
+	irqRecv   uint16
+	irqReset  uint16
+	trans     uint16
+	psrdyRecv uint16
+	msgRecv   uint16
+	msgAccept uint16
+	msgReject uint16
+	msgCRC    uint16
+	peState   uint8
+}
+
+// New creates a new STUSB4500 connection. The given I2C interface must already
+// be configured.
+func New(bus drivers.I2C) *Device {
+	return &Device{
+		bus:     bus,
+		address: Address,
+		fsm: deviceState{
+			cable: CableInvalid,
+		},
+	}
+}
+
+// GetAddress returns the I2C peripheral address of a connected Device.
+func (d *Device) GetAddress() uint8 {
+	return d.address
+}
+
+// Configure modifies the device configuration settings and must be called after
+// a Device is created via New.
+//
+// Note that the given pins must already be configured as follows:
+//   config.ResetPin  - GPIO output
+//   config.AlertPin  - GPIO input pullup (must be external interrupt capable)
+//   config.AttachPin - GPIO input pullup (must be external interrupt capable)
+func (d *Device) Configure(config conf.Configuration) *Device {
+	d.config = config
+	if d.config.ResetPin != machine.NoPin {
+		d.config.ResetPin.Low() // RST is active high, so drive low before init
+	}
+	if d.config.AlertPin != machine.NoPin {
+		d.config.AlertPin.SetInterrupt(machine.PinFalling, d.onAlert)
+	}
+	if d.config.AttachPin != machine.NoPin {
+		d.config.AttachPin.SetInterrupt(machine.PinFalling, d.onAttach)
+	}
+	if 0 == d.config.USBPDTimeout {
+		d.config.USBPDTimeout = conf.DefaultUSBPDTimeout
+	}
+	d.ready = true
+	return d
+}
+
+// Initialize clears and unmasks all needed interrupts, and initializes device
+// registers and USB PD state machine.
+// A non-nil error is returned if communication with device was unsuccessful, or
+// the device was unable to negotiate with a USB PD-capable supply.
+func (d *Device) Initialize() error {
+
+	// clear the lists of PDOs
+	d.status.snk = []regStatusSnkPDO{}
+	d.SnkPDO = []PDO{}
+	d.status.rdo = regStatusRDO{}
+	d.SnkRDO = PDO{}
+	d.status.src = []regStatusSrcPDO{}
+	d.SrcPDO = []PDO{}
+
+	// ensure Configure has been called to register interrupt handlers
+	if !d.ready {
+		return ErrDeviceNotConfigured
+	}
+	// ensure enough time has elapsed for NVM loading and PD negotiation
+	time.Sleep(negotiationDuration)
+
+	// check that we are communicating with the device
+	found := false
+	for i := 0; !found && i < d.config.USBPDTimeout; i++ {
+		if found = d.Connected(); !found {
+			time.Sleep(reconnectWaitDuration)
+		}
+	}
+	if !found {
+		return ErrDeviceNotFound
+	}
+
+	if err := d.enableAlerts(); nil != err {
+		return err
+	}
+	if err := d.updateStatus(); nil != err {
+		return err
+	}
+	if err := d.setNumSnkPDO(1); nil != err {
+		return err
+	}
+	if err := d.updateSnkPDO(); nil != err {
+		return err
+	}
+	if err := d.updateSnkRDO(); nil != err {
+		return err
+	}
+	if connected, _ := d.GetCableStatus(); connected {
+		if err := d.updateSrcPDO(); nil != err {
+			return err
+		}
+	}
+	return nil
+}
+
+// Connected returns true if and only if we are connected to an STUSB4500.
+// A valid connection is determined by reading the device ID register over I2C.
+func (d *Device) Connected() bool {
+	id, err := d.readRegister(REG_DEVICE_ID)
+	if nil != err {
+		return false
+	}
+	return isDeviceIDValid(id)
+}
+
+// GetCableStatus returns whether a USB cable is connected and the orientation
+// of its plug to the STUSB4500 Type-C port.
+func (d *Device) GetCableStatus() (bool, CableStatus) {
+	// first verify a cable is attached
+	cc, err := d.readRegister(REG_PORT_STATUS_1)
+	if nil != err {
+		return false, CableInvalid
+	}
+	var ccDetect regStatusCCDetect
+	ccDetect.parse(cc)
+	if !ccDetect.attached {
+		return false, Disconnected
+	}
+	// next check which CC1/CC2 is connected through to a source
+	tc, err := d.readRegister(REG_TYPEC_STATUS)
+	if nil != err {
+		return false, CableInvalid
+	}
+	var typeC regStatusTypeC
+	typeC.parse(tc)
+	if typeC.reverse {
+		return true, ConnectedCC2
+	}
+	return true, ConnectedCC1
+}
+
+// Update processes interrupts and internal alerts, and progresses the PD state
+// machine by one cycle. The user application must call Update continuously for
+// successful operation of the STUSB4500.
+func (d *Device) Update() error {
+
+	if pe, err := d.readRegister(REG_PE_FSM); nil != err {
+		return err
+	} else {
+		d.fsm.peState = pe
+	}
+
+	// if alert line is low, ensure we run through the ISR at least once
+	if !d.config.AlertPin.Get() {
+		d.fsm.alert.Set(d.fsm.alert.Get() + 1)
+	}
+
+	for {
+		if d.fsm.alert.Get() > 0 {
+			d.fsm.alert.Set(d.fsm.alert.Get() - 1)
+			if err := d.processAlerts(); nil != err {
+				return err
+			}
+		} else {
+			break // no alerts remaining
+		}
+	}
+
+	for {
+		if d.fsm.attach.Get() > 0 {
+			d.fsm.attach.Set(d.fsm.attach.Get() - 1)
+			connected, cable := d.GetCableStatus()
+			// ignore duplicate interrupts, only handle connection state changes
+			if d.fsm.cable != cable {
+				if connected {
+					time.Sleep(attachBounceDuration)
+					if nil != d.config.OnCableAttach {
+						d.config.OnCableAttach()
+					}
+				} else {
+					if Disconnected == cable {
+						if nil != d.config.OnCableDetach {
+							d.config.OnCableDetach()
+						}
+					}
+					// clear source PDO list
+					d.status.src = []regStatusSrcPDO{}
+					d.SrcPDO = []PDO{}
+				}
+				d.fsm.cable = cable
+			}
+		} else {
+			break // no attach events remaining
+		}
+	}
+
+	if d.fsm.receive.Get() > 0 {
+		d.fsm.receive.Set(0) // only accept a single source capabilities event
+		if nil != d.config.OnCapabilities {
+			d.config.OnCapabilities()
+		}
+	}
+
+	return nil
+}
+
+// SoftReset performs a soft reset of the STUSB4500 by setting and then clearing
+// the REG_RESET_CTRL (0x23) register.
+//
+// This resets the internal registers and USB PD state machine, and it causes
+// electrical disconnect on both source and sink sides. While reset, all pending
+// interrupts and internal alerts are cleared.
+//
+// If the given bool argument wait is true, SoftReset will not return until the
+// STUSB4500 is identified and communicating over I2C.
+func (d *Device) SoftReset(wait bool) error {
+	return d.resetUntilReady(
+		func() error {
+			// set reset-enable register field
+			if err := d.writeRegister(REG_RESET_CTRL,
+				(&regControlReset{reset: true}).format()[0]); nil != err {
+				return err
+			}
+			// start measuring time once we initiated reset
+			start := time.Now()
+			// clear alerts, updating port status
+			if err := d.updateStatus(); nil != err {
+				return err
+			}
+			// sleep for the remaining reset duration (if any), after subtracting the
+			// duration it took to clear the alert registers
+			if remaining := softResetDuration - time.Now().Sub(start); remaining > 0 {
+				time.Sleep(remaining)
+			}
+			// clear reset-enable register field
+			if err := d.writeRegister(REG_RESET_CTRL,
+				(&regControlReset{reset: false}).format()[0]); nil != err {
+				return err
+			}
+			return nil
+		},
+		wait)
+}
+
+// Reset performs a hard reset of the STUSB4500 by asserting and de-asserting
+// the active-high RST pin for a short duration.
+//
+// All registers and power contracts are reset to their default power-on state.
+//
+// If the given bool argument wait is true, Reset will not return until the
+// STUSB4500 is identified and communicating over I2C.
+func (d *Device) Reset(wait bool) error {
+	return d.resetUntilReady(
+		func() error {
+			// perform hardware reset using RST pin (active high)
+			d.config.ResetPin.High()
+			time.Sleep(hardResetDuration)
+			d.config.ResetPin.Low()
+			return nil
+		},
+		wait)
+}
+
+// SetPower attempts to negotiate an explicit power contract with given voltage
+// and current from the PD source.
+//
+// The given voltage, in millivolts (mV), must be a multiple of 50 mV.
+// The given current, in milliamps (mA), must be a multiple of 10 mA.
+func (d *Device) SetPower(voltage uint32, current uint32) error {
+	if connected, _ := d.GetCableStatus(); connected {
+		// PDO 1 is fixed (see comments inside SetPowerUSBDefault). So we construct
+		// a custom PDO with given voltage/current and set it as PDO 2. Leave PDO 3
+		// undefined, and send a PD negotiation request with the contents of PDO 2,
+		// falling back to PDO 1 (USB default +5V) if there was a failure.
+		if err := d.setNumSnkPDO(2); nil != err {
+			return err
+		}
+		if err := d.setSnkPDO(
+			PDO{
+				Number:  2,
+				Voltage: (voltage / pdoVoltageUnits) * pdoVoltageUnits,
+				Current: (current / pdoCurrentUnits) * pdoCurrentUnits,
+			}); nil != err {
+			return err
+		}
+		if err := d.updateSnkPDO(); nil != err {
+			return err
+		}
+		if err := d.updateSnkRDO(); nil != err {
+			return err
+		}
+		if err := d.resetCable(); nil != err {
+			return err
+		}
+	}
+	return nil
+}
+
+// SetPowerUSBDefault selects the default +5V (0.5-3.0A) USB power profile. This
+// is the fallback power profile used when USB PD negotiation fails and is the
+// same power profile used by all USB 2.0 devices.
+func (d *Device) SetPowerUSBDefault() error {
+	if connected, _ := d.GetCableStatus(); connected {
+		// PDO 1 is fixed and is always USB default (+5V). So simply remove all
+		// other PDOs, forcing negotiation to always select that profile.
+		if err := d.setNumSnkPDO(1); nil != err {
+			return err
+		}
+		if err := d.resetCable(); nil != err {
+			return err
+		}
+		if err := d.updateSnkPDO(); nil != err {
+			return err
+		}
+		if err := d.updateSnkRDO(); nil != err {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *Device) writeRegister(addr uint8, data uint8) error {
+	return d.bus.WriteRegister(d.address, addr, []uint8{data})
+}
+
+func (d *Device) writeRegisters(addr uint8, data ...uint8) error {
+	return d.bus.WriteRegister(d.address, addr, data)
+}
+
+// readRegister returns the byte in a given register subaddress from the
+// connected peripheral Device.
+func (d *Device) readRegister(addr uint8) (uint8, error) {
+	data := make([]uint8, 1)
+	if err := d.bus.ReadRegister(d.address, addr, data); nil != err {
+		return 0, err
+	}
+	return data[0], nil
+}
+
+// readRegisters returns a slice of count bytes starting at the given register
+// subaddress from the connected peripheral Device.
+func (d *Device) readRegisters(addr uint8, count int) ([]uint8, error) {
+	data := make([]uint8, count)
+	if err := d.bus.ReadRegister(d.address, addr, data); nil != err {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (d *Device) setNumSnkPDO(num uint8) error {
+	if num < 1 || num > pdoSnkMax {
+		return ErrInvalidNumPDO
+	}
+	return d.writeRegister(REG_DPM_PDO_NUMB, num)
+}
+
+func (d *Device) setSnkPDO(pdo PDO) error {
+	const pdoSnkMax = 3
+	if pdo.Number <= 1 || pdo.Number > pdoSnkMax {
+		return ErrInvalidNumPDO
+	}
+
+	// First we need to convert the convenience wrapper type `PDO` to the 32-bit
+	// register (4x 8-bit registers) definition for the STUSB4500. To simplify
+	// this, we simply copy PDO 1 (USB default +5V) 32-bit register definition as
+	// template, replacing its voltage and current from our given PDO. We choose
+	// PDO 1 because it is fixed and must always exist.
+	//
+	// It's assumed we already received the PDO 1 32-bit register definition
+	// during device initialization. If for some reason it does not exist, you
+	// will need to call `updateSnkPDO` to retrieve it.
+	def := d.status.snk[0]
+	addr := uint8(REG_DPM_SNK_PDO1_0 + 4*(pdo.Number-1))
+	def.cons.voltage = pdo.Voltage / pdoVoltageUnits
+	def.cons.operationalCurrent = pdo.Current / pdoCurrentUnits
+
+	return d.writeRegisters(addr, def.format()[0:4]...)
+}
+
+func (d *Device) updateSnkPDO() error {
+	numSnkPDO, err := d.readRegister(REG_DPM_PDO_NUMB)
+	if err != nil {
+		return err
+	}
+	d.status.snk = make([]regStatusSnkPDO, numSnkPDO)
+	d.SnkPDO = []PDO{}
+	// read all of the 32-bit (4 registers each) SNK PDO registers
+	p, err := d.readRegisters(REG_DPM_SNK_PDO1_0, int(numSnkPDO)*4)
+	if nil != err {
+		return err
+	}
+	for i, j := 0, 0; i < int(numSnkPDO); i, j = i+1, j+4 {
+		d.status.snk[i].parse(p[j : j+4]...)
+		d.SnkPDO = append(d.SnkPDO, PDO{
+			Number:  i + 1,
+			Voltage: d.status.snk[i].cons.voltage * 50,
+			Current: d.status.snk[i].cons.operationalCurrent * 10,
+		})
+	}
+	return nil
+}
+
+func (d *Device) updateSnkRDO() error {
+	// read the 32-bit (4 registers) SNK RDO register
+	r, err := d.readRegisters(REG_RDO_REG_STATUS_0, 4)
+	if nil != err {
+		return err
+	}
+	d.status.rdo.parse(r...)
+	if d.status.rdo.objectPos == 0 {
+		d.SnkRDO = invalidPDO
+		return ErrUndefinedRDO
+	}
+	d.SnkRDO = PDO{
+		Number:     int(d.status.rdo.objectPos),
+		Current:    d.status.rdo.operatingCurrent * 10,
+		MaxCurrent: d.status.rdo.maxCurrent * 10,
+	}
+	if d.SnkRDO.Number <= len(d.status.snk) {
+		d.SnkRDO.Voltage = d.status.snk[d.SnkRDO.Number-1].cons.voltage * 50
+	}
+	return nil
+}
+
+func (d *Device) updateSrcPDO() error {
+	d.fsm.request.Set(1)
+	for try := 0; try < d.config.USBPDTimeout; try++ {
+		if !d.fsm.request.HasBits(1) {
+			return nil // source capabilities received
+		}
+		if err := d.resetCable(); nil != err {
+			return err
+		}
+		if err := d.Update(); nil != err {
+			return err
+		}
+	}
+	if d.fsm.request.HasBits(1) {
+		return ErrSourcePDOTimeout
+	}
+	return nil
+}
+
+func (d *Device) enableAlerts() error {
+	// unmask the alert interrupts needed for general operation. any field set to
+	// false below will effectively enable that alert (specifically, it will NOT
+	// be masked off when reading the alert status register).
+	// note that calling `updateStatus` will read all of these status registers
+	// and update the internal status struct of the receiver device regardless of
+	// what is masked here. the masking only affects which status registers are
+	// handled by the alert interrupt service routine `processAlerts`.
+	return d.writeRegister(REG_ALERT_STATUS_1_MASK,
+		(&regControlAlert{
+			phy:       true, // don't care
+			prt:       false,
+			typeC:     false,
+			hwFault:   true, // don't care
+			monitor:   false,
+			ccDetect:  false,
+			hardReset: false,
+		}).format()[0])
+}
+
+func (d *Device) updateStatus() error {
+	// read all of the port-related status registers in a single I2C multi-read
+	// request. many of these are alert registers (R/C) and will be cleared when
+	// read, so we copy their content to local application memory.
+	data, err := d.readRegisters(REG_ALERT_STATUS_1, 13)
+	if nil != err {
+		return err
+	}
+	// I2C read base address = 0x0B (REG_ALERT_STATUS_1)
+	d.status.ccDetect.parse(data[3]) // regStatusCCDetect = 0x0E [0x0B+03]
+	d.status.typeCMon.parse(data[5]) // regStatusTypeCMon = 0x10 [0x0B+05]
+	d.status.cc.parse(data[6])       // regStatusCC       = 0x11 [0x0B+06]
+	d.status.prt.parse(data[11])     // regStatusPRT      = 0x16 [0x0B+11]
+	d.status.phy.parse(data[12])     // regStatusPHY      = 0x17 [0x0B+12]
+	return nil
+}
+
+func (d *Device) resetCable() error {
+	// send PD message "soft reset" to source by setting TX header (0x51) to 0x0D,
+	// and set PD command (0x1A) to 0x26.
+	if err := d.writeRegister(REG_TX_HEADER_LOW, ctrlSoftReset); nil != err {
+		return err
+	}
+	return d.writeRegister(REG_PD_COMMAND_CTRL,
+		(&regControlPDCmd{cmd: ctrlPDCommand}).format()[0])
+}
+
+type resetFunc func() error
+
+func (d *Device) resetUntilReady(reset resetFunc, wait bool) error {
+	// always perform the initial reset
+	if err := reset(); nil != err {
+		return err
+	}
+	// wait for an STUSB4500 to start responding, occassionally repeating the
+	// reset again if a response isn't received after adequate time/attempts.
+	for wait {
+		found := false
+		// ensure enough time has elapsed for NVM loading and PD negotiation
+		time.Sleep(negotiationDuration)
+		// timeout loop: check that we are communicating with the device
+		for i := 0; i < d.config.USBPDTimeout; i++ {
+			// delay before try (NOT after); so if the last try fails, we return ASAP
+			if i > 0 { // also, never delay before the first try
+				time.Sleep(reconnectWaitDuration)
+			}
+			// check if we found connection, breaking out of timeout loop on success
+			if found = d.Connected(); found {
+				break
+			}
+		}
+		// found will be true if and only if we broke timeout loop prematurely, in
+		// which case we do not issue another reset, but instead gracefully exit
+		// outer loop and return to caller (because wait will be false).
+		if wait = !found; wait {
+			// reset device again!
+			if err := reset(); nil != err {
+				return err
+			}
+			// next we will sleep for negotiationDuration and then enter timeout loop.
+		}
+	}
+	return nil
+}
+
+func (d *Device) processAlerts() error {
+
+	al, err := d.readRegisters(REG_ALERT_STATUS_1, 2)
+	if nil != err {
+		return err
+	}
+	stat := al[0] & ^(al[1])
+
+	// parse the interrupt status
+	var alert regStatusAlert
+	alert.parse(stat)
+
+	if 0 != stat {
+
+		if alert.prt { // bit 2
+
+			// parse PRT status
+			prt, err := d.readRegister(REG_PRT_STATUS)
+			if nil != err {
+				return err
+			}
+			d.status.prt.parse(prt)
+
+			// if interrupt status contains a new USB PD message
+			if d.status.prt.msgReceived {
+
+				// parse the PD message header
+				heads, err := d.readRegisters(REG_RX_HEADER_LOW, 2)
+				if nil != err {
+					return err
+				}
+				var header msgUsbpdHeader
+				header.parse(heads...)
+
+				// if header contains PDO definitions
+				if header.dataObjectCount > 0 {
+
+					// verify the received byte count matches expected number of PDOs
+					cnt, err := d.readRegister(REG_RX_BYTE_CNT)
+					if nil != err {
+						return err
+					}
+					if cnt != 4*header.dataObjectCount {
+						return ErrByteCountPDHeader
+					}
+
+					switch header.messageType {
+					case dataMsgSourceCap:
+						// read all SRC PDO registers
+						p, err := d.readRegisters(REG_RX_DATA_OBJ1_0, int(cnt))
+						if nil != err {
+							return err
+						}
+						// clear existing SRC PDO list
+						d.status.src = make([]regStatusSrcPDO, header.dataObjectCount)
+						d.SrcPDO = []PDO{}
+						// parse received source PDO list
+						for i, j := 0, 0; i < int(header.dataObjectCount); i, j = i+1, j+4 {
+							d.status.src[i].parse(p[j : j+4]...)
+							if i == 0 {
+								d.status.src[i].cons.voltage = 100
+							}
+							d.SrcPDO = append(d.SrcPDO, PDO{
+								Number:  i + 1,
+								Voltage: d.status.src[i].cons.voltage * 50,
+								Current: d.status.src[i].cons.maxOperatingCurrent * 10,
+							})
+						}
+						d.fsm.request.Set(0)
+						d.fsm.receive.Set(d.fsm.receive.Get() + 1)
+
+					case dataMsgRequest:
+					case dataMsgSinkCap:
+					case dataMsgVendorDefined:
+					default:
+					}
+
+				} else {
+
+					switch header.messageType {
+					case ctrlMsgGoodCRC:
+						d.fsm.msgCRC++
+
+					case ctrlMsgAccept:
+						d.fsm.msgAccept++
+
+					case ctrlMsgReject:
+						d.fsm.msgReject++
+
+					case ctrlMsgPSRDY:
+						d.fsm.psrdyRecv++
+
+					case ctrlMsgGetSourceCap:
+					case ctrlMsgGetSinkCap:
+					case ctrlMsgWait:
+					case ctrlMsgSoftReset:
+					case ctrlMsgNotSupported:
+					case ctrlMsgGetSourceCapExt:
+					case ctrlMsgGetStatus:
+					case ctrlMsgFRSwap:
+					case ctrlMsgGetPPSStatus:
+					default:
+					}
+
+				}
+			}
+		}
+
+		d.status.reset = alert.hardReset
+		if alert.hardReset { // bit 8
+			d.fsm.irqReset++
+		}
+
+		if alert.ccDetect { // bit 7
+			ccDetect, err := d.readRegisters(REG_PORT_STATUS_0, 2)
+			if nil != err {
+				return err
+			}
+			d.status.ccDetect.parse(ccDetect[1])
+			var trans regStatusCCDetectTrans
+			trans.parse(ccDetect[0])
+			if trans.attached {
+				d.fsm.trans++
+			}
+		}
+
+		if alert.monitor { // bit 6
+			typeCMon, err := d.readRegisters(REG_TYPEC_MONITORING_STATUS_0, 2)
+			if nil != err {
+				return err
+			}
+			d.status.typeCMon.parse(typeCMon[1])
+		}
+
+		// always read and update CC attachment status
+		cc, err := d.readRegister(REG_CC_STATUS)
+		if nil != err {
+			return err
+		}
+		d.status.cc.parse(cc)
+
+		if alert.hwFault { // bit 5
+			hwFault, err := d.readRegisters(REG_CC_HW_FAULT_STATUS_0, 2)
+			if nil != err {
+				return err
+			}
+			d.status.hwFault.parse(hwFault[1])
+		}
+	}
+	return nil
+}
+
+func (d *Device) onAlert(machine.Pin) {
+	d.fsm.alert.Set(d.fsm.alert.Get() + 1)
+}
+
+func (d *Device) onAttach(machine.Pin) {
+	d.fsm.attach.Set(d.fsm.attach.Get() + 1)
+}

--- a/stusb4500/message.go
+++ b/stusb4500/message.go
@@ -1,0 +1,60 @@
+package stusb4500
+
+type pdMsgType uint8
+
+const (
+	pdData pdMsgType = iota
+	pdCtrl
+)
+
+type pdMsg struct {
+	t pdMsgType // message type
+	v uint8     // message value
+}
+
+type pdIrq struct {
+	a regStatusAlert // parsed alert register
+	b uint8          // alert register bits
+}
+
+const (
+	// Control Message Types
+	ctrlMsgReserved1       = 0x00
+	ctrlMsgGoodCRC         = 0x01
+	ctrlMsgGotoMin         = 0x02
+	ctrlMsgAccept          = 0x03
+	ctrlMsgReject          = 0x04
+	ctrlMsgPing            = 0x05
+	ctrlMsgPSRDY           = 0x06
+	ctrlMsgGetSourceCap    = 0x07
+	ctrlMsgGetSinkCap      = 0x08
+	ctrlMsgDRSwap          = 0x09
+	ctrlMsgPRSwap          = 0x0A
+	ctrlMsgVCONNSwap       = 0x0B
+	ctrlMsgWait            = 0x0C
+	ctrlMsgSoftReset       = 0x0D
+	ctrlMsgReserved2       = 0x0E
+	ctrlMsgReserved3       = 0x0F
+	ctrlMsgNotSupported    = 0x10
+	ctrlMsgGetSourceCapExt = 0x11
+	ctrlMsgGetStatus       = 0x12
+	ctrlMsgFRSwap          = 0x13
+	ctrlMsgGetPPSStatus    = 0x14
+	ctrlMsgGetCountryCodes = 0x15
+	ctrlMsgReserved4       = 0x16
+	ctrlMsgReserved5       = 0x1F
+	// Data Message Types
+	dataMsgReserved1      = 0x00
+	dataMsgSourceCap      = 0x01
+	dataMsgRequest        = 0x02
+	dataMsgBIST           = 0x03
+	dataMsgSinkCap        = 0x04
+	dataMsgBatteryStatus  = 0x05
+	dataMsgAlert          = 0x06
+	dataMsgGetCountryInfo = 0x07
+	dataMsgReserved2      = 0x08
+	dataMsgReserved3      = 0x0E
+	dataMsgVendorDefined  = 0x0F
+	dataMsgReserved4      = 0x10
+	dataMsgReserved5      = 0x1F
+)

--- a/stusb4500/message.go
+++ b/stusb4500/message.go
@@ -1,22 +1,5 @@
 package stusb4500
 
-type pdMsgType uint8
-
-const (
-	pdData pdMsgType = iota
-	pdCtrl
-)
-
-type pdMsg struct {
-	t pdMsgType // message type
-	v uint8     // message value
-}
-
-type pdIrq struct {
-	a regStatusAlert // parsed alert register
-	b uint8          // alert register bits
-}
-
 const (
 	// Control Message Types
 	ctrlMsgReserved1       = 0x00

--- a/stusb4500/monitor.go
+++ b/stusb4500/monitor.go
@@ -1,0 +1,121 @@
+package stusb4500
+
+import (
+	"machine"
+	"runtime"
+	"sync"
+)
+
+// monitorLock is a mutex used to synchronize access to the control flags of a
+// Device monitor.
+type monitorLock struct {
+	sync.Mutex
+	active bool
+}
+
+func (mon *monitorLock) isActive() bool {
+	var active bool
+	mon.Lock()
+	active = mon.active
+	mon.Unlock()
+	return active
+}
+
+func (mon *monitorLock) setActive(active bool) {
+	mon.Lock()
+	mon.active = active
+	mon.Unlock()
+}
+
+// Monitor provides an event loop for maintaining connection to the STUSB4500,
+// and calling user callback functions for important state changes.
+//
+// Since the STUSB4500 may occassionally lose power (such as when a USB Type-C
+// cable or PD supply source is disconnected), this will safely re-establish
+// a connection and re-initialize the device on subsequent cable attachments.
+//
+// Note this method will not normally return to the caller. Therefore, this
+// method is designed to be run in a goroutine, and it will periodically yield
+// to any other goroutines needing processor time (via `runtime.Gosched()`).
+//
+// Call this Device receiver's `StopMonitor` method to terminate this monitor
+// and stop processing all USB PD events.
+//
+// This routine is implemented entirely with public exported methods from
+// package `stusb4500`. Meaning, the user may view this method as a convenience
+// function, or as a template for manually managing USB PD connections from
+// their own driver package.
+func (d *Device) Monitor() error {
+	// ensure the monitor has not yet been started
+	if d.monitor.isActive() {
+		return ErrMonitorStarted
+	}
+	// verify the STUSB4500 RST pin is connected to GPIO
+	if d.config.ResetPin == machine.NoPin {
+		return ErrMonitorResetUndef
+	}
+	// verify the STUSB4500 ALRT pin is connected to GPIO
+	if d.config.AlertPin == machine.NoPin {
+		return ErrMonitorAlertUndef
+	}
+	// verify the STUSB4500 ATCH pin is connected to GPIO
+	if d.config.AttachPin == machine.NoPin {
+		return ErrMonitorAttachUndef
+	}
+	d.monitor.setActive(true)
+	for d.monitor.isActive() {
+		// clear alerts, unmask interrupts, initialize registers, reset USB state
+		// machines, and verify we can communicate with the expected device.
+		if err := d.Initialize(); nil != err {
+			if nil != d.config.OnInitFail {
+				d.config.OnInitFail(err)
+			}
+		}
+		// check I2C communication is working
+		if d.Connected() {
+			if nil != d.config.OnConnect {
+				d.config.OnConnect()
+			}
+			// enter the primary state machine run loop
+			for d.monitor.isActive() {
+				if err := d.Update(); nil != err {
+					if nil != d.config.OnError {
+						d.config.OnError(err)
+					}
+					break
+				}
+				// yield to other goroutines after processing each iteration
+				runtime.Gosched()
+			}
+		} else {
+			if nil != d.config.OnConnectFail {
+				d.config.OnConnectFail(nil)
+			}
+		}
+		// shouldn't reach here unless something failed. reset the device.
+		for d.monitor.isActive() {
+			if err := d.Reset(false); nil != err {
+				if nil != d.config.OnResetFail {
+					d.config.OnResetFail(err)
+				}
+			} else {
+				break
+			}
+			// yield to other goroutines after each reset attempt
+			runtime.Gosched()
+		}
+		// yield to other goroutines after each closed connection
+		runtime.Gosched()
+	}
+	return nil
+}
+
+// StopMonitor signals the monitor event loop to terminate and stop all USB PD
+// processing and message handling.
+func (d *Device) StopMonitor() error {
+	if !d.monitor.isActive() {
+		return ErrMonitorNotStarted
+	}
+	d.monitor.setActive(false)
+	return nil
+}

--- a/stusb4500/pdo.go
+++ b/stusb4500/pdo.go
@@ -1,0 +1,39 @@
+package stusb4500
+
+import (
+	"strconv"
+	"strings"
+)
+
+type PDO struct {
+	Number     int
+	Voltage    uint32
+	Current    uint32
+	MaxCurrent uint32
+}
+
+var invalidPDO = PDO{}
+
+func (p PDO) Equals(o PDO) bool {
+	return (p.Voltage == o.Voltage) &&
+		(p.Current == o.Current) &&
+		(p.MaxCurrent == o.MaxCurrent)
+}
+
+func (p PDO) IsValid() bool {
+	return p.Number > 0 && !p.Equals(invalidPDO)
+}
+
+func (p PDO) String() string {
+	var sb strings.Builder
+	sb.WriteString("{ Number: ")
+	sb.WriteString(strconv.FormatInt(int64(p.Number), 10))
+	sb.WriteString(", Voltage: ")
+	sb.WriteString(strconv.FormatUint(uint64(p.Voltage), 10))
+	sb.WriteString(" mV, Current: ")
+	sb.WriteString(strconv.FormatUint(uint64(p.Current), 10))
+	sb.WriteString(" mA, MaxCurrent: ")
+	sb.WriteString(strconv.FormatUint(uint64(p.MaxCurrent), 10))
+	sb.WriteString(" mA }")
+	return sb.String()
+}

--- a/stusb4500/registers.go
+++ b/stusb4500/registers.go
@@ -1,0 +1,733 @@
+package stusb4500
+
+// Constants defining the important register addresses of the STUSB4500
+const (
+	REG_BCD_TYPEC_REV_LOW         = 0x06 // BCD_TYPEC_REV_LOW register
+	REG_BCD_TYPEC_REV_HIGH        = 0x07 // BCD_TYPEC_REV_HIGH register
+	REG_BCD_USBPD_REV_LOW         = 0x08 // BCD_USBPD_REV_LOW register
+	REG_BCD_USBPD_REV_HIGH        = 0x09 // BCD_USBPD_REV_HIGH register
+	REG_DEVICE_CAPAB_HIGH         = 0x0A // DEVICE_CAPAB_HIGH register
+	REG_ALERT_STATUS_1            = 0x0B // ALERT_STATUS_1 register
+	REG_ALERT_STATUS_1_MASK       = 0x0C // ALERT_STATUS_1_MASK register
+	REG_PORT_STATUS_0             = 0x0D // PORT_STATUS_0 register
+	REG_PORT_STATUS_1             = 0x0E // PORT_STATUS_1 register
+	REG_TYPEC_MONITORING_STATUS_0 = 0x0F // TYPEC_MONITORING_STATUS_0 register
+	REG_TYPEC_MONITORING_STATUS_1 = 0x10 // TYPEC_MONITORING_STATUS_1 register
+	REG_CC_STATUS                 = 0x11 // CC_STATUS register
+	REG_CC_HW_FAULT_STATUS_0      = 0x12 // CC_HW_FAULT_STATUS_0 register
+	REG_CC_HW_FAULT_STATUS_1      = 0x13 // CC_HW_FAULT_STATUS_1 register
+	REG_PD_TYPEC_STATUS           = 0x14 // PD_TYPEC_STATUS register
+	REG_TYPEC_STATUS              = 0x15 // TYPEC_STATUS register
+	REG_PRT_STATUS                = 0x16 // PRT_STATUS register
+	REG_PHY_STATUS                = 0x17 // PHY_STATUS register
+	REG_CC_CAPABILITY_CTRL        = 0x18 // CC_CAPABILITY_CTRL register
+	REG_PRT_TX_CTRL               = 0x19 // PRT_TX_CTRL register
+	REG_PD_COMMAND_CTRL           = 0x1A // PD_COMMAND_CTRL register
+	REG_MONITORING_CTRL_0         = 0x20 // MONITORING_CTRL_0 register
+	REG_MONITORING_CTRL_2         = 0x22 // MONITORING_CTRL_2 register
+	REG_RESET_CTRL                = 0x23 // RESET_CTRL register
+	REG_VBUS_DISCHARGE_TIME_CTRL  = 0x25 // VBUS_DISCHARGE_TIME_CTRL register
+	REG_VBUS_DISCHARGE_CTRL       = 0x26 // VBUS_DISCHARGE_CTRL register
+	REG_VBUS_CTRL                 = 0x27 // VBUS_CTRL register
+	REG_PE_FSM                    = 0x29 // PE_FSM register
+	REG_GPIO_SW_GPIO              = 0x2D // GPIO_SW_GPIO register
+	REG_DEVICE_ID                 = 0x2F // DEVICE_ID register
+	REG_RX_BYTE_CNT               = 0x30 // RX_BYTE_CNT register
+	REG_RX_HEADER_LOW             = 0x31 // RX_HEADER_LOW register
+	REG_RX_HEADER_HIGH            = 0x32 // RX_HEADER_HIGH register
+	REG_RX_DATA_OBJ1_0            = 0x33 // RX_DATA_OBJ1_0 register
+	REG_RX_DATA_OBJ1_1            = 0x34 // RX_DATA_OBJ1_1 register
+	REG_RX_DATA_OBJ1_2            = 0x35 // RX_DATA_OBJ1_2 register
+	REG_RX_DATA_OBJ1_3            = 0x36 // RX_DATA_OBJ1_3 register
+	REG_RX_DATA_OBJ2_0            = 0x37 // RX_DATA_OBJ2_0 register
+	REG_RX_DATA_OBJ2_1            = 0x38 // RX_DATA_OBJ2_1 register
+	REG_RX_DATA_OBJ2_2            = 0x39 // RX_DATA_OBJ2_2 register
+	REG_RX_DATA_OBJ2_3            = 0x3A // RX_DATA_OBJ2_3 register
+	REG_RX_DATA_OBJ3_0            = 0x3B // RX_DATA_OBJ3_0 register
+	REG_RX_DATA_OBJ3_1            = 0x3C // RX_DATA_OBJ3_1 register
+	REG_RX_DATA_OBJ3_2            = 0x3D // RX_DATA_OBJ3_2 register
+	REG_RX_DATA_OBJ3_3            = 0x3E // RX_DATA_OBJ3_3 register
+	REG_RX_DATA_OBJ4_0            = 0x3F // RX_DATA_OBJ4_0 register
+	REG_RX_DATA_OBJ4_1            = 0x40 // RX_DATA_OBJ4_1 register
+	REG_RX_DATA_OBJ4_2            = 0x41 // RX_DATA_OBJ4_2 register
+	REG_RX_DATA_OBJ4_3            = 0x42 // RX_DATA_OBJ4_3 register
+	REG_RX_DATA_OBJ5_0            = 0x43 // RX_DATA_OBJ5_0 register
+	REG_RX_DATA_OBJ5_1            = 0x44 // RX_DATA_OBJ5_1 register
+	REG_RX_DATA_OBJ5_2            = 0x45 // RX_DATA_OBJ5_2 register
+	REG_RX_DATA_OBJ5_3            = 0x46 // RX_DATA_OBJ5_3 register
+	REG_RX_DATA_OBJ6_0            = 0x47 // RX_DATA_OBJ6_0 register
+	REG_RX_DATA_OBJ6_1            = 0x48 // RX_DATA_OBJ6_1 register
+	REG_RX_DATA_OBJ6_2            = 0x49 // RX_DATA_OBJ6_2 register
+	REG_RX_DATA_OBJ6_3            = 0x4A // RX_DATA_OBJ6_3 register
+	REG_RX_DATA_OBJ7_0            = 0x4B // RX_DATA_OBJ7_0 register
+	REG_RX_DATA_OBJ7_1            = 0x4C // RX_DATA_OBJ7_1 register
+	REG_RX_DATA_OBJ7_2            = 0x4D // RX_DATA_OBJ7_2 register
+	REG_RX_DATA_OBJ7_3            = 0x4E // RX_DATA_OBJ7_3 register
+	REG_TX_HEADER_LOW             = 0x51 // TX_HEADER_LOW register
+	REG_TX_HEADER_HIGH            = 0x52 // TX_HEADER_HIGH register
+	REG_DPM_PDO_NUMB              = 0x70 // DPM_PDO_NUMB register
+	REG_DPM_SNK_PDO1_0            = 0x85 // DPM_SNK_PDO1_0 register
+	REG_DPM_SNK_PDO1_1            = 0x86 // DPM_SNK_PDO1_1 register
+	REG_DPM_SNK_PDO1_2            = 0x87 // DPM_SNK_PDO1_2 register
+	REG_DPM_SNK_PDO1_3            = 0x88 // DPM_SNK_PDO1_3 register
+	REG_DPM_SNK_PDO2_0            = 0x89 // DPM_SNK_PDO2_0 register
+	REG_DPM_SNK_PDO2_1            = 0x8A // DPM_SNK_PDO2_1 register
+	REG_DPM_SNK_PDO2_2            = 0x8B // DPM_SNK_PDO2_2 register
+	REG_DPM_SNK_PDO2_3            = 0x8C // DPM_SNK_PDO2_3 register
+	REG_DPM_SNK_PDO3_0            = 0x8D // DPM_SNK_PDO3_0 register
+	REG_DPM_SNK_PDO3_1            = 0x8E // DPM_SNK_PDO3_1 register
+	REG_DPM_SNK_PDO3_2            = 0x8F // DPM_SNK_PDO3_2 register
+	REG_DPM_SNK_PDO3_3            = 0x90 // DPM_SNK_PDO3_3 register
+	REG_RDO_REG_STATUS_0          = 0x91 // RDO_REG_STATUS_0 register
+	REG_RDO_REG_STATUS_1          = 0x92 // RDO_REG_STATUS_1 register
+	REG_RDO_REG_STATUS_2          = 0x93 // RDO_REG_STATUS_2 register
+	REG_RDO_REG_STATUS_3          = 0x94 // RDO_REG_STATUS_3 register
+)
+
+const (
+	// USB PD policy engine states, as defined in REG_PE_FSM (0x29)
+	peSoftReset               = 0x01 // 00000001
+	peHardReset               = 0x02 // 00000010
+	peSendSoftReset           = 0x03 // 00000011
+	peBistCarrierMode         = 0x04 // 00000100
+	peSnkStartup              = 0x12 // 00010010
+	peSnkDiscovery            = 0x13 // 00010011
+	peSnkWaitForCapabilities  = 0x14 // 00010100
+	peSnkEvaluateCapabilities = 0x15 // 00010101
+	peSnkSelectCapabilities   = 0x16 // 00010110
+	peSnkTransitionSink       = 0x17 // 00010111
+	peSnkReady                = 0x18 // 00011000
+	peSnkReadySending         = 0x19 // 00011001
+	peDbCpCheckForVbus        = 0x1A // 00011010
+	peErrorrecovery           = 0x30 // 00110000
+	peSrcTransitionSupply3    = 0x31 // 00110001
+	peSrcTransitionSupply2b   = 0x31 // 00110001
+	peSrcGetSinkCap           = 0x31 // 00110001
+)
+
+const (
+	// Some STUSB4500 devices contain 0x21 in the device ID register (0x2F), and
+	// others contain 0x25. See the following discussion:
+	//   https://github.com/ardnew/STUSB4500/issues/2
+	evalDeviceID = 0x21
+	prodDeviceID = 0x25
+)
+
+// isDeviceIDValid returns true if and only if the provided id equals one of the
+// known STUSB4500 device ID register (0x2F) contents.
+func isDeviceIDValid(id uint8) bool {
+	return evalDeviceID == id || prodDeviceID == id
+}
+
+// statusRegister defines the methods available on a read-only (R/O) status
+// register. This includes registers whose contents are cleared when read (R/C).
+type statusRegister interface {
+	parse(...uint8) error
+}
+
+// controlRegister defines the methods available on a read-write (R/W) control
+// register. All methods defined on statusRegister are also available on
+// controlRegister.
+type controlRegister interface {
+	parse(...uint8)
+	format() []uint8
+}
+
+type regStatusSnkPDO struct {
+	cons struct {
+		operationalCurrent uint32 // 0[10]
+		voltage            uint32 // 10[10]
+		_                  uint8  // 20[3]
+		fastRoleReqCurrent uint8  // 23[2]
+		dualRoleData       bool   // 25[1]
+		usbCommsCapable    bool   // 26[1]
+		unconstrainedPower bool   // 27[1]
+		higherCapability   bool   // 28[1]
+		dualRolePower      bool   // 29[1]
+		fixedSupply        uint8  // 30[2]
+	}
+	vari struct {
+		operatingCurrent uint32 // 0[10]
+		minVoltage       uint32 // 10[10]
+		maxVoltage       uint32 // 20[10]
+		variableSupply   uint8  // 30[2]
+	}
+	batt struct {
+		operatingPower uint32 // 0[10]
+		minVoltage     uint32 // 10[10]
+		maxVoltage     uint32 // 20[10]
+		battery        uint8  // 30[2]
+	}
+}
+
+func (reg *regStatusSnkPDO) parse(word ...uint8) {
+	data := lendU32(word...)
+	// fixed supply
+	reg.cons.operationalCurrent = (data >> 0) & 0x3FF       // uint32 // 0[10]
+	reg.cons.voltage = (data >> 10) & 0x3FF                 // uint32 // 10[10]
+	reg.cons.fastRoleReqCurrent = uint8((data >> 23) & 0x3) // uint8  // 23[2]
+	reg.cons.dualRoleData = 0 != (data>>25)&0x1             // bool   // 25[1]
+	reg.cons.usbCommsCapable = 0 != (data>>26)&0x1          // bool   // 26[1]
+	reg.cons.unconstrainedPower = 0 != (data>>27)&0x1       // bool   // 27[1]
+	reg.cons.higherCapability = 0 != (data>>28)&0x1         // bool   // 28[1]
+	reg.cons.dualRolePower = 0 != (data>>29)&0x1            // bool   // 29[1]
+	reg.cons.fixedSupply = uint8((data >> 30) & 0x3)        // uint8  // 30[2]
+	// variable supply
+	reg.vari.operatingCurrent = (data >> 0) & 0x3FF     // uint32 // 0[10]
+	reg.vari.minVoltage = (data >> 10) & 0x3FF          // uint32 // 10[10]
+	reg.vari.maxVoltage = (data >> 20) & 0x3FF          // uint32 // 20[10]
+	reg.vari.variableSupply = uint8((data >> 30) & 0x3) // uint8  // 30[2]
+	// battery
+	reg.batt.operatingPower = (data >> 0) & 0x3FF // uint32 // 0[10]
+	reg.batt.minVoltage = (data >> 10) & 0x3FF    // uint32 // 10[10]
+	reg.batt.maxVoltage = (data >> 20) & 0x3FF    // uint32 // 20[10]
+	reg.batt.battery = uint8((data >> 30) & 0x3)  // uint8  // 30[2]
+}
+
+// since we don't have unions in Go, each of the sub-structs are formatted as
+// three separate 32-bit words at the following positions in the returned slice:
+//   cons = [0..3], vari = [4..7], batt = [8..11]
+func (reg *regStatusSnkPDO) format() []uint8 {
+
+	var cons, vari, batt uint32
+
+	cons |= (reg.cons.operationalCurrent & 0x3FF) << 0
+	cons |= (reg.cons.voltage & 0x3FF) << 10
+	cons |= (uint32(reg.cons.fastRoleReqCurrent) & 0x3) << 23
+	if reg.cons.dualRoleData {
+		cons |= 1 << 25
+	}
+	if reg.cons.usbCommsCapable {
+		cons |= 1 << 26
+	}
+	if reg.cons.unconstrainedPower {
+		cons |= 1 << 27
+	}
+	if reg.cons.higherCapability {
+		cons |= 1 << 28
+	}
+	if reg.cons.dualRolePower {
+		cons |= 1 << 29
+	}
+	cons |= (uint32(reg.cons.fixedSupply) & 0x3) << 30
+
+	vari |= (reg.vari.operatingCurrent & 0x3FF) << 0
+	vari |= (reg.vari.minVoltage & 0x3FF) << 10
+	vari |= (reg.vari.maxVoltage & 0x3FF) << 20
+	vari |= (uint32(reg.vari.variableSupply) & 0x3) << 30
+
+	batt |= (reg.batt.operatingPower & 0x3FF) << 0
+	batt |= (reg.batt.minVoltage & 0x3FF) << 10
+	batt |= (reg.batt.maxVoltage & 0x3FF) << 20
+	batt |= (uint32(reg.batt.battery) & 0x3) << 30
+
+	data := []uint8{}
+	data = append(data, bytes32(cons)...)
+	data = append(data, bytes32(vari)...)
+	data = append(data, bytes32(batt)...)
+	return data
+	//	return append(append(append([]uint8{}, bytes32(cons)...), bytes32(vari)...), bytes32(batt)...)
+}
+
+type regStatusSrcPDO struct {
+	cons struct {
+		maxOperatingCurrent uint32 // 0[10]
+		voltage             uint32 // 10[10]
+		peakCurrent         uint8  // 20[2]
+		_                   uint8  // 22[3]
+		dataRoleSwap        bool   // 25[1]
+		communication       bool   // 26[1]
+		externallyPowered   bool   // 27[1]
+		suspendSupported    bool   // 28[1]
+		dualRolePower       bool   // 29[1]
+		fixedSupply         uint8  // 30[2]
+	}
+	vari struct {
+		operatingCurrent uint32 // 0[10]
+		minVoltage       uint32 // 10[10]
+		maxVoltage       uint32 // 20[10]
+		variableSupply   uint8  // 30[2]
+	}
+	batt struct {
+		operatingPower uint32 // 0[10]
+		minVoltage     uint32 // 10[10]
+		maxVoltage     uint32 // 20[10]
+		battery        uint8  // 30[2]
+	}
+}
+
+func (reg *regStatusSrcPDO) parse(word ...uint8) {
+	data := lendU32(word...)
+	// fixed supply
+	reg.cons.maxOperatingCurrent = (data >> 0) & 0x3FF // uint32 // 0[10]
+	reg.cons.voltage = (data >> 10) & 0x3FF            // uint32 // 10[10]
+	reg.cons.peakCurrent = uint8((data >> 20) & 0x3)   // uint8  // 20[2]
+	reg.cons.dataRoleSwap = 0 != (data>>25)&0x1        // bool   // 25[1]
+	reg.cons.communication = 0 != (data>>26)&0x1       // bool   // 26[1]
+	reg.cons.externallyPowered = 0 != (data>>27)&0x1   // bool   // 27[1]
+	reg.cons.suspendSupported = 0 != (data>>28)&0x1    // bool   // 28[1]
+	reg.cons.dualRolePower = 0 != (data>>29)&0x1       // bool   // 29[1]
+	reg.cons.fixedSupply = uint8((data >> 30) & 0x3)   // uint8  // 30[2]
+	// variable supply
+	reg.vari.operatingCurrent = (data >> 0) & 0x3FF     // uint32 // 0[10]
+	reg.vari.minVoltage = (data >> 10) & 0x3FF          // uint32 // 10[10]
+	reg.vari.maxVoltage = (data >> 20) & 0x3FF          // uint32 // 20[10]
+	reg.vari.variableSupply = uint8((data >> 30) & 0x3) // uint8  // 30[2]
+	// battery
+	reg.batt.operatingPower = (data >> 0) & 0x3FF // uint32 // 0[10]
+	reg.batt.minVoltage = (data >> 10) & 0x3FF    // uint32 // 10[10]
+	reg.batt.maxVoltage = (data >> 20) & 0x3FF    // uint32 // 20[10]
+	reg.batt.battery = uint8((data >> 30) & 0x3)  // uint8  // 30[2]
+}
+
+type regStatusRDO struct {
+	maxCurrent        uint32 // 0[10]
+	operatingCurrent  uint32 // 10[10]
+	_                 uint8  // 20[3]
+	unchunkMsgSupport bool   // 23[1]
+	usbSuspend        bool   // 24[1]
+	usbCommsCapable   bool   // 25[1]
+	capMismatch       bool   // 26[1]
+	giveBack          bool   // 27[1]
+	objectPos         uint8  // 28[3]
+	_                 uint8  // 31[1]
+}
+
+func (reg *regStatusRDO) parse(word ...uint8) {
+	data := lendU32(word...)
+	reg.maxCurrent = (data >> 0) & 0x3FF
+	reg.operatingCurrent = (data >> 10) & 0x3FF
+	reg.unchunkMsgSupport = 0 != (data>>23)&0x1
+	reg.usbSuspend = 0 != (data>>24)&0x1
+	reg.usbCommsCapable = 0 != (data>>25)&0x1
+	reg.capMismatch = 0 != (data>>26)&0x1
+	reg.giveBack = 0 != (data>>27)&0x1
+	reg.objectPos = uint8((data >> 28) & 0x7)
+}
+
+type msgUsbpdHeader struct {
+	messageType     uint8 // 0[5]
+	portDataRole    uint8 // 5[1]
+	specRevision    uint8 // 6[2]
+	portPowerRole   uint8 // 8[1]
+	messageID       uint8 // 9[3]
+	dataObjectCount uint8 // 12[3]
+	extended        uint8 // 15[1]
+}
+
+func (reg *msgUsbpdHeader) parse(word ...uint8) {
+	data := lendU16(word...)
+	reg.messageType = uint8((data >> 0) & 0x1F)
+	reg.portDataRole = uint8((data >> 5) & 0x1)
+	reg.specRevision = uint8((data >> 6) & 0x3)
+	reg.portPowerRole = uint8((data >> 8) & 0x1)
+	reg.messageID = uint8((data >> 9) & 0x7)
+	reg.dataObjectCount = uint8((data >> 12) & 0x7)
+	reg.extended = uint8((data >> 15) & 0x1)
+}
+
+// This register (0x0B, access=R/C) indicates an Alert has occurred.
+type regStatusAlert struct {
+	phy       bool  // 0[1]
+	prt       bool  // 1[1]
+	_         uint8 // 2[1]
+	typeC     bool  // 3[1]
+	hwFault   bool  // 4[1]
+	monitor   bool  // 5[1]
+	ccDetect  bool  // 6[1]
+	hardReset bool  // 7[1]
+}
+
+func (reg *regStatusAlert) parse(word ...uint8) {
+	data := lendU8(word...)
+	reg.phy = 0 != (data>>0)&0x1
+	reg.prt = 0 != (data>>1)&0x1
+	reg.typeC = 0 != (data>>3)&0x1
+	reg.hwFault = 0 != (data>>4)&0x1
+	reg.monitor = 0 != (data>>5)&0x1
+	reg.ccDetect = 0 != (data>>6)&0x1
+	reg.hardReset = 0 != (data>>7)&0x1
+}
+
+type regControlAlert struct {
+	phy       bool  // 0[1]
+	prt       bool  // 1[1]
+	_         uint8 // 2[1]
+	typeC     bool  // 3[1]
+	hwFault   bool  // 4[1]
+	monitor   bool  // 5[1]
+	ccDetect  bool  // 6[1]
+	hardReset bool  // 7[1]
+}
+
+func (reg *regControlAlert) parse(word ...uint8) {
+	data := lendU8(word...)
+	reg.phy = 0 != (data>>0)&0x1
+	reg.prt = 0 != (data>>1)&0x1
+	reg.typeC = 0 != (data>>3)&0x1
+	reg.hwFault = 0 != (data>>4)&0x1
+	reg.monitor = 0 != (data>>5)&0x1
+	reg.ccDetect = 0 != (data>>6)&0x1
+	reg.hardReset = 0 != (data>>7)&0x1
+}
+
+func (reg *regControlAlert) format() []uint8 {
+	var data uint8
+	if reg.phy {
+		data |= 1 << 0
+	}
+	if reg.prt {
+		data |= 1 << 1
+	}
+	if reg.typeC {
+		data |= 1 << 3
+	}
+	if reg.hwFault {
+		data |= 1 << 4
+	}
+	if reg.monitor {
+		data |= 1 << 5
+	}
+	if reg.ccDetect {
+		data |= 1 << 6
+	}
+	if reg.hardReset {
+		data |= 1 << 7
+	}
+	return []uint8{data}
+}
+
+// This register (0x0D, access=R/C) indicates a bit value change has occurred in
+// CC_DETECTION_STATUS register (0x0E).
+type regStatusCCDetectTrans struct {
+	attached bool  // 0[1]
+	_        uint8 // 1[7]
+}
+
+func (reg *regStatusCCDetectTrans) parse(word ...uint8) {
+	data := lendU8(word...)
+	reg.attached = 0 != (data>>0)&0x1
+}
+
+// This register (0x0E, access=R/O) provides current status of the connection
+// detection and corresponding operation modes.
+type regStatusCCDetect struct {
+	attached         bool  // 0[1]
+	vconnSupplyState uint8 // 1[1]
+	dataRole         uint8 // 2[1]
+	powerRole        uint8 // 3[1]
+	startupPowerMode uint8 // 4[1]
+	attachMode       uint8 // 5[3]
+}
+
+func (reg *regStatusCCDetect) parse(word ...uint8) {
+	data := lendU8(word...)
+	reg.attached = 0 != (data>>0)&0x1
+	reg.vconnSupplyState = (data >> 1) & 0x1
+	reg.dataRole = (data >> 2) & 0x1
+	reg.powerRole = (data >> 3) & 0x1
+	reg.startupPowerMode = (data >> 4) & 0x1
+	reg.attachMode = (data >> 5) & 0x7
+}
+
+// This register (0x0F, access=R/C) allows to:
+//   - Alert about any change that occurs in MONITORING_STATUS (0x10) register
+//   - Manage specific USB PD Acknowledge commands
+//   - to manage Type-C state machine Acknowledge to USB PD Requests commands
+type regStatusTypeCMonTrans struct {
+	vconnValid     bool  // 0[1]
+	vbusValid      bool  // 1[1]
+	vbusVSafe0V    bool  // 2[1]
+	vbusReady      bool  // 3[1]
+	vbusLowStatus  bool  // 4[1]
+	vbusHighStatus bool  // 5[1]
+	_              uint8 // 6[2]
+}
+
+func (reg *regStatusTypeCMonTrans) parse(word ...uint8) {
+	data := lendU8(word...)
+	reg.vconnValid = 0 != (data>>0)&0x1
+	reg.vbusValid = 0 != (data>>1)&0x1
+	reg.vbusVSafe0V = 0 != (data>>2)&0x1
+	reg.vbusReady = 0 != (data>>3)&0x1
+	reg.vbusLowStatus = 0 != (data>>4)&0x1
+	reg.vbusHighStatus = 0 != (data>>5)&0x1
+}
+
+// This register (0x10, access=R/O) provides information on current status of
+// the VBUS and VCONN voltages monitoring done respectively on VBUS_SENSE input
+// pin and VCONN input pin.
+type regStatusTypeCMon struct {
+	vconnValid    bool  // 0[1]
+	vbusValidSink bool  // 1[1]
+	vbusVSafe0V   bool  // 2[1]
+	vbusReady     bool  // 3[1]
+	_             uint8 // 4[4]
+}
+
+func (reg *regStatusTypeCMon) parse(word ...uint8) {
+	data := lendU8(word...)
+	reg.vconnValid = 0 != (data>>0)&0x1
+	reg.vbusValidSink = 0 != (data>>1)&0x1
+	reg.vbusVSafe0V = 0 != (data>>2)&0x1
+	reg.vbusReady = 0 != (data>>3)&0x1
+}
+
+type regStatusCC struct {
+	cc1State             uint8 // 0[2]
+	cc2State             uint8 // 2[2]
+	connectResult        bool  // 4[1]
+	lookingForConnection bool  // 5[1]
+	_                    uint8 // 6[2]
+}
+
+func (reg *regStatusCC) parse(word ...uint8) {
+	data := lendU8(word...)
+	reg.cc1State = (data >> 0) & 0x3
+	reg.cc2State = (data >> 2) & 0x3
+	reg.connectResult = 0 != (data>>4)&0x1
+	reg.lookingForConnection = 0 != (data>>5)&0x1
+}
+
+// This register (0x12, access=R/C) indicates a bit value change has occurred in
+// HW_FAULT_STATUS (0x13) register. It alerts also when the over-temperature
+// condition is met.
+type regStatusHWFaultTrans struct {
+	vconnSwOVPFault    bool  // 0[1]
+	vconnSwOCPFault    bool  // 1[1]
+	vconnSwRVPFault    bool  // 2[1]
+	vbusVsrcDischFault bool  // 3[1]
+	vpuValid           bool  // 4[1]
+	vpuOVPFault        bool  // 5[1]
+	_                  uint8 // 6[1]
+	thermalFault       bool  // 7[1]
+}
+
+func (reg *regStatusHWFaultTrans) parse(word ...uint8) {
+	data := lendU8(word...)
+	reg.vconnSwOVPFault = 0 != (data>>0)&0x1
+	reg.vconnSwOCPFault = 0 != (data>>1)&0x1
+	reg.vconnSwRVPFault = 0 != (data>>2)&0x1
+	reg.vbusVsrcDischFault = 0 != (data>>3)&0x1
+	reg.vpuValid = 0 != (data>>4)&0x1
+	reg.vpuOVPFault = 0 != (data>>5)&0x1
+	reg.thermalFault = 0 != (data>>7)&0x1
+}
+
+// This register (0x13, access=R/O) provides information on hardware fault
+// conditions related to the internal pull-up voltage in Source power role and
+// to the VCONN power switches.
+type regStatusHWFault struct {
+	vconnSwOVPFault bool  // 0[1]
+	vconnSwOCPFault bool  // 1[1]
+	vconnSwRVPFault bool  // 2[1]
+	vsrcDischFault  bool  // 3[1]
+	_               uint8 // 4[1]
+	vbusDischFault  bool  // 5[1]
+	vpuPresence     bool  // 6[1]
+	vpuOVPFault     bool  // 7[1]
+}
+
+func (reg *regStatusHWFault) parse(word ...uint8) {
+	data := lendU8(word...)
+	reg.vconnSwOVPFault = 0 != (data>>0)&0x1
+	reg.vconnSwOCPFault = 0 != (data>>1)&0x1
+	reg.vconnSwRVPFault = 0 != (data>>2)&0x1
+	reg.vsrcDischFault = 0 != (data>>3)&0x1
+	reg.vbusDischFault = 0 != (data>>5)&0x1
+	reg.vpuPresence = 0 != (data>>6)&0x1
+	reg.vpuOVPFault = 0 != (data>>7)&0x1
+}
+
+// This register (0x15, access=R/O) provides information on Type-C connection
+// status.
+type regStatusTypeC struct {
+	typeCFSMState uint8 // 0[5]
+	pdSnkTxRp     bool  // 5[1]
+	pdSrcTxRp     bool  // 6[1]
+	reverse       bool  // 7[1]
+}
+
+func (reg *regStatusTypeC) parse(word ...uint8) {
+	data := lendU8(word...)
+	reg.typeCFSMState = (data >> 0) & 0x1F
+	reg.pdSnkTxRp = 0 != (data>>5)&0x1
+	reg.pdSrcTxRp = 0 != (data>>6)&0x1
+	reg.reverse = 0 != (data>>7)&0x1
+}
+
+// This register (0x16, access=R/O) provides information on PRT status.
+type regStatusPRT struct {
+	hardResetReceived bool  // 0[1]
+	hardResetDone     bool  // 1[1]
+	msgReceived       bool  // 2[1]
+	msgSent           bool  // 3[1]
+	bistReceived      bool  // 4[1]
+	bistSent          bool  // 5[1]
+	_                 uint8 // 6[1]
+	txError           bool  // 7[1]
+}
+
+func (reg *regStatusPRT) parse(word ...uint8) {
+	data := lendU8(word...)
+	reg.hardResetReceived = 0 != (data>>0)&0x1
+	reg.hardResetDone = 0 != (data>>1)&0x1
+	reg.msgReceived = 0 != (data>>2)&0x1
+	reg.msgSent = 0 != (data>>3)&0x1
+	reg.bistReceived = 0 != (data>>4)&0x1
+	reg.bistSent = 0 != (data>>5)&0x1
+	reg.txError = 0 != (data>>7)&0x1
+}
+
+// This register (0x17, access=R/O) provides information on PHY status.
+type regStatusPHY struct {
+	txMsgFail bool  // 0[1]
+	txMsgDisc bool  // 1[1]
+	txMsgSucc bool  // 2[1]
+	idle      bool  // 3[1]
+	_         uint8 // 4[1]
+	sopRxType uint8 // 5[3]
+}
+
+func (reg *regStatusPHY) parse(word ...uint8) {
+	data := lendU8(word...)
+	reg.txMsgFail = 0 != (data>>0)&0x1
+	reg.txMsgDisc = 0 != (data>>1)&0x1
+	reg.txMsgSucc = 0 != (data>>2)&0x1
+	reg.idle = 0 != (data>>3)&0x1
+	reg.sopRxType = (data >> 5) & 0x7
+}
+
+// This register (0x18, access=R/W) allows to change the advertising of the
+// current capability and the VCONN supply capability when operating in Source
+// power role.
+type regControlCCCap struct {
+	vconnSupplyEn     bool  // 0[1]
+	vconnSwapEn       bool  // 1[1]
+	prSwapEn          bool  // 2[1]
+	drSwapEn          bool  // 3[1]
+	vconnDischargeEn  bool  // 4[1]
+	sinkDisconnect    bool  // 5[1]
+	currentAdvertised uint8 // 6[2]
+}
+
+func (reg *regControlCCCap) parse(word ...uint8) {
+	data := lendU8(word...)
+	reg.vconnSupplyEn = 0 != (data>>0)&0x1
+	reg.vconnSwapEn = 0 != (data>>1)&0x1
+	reg.prSwapEn = 0 != (data>>2)&0x1
+	reg.drSwapEn = 0 != (data>>3)&0x1
+	reg.vconnDischargeEn = 0 != (data>>4)&0x1
+	reg.sinkDisconnect = 0 != (data>>5)&0x1
+	reg.currentAdvertised = (data >> 6) & 0x3
+}
+
+func (reg *regControlCCCap) format() []uint8 {
+	var data uint8
+	if reg.vconnSupplyEn {
+		data |= 1 << 0
+	}
+	if reg.vconnSwapEn {
+		data |= 1 << 1
+	}
+	if reg.prSwapEn {
+		data |= 1 << 2
+	}
+	if reg.drSwapEn {
+		data |= 1 << 3
+	}
+	if reg.vconnDischargeEn {
+		data |= 1 << 4
+	}
+	if reg.sinkDisconnect {
+		data |= 1 << 5
+	}
+	data |= (reg.currentAdvertised & 0x3) << 6
+	return []uint8{data}
+}
+
+// This register (0x19, access=R/W) allows PRT TX layer.
+type regControlPRTTx struct {
+	prtTxSOPMsg      uint8 // 0[3]
+	_                uint8 // 3[1]
+	prtRetryMsgCount uint8 // 4[2]
+	_                uint8 // 6[2]
+}
+
+func (reg *regControlPRTTx) parse(word ...uint8) {
+	data := lendU8(word...)
+	reg.prtTxSOPMsg = (data >> 0) & 0x7
+	reg.prtRetryMsgCount = (data >> 4) & 0x3
+}
+
+func (reg *regControlPRTTx) format() []uint8 {
+	var data uint8
+	data |= (reg.prtTxSOPMsg & 0x7) << 0
+	data |= (reg.prtRetryMsgCount & 0x3) << 4
+	return []uint8{data}
+}
+
+// This register (0x1A, access=R/W) allows to send command to PRL or PE internal
+// state machines.
+type regControlPDCmd struct {
+	cmd uint8 // 0[8]
+}
+
+const (
+	ctrlPDCommand = 0x26
+	ctrlSoftReset = 0x0D
+)
+
+func (reg *regControlPDCmd) parse(word ...uint8) {
+	data := lendU8(word...)
+	reg.cmd = data
+}
+
+func (reg *regControlPDCmd) format() []uint8 {
+	return []uint8{reg.cmd}
+}
+
+// This register (0x1D, access=R/W) allows to Reset PHYTX & change device
+// Automation level.
+type regControlDevice struct {
+	_          uint8 // 0[1]
+	phyTxReset bool  // 1[1]
+	_          uint8 // 2[4]
+	pdTopLayer uint8 // 6[2]
+}
+
+func (reg *regControlDevice) parse(word ...uint8) {
+	data := lendU8(word...)
+	reg.phyTxReset = 0 != (data>>1)&0x1
+	reg.pdTopLayer = (data >> 6) & 0x3
+}
+
+func (reg *regControlDevice) format() []uint8 {
+	var data uint8
+	if reg.phyTxReset {
+		data |= 1 << 1
+	}
+	data |= (reg.pdTopLayer & 0x3) << 6
+	return []uint8{data}
+}
+
+// This register (0x23, access=R/W) allows to reset the device by software.
+// The SW_RESET_EN bit acts as the hardware RESET pin but it does not command
+// the RESET pin.
+type regControlReset struct {
+	reset bool  // 0[1]
+	_     uint8 // 1[7]
+}
+
+func (reg *regControlReset) parse(word ...uint8) {
+	data := lendU8(word...)
+	reg.reset = 0 != (data>>0)&0x1
+}
+
+func (reg *regControlReset) format() []uint8 {
+	var data uint8
+	if reg.reset {
+		data |= 1 << 0
+	}
+	return []uint8{data}
+}

--- a/stusb4500/util.go
+++ b/stusb4500/util.go
@@ -1,0 +1,65 @@
+package stusb4500
+
+// lendU32 returns a uint32 from the given slice of bytes.
+// the first element (0) in the given slice becomes the least-significant byte;
+// this can be interpreted as a "little-endian" conversion, hence the name.
+// if less than 4 bytes are given (len(word) < 4), the missing most-significant
+// bytes are set to 0.
+// any additional bytes trailing the first 4 bytes are ignored.
+func lendU32(word ...uint8) uint32 {
+	numWords := 4 // read at most 4 bytes to form a 32-bit object
+	if len(word) < numWords {
+		numWords = len(word)
+	}
+	var data uint32
+	for i, j := 0, 0; i < numWords; i, j = i+1, j+8 {
+		data |= uint32(word[i]) << j
+	}
+	return data
+}
+
+// lendU16 returns a uint16 from the given slice of bytes.
+// the first element (0) in the given slice becomes the least-significant byte;
+// this can be interpreted as a "little-endian" conversion, hence the name.
+// if less than 2 bytes are given (len(word) < 2), the missing most-significant
+// bytes are set to 0.
+// any additional bytes trailing the first 2 bytes are ignored.
+func lendU16(word ...uint8) uint16 {
+	numWords := 2 // read at most 2 bytes to form a 16-bit object
+	if len(word) < numWords {
+		numWords = len(word)
+	}
+	var data uint16
+	for i, j := 0, 0; i < numWords; i, j = i+1, j+8 {
+		data |= uint16(word[i]) << j
+	}
+	return data
+}
+
+// lendU8 returns a uint8 from the given slice of bytes.
+// the first element (0) in the given slice becomes the resulting byte returned;
+// this can be interpreted as a "little-endian" conversion, hence the name.
+// if 0 bytes are given (len(word) == 0), the zero byte is returned.
+// any additional bytes trailing the first byte are ignored.
+func lendU8(word ...uint8) uint8 {
+	if len(word) > 0 {
+		return word[0]
+	}
+	return 0
+}
+
+func bytes32(data uint32) []byte {
+	b := make([]byte, 4)
+	for i := range b {
+		b[i] = byte((data >> (8 * i)) & 0xFF)
+	}
+	return b
+}
+
+// boolToByte returns 1 if and only if set is true, otherwise 0.
+func boolToByte(set bool) byte {
+	if set {
+		return 1
+	}
+	return 0
+}


### PR DESCRIPTION
This PR adds an I2C driver and example program for the STUSB4500 USB Type-C Power Delivery (PD) Sink Controller by STMicroelectronics.

The driver includes the ability to detect USB Type-C cable attach/detach, determine cable orientation, read USB PD source capabilities, request arbitrary power profiles 5-20V (in 50mV increments), 0-5A (in 10mA increments), and supports user callback functions for each of these and various other USB PD-related events.

The demo program in `examples/stusb4500` requires an external push button and an LED. After the user plugs in a USB Type-C cable and the source capabilities are detected, the user can push a button to cycle through each of the detected power profiles. For example, pushing the button 3 times with a PD source that supports 3 different profiles will cycle the user back to the initial startup profile: 5V/1.5A -> 9V/3A -> 12V/3A -> 5V/1.5A -> ...

The LED in the demo program lights up during active USB PD negotiation, and will turn off once a power contract is established.