### PR TITLE
pin: implement driver.Pin interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,12 +161,11 @@ endif
 	@md5sum ./build/test.hex
 
 DRIVERS = $(wildcard */)
-NOTESTS = build examples flash semihosting pcd8544 shiftregister st7789 microphone mcp3008 gps microbitmatrix \
-		hcsr04 ssd1331 ws2812 thermistor apa102 easystepper ssd1351 ili9341 wifinina shifter hub75 \
-		hd44780 buzzer ssd1306 espat l9110x st7735 bmi160 l293x
+NOTESTS = build examples flash semihosting pcd8544 microphone mcp3008 gps microbitmatrix \
+		ws2812 thermistor ili9341 wifinina shifter hd44780 espat l9110x bmi160 l293x touch
 TESTS = $(filter-out $(addsuffix /%,$(NOTESTS)),$(DRIVERS))
 
 unit-test:
-	@go test -v $(addprefix ./,$(TESTS)) 
+	@go test -v $(addprefix ./,$(TESTS)) ./waveshare-epd/... 
 
 test: clean fmt-check unit-test smoke-test

--- a/apa102/apa102.go
+++ b/apa102/apa102.go
@@ -5,7 +5,6 @@ package apa102 // import "tinygo.org/x/drivers/apa102"
 
 import (
 	"image/color"
-	"machine"
 
 	"tinygo.org/x/drivers"
 )
@@ -36,7 +35,7 @@ func New(b drivers.SPI) Device {
 
 // NewSoftwareSPI returns a new APA102 driver that will use a software based
 // implementation of the SPI protocol.
-func NewSoftwareSPI(sckPin, sdoPin machine.Pin, delay uint32) Device {
+func NewSoftwareSPI(sckPin, sdoPin drivers.Pin, delay uint32) Device {
 	return New(&bbSPI{SCK: sckPin, SDO: sdoPin, Delay: delay})
 }
 

--- a/apa102/apa102_test.go
+++ b/apa102/apa102_test.go
@@ -1,0 +1,15 @@
+package apa102
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"tinygo.org/x/drivers/tester"
+)
+
+func TestDefaultAPA102(t *testing.T) {
+	c := qt.New(t)
+	bus := tester.NewSPIBus(c)
+	dev := New(bus)
+	c.Assert(dev, qt.Not(qt.IsNil))
+}

--- a/apa102/softspi.go
+++ b/apa102/softspi.go
@@ -1,6 +1,6 @@
 package apa102
 
-import "machine"
+import "tinygo.org/x/drivers"
 
 // bbSPI is a dumb bit-bang implementation of SPI protocol that is hardcoded
 // to mode 0 and ignores trying to receive data. Just enough for the APA102.
@@ -8,15 +8,16 @@ import "machine"
 // most purposes other than the APA102 package. It might be desirable to make
 // this more generic and include it in the TinyGo "machine" package instead.
 type bbSPI struct {
-	SCK   machine.Pin
-	SDO   machine.Pin
+	SCK   drivers.Pin
+	SDO   drivers.Pin
 	Delay uint32
 }
 
-// Configure sets up the SCK and SDO pins as outputs and sets them low
+// Configure sets up the SCK and SDO low.
+// The pins must already be set as outputs in the main program that uses this driver.
 func (s *bbSPI) Configure() {
-	s.SCK.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	s.SDO.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	// s.SCK.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	// s.SDO.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	s.SCK.Low()
 	s.SDO.Low()
 	if s.Delay == 0 {

--- a/buzzer/buzzer.go
+++ b/buzzer/buzzer.go
@@ -3,20 +3,20 @@
 package buzzer // import "tinygo.org/x/drivers/buzzer"
 
 import (
-	"machine"
-
 	"time"
+
+	"tinygo.org/x/drivers"
 )
 
 // Device wraps a GPIO connection to a buzzer.
 type Device struct {
-	pin  machine.Pin
+	pin  drivers.Pin
 	High bool
 	BPM  float64
 }
 
 // New returns a new buzzer driver given which pin to use
-func New(pin machine.Pin) Device {
+func New(pin drivers.Pin) Device {
 	return Device{
 		pin:  pin,
 		High: false,

--- a/buzzer/buzzer_test.go
+++ b/buzzer/buzzer_test.go
@@ -1,0 +1,15 @@
+package buzzer
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"tinygo.org/x/drivers/tester"
+)
+
+func TestDefaultBuzzer(t *testing.T) {
+	c := qt.New(t)
+	pin := tester.NewPin(c)
+	dev := New(pin)
+	c.Assert(dev, qt.Not(qt.IsNil))
+}

--- a/easystepper/easystepper.go
+++ b/easystepper/easystepper.go
@@ -2,13 +2,14 @@
 package easystepper // import "tinygo.org/x/drivers/easystepper"
 
 import (
-	"machine"
 	"time"
+
+	"tinygo.org/x/drivers"
 )
 
 // Device holds the pins and the delay between steps
 type Device struct {
-	pins       [4]machine.Pin
+	pins       [4]drivers.Pin
 	stepDelay  int32
 	stepNumber uint8
 }
@@ -19,29 +20,26 @@ type DualDevice struct {
 }
 
 // New returns a new easystepper driver given 4 pins, number of steps and rpm
-func New(pin1, pin2, pin3, pin4 machine.Pin, steps int32, rpm int32) Device {
+func New(pin1, pin2, pin3, pin4 drivers.Pin, steps int32, rpm int32) Device {
 	return Device{
-		pins:      [4]machine.Pin{pin1, pin2, pin3, pin4},
+		pins:      [4]drivers.Pin{pin1, pin2, pin3, pin4},
 		stepDelay: 60000000 / (steps * rpm),
 	}
 }
 
-// Configure configures the pins of the Device
+// Configure does not do much. Pins must already be configured as output.
 func (d *Device) Configure() {
-	for _, pin := range d.pins {
-		pin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	}
 }
 
 // NewDual returns a new dual easystepper driver given 8 pins, number of steps and rpm
-func NewDual(pin1, pin2, pin3, pin4, pin5, pin6, pin7, pin8 machine.Pin, steps int32, rpm int32) DualDevice {
+func NewDual(pin1, pin2, pin3, pin4, pin5, pin6, pin7, pin8 drivers.Pin, steps int32, rpm int32) DualDevice {
 	var dual DualDevice
 	dual.devices[0] = Device{
-		pins:      [4]machine.Pin{pin1, pin2, pin3, pin4},
+		pins:      [4]drivers.Pin{pin1, pin2, pin3, pin4},
 		stepDelay: 60000000 / (steps * rpm),
 	}
 	dual.devices[1] = Device{
-		pins:      [4]machine.Pin{pin5, pin6, pin7, pin8},
+		pins:      [4]drivers.Pin{pin5, pin6, pin7, pin8},
 		stepDelay: 60000000 / (steps * rpm),
 	}
 	return dual

--- a/easystepper/easystepper_test.go
+++ b/easystepper/easystepper_test.go
@@ -1,0 +1,18 @@
+package easystepper
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"tinygo.org/x/drivers/tester"
+)
+
+func TestDefaultEasyStepper(t *testing.T) {
+	c := qt.New(t)
+	pin1 := tester.NewPin(c)
+	pin2 := tester.NewPin(c)
+	pin3 := tester.NewPin(c)
+	pin4 := tester.NewPin(c)
+	dev := New(pin1, pin2, pin3, pin4, 100, 100)
+	c.Assert(dev, qt.Not(qt.IsNil))
+}

--- a/examples/amg88xx/main.go
+++ b/examples/amg88xx/main.go
@@ -19,6 +19,11 @@ func main() {
 	})
 	machine.I2C0.Configure(machine.I2CConfig{SCL: machine.SCL_PIN, SDA: machine.SDA_PIN})
 
+	machine.TFT_RST.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.TFT_DC.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.TFT_CS.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.TFT_LITE.Configure(machine.PinConfig{Mode: machine.PinOutput})
+
 	display := st7735.New(machine.SPI1, machine.TFT_RST, machine.TFT_DC, machine.TFT_CS, machine.TFT_LITE)
 	display.Configure(st7735.Config{
 		Rotation: st7735.ROTATION_90,

--- a/examples/easystepper/main.go
+++ b/examples/easystepper/main.go
@@ -8,6 +8,11 @@ import (
 )
 
 func main() {
+	machine.P13.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.P15.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.P14.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.P16.Configure(machine.PinConfig{Mode: machine.PinOutput})
+
 	motor := easystepper.New(machine.P13, machine.P15, machine.P14, machine.P16, 200, 75)
 	motor.Configure()
 

--- a/examples/hcsr04/main.go
+++ b/examples/hcsr04/main.go
@@ -8,6 +8,9 @@ import (
 )
 
 func main() {
+	machine.D10.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.D9.Configure(machine.PinConfig{Mode: machine.PinInput})
+
 	sensor := hcsr04.New(machine.D10, machine.D9)
 	sensor.Configure()
 

--- a/examples/hub75/main.go
+++ b/examples/hub75/main.go
@@ -18,7 +18,21 @@ func main() {
 		Mode:      0},
 	)
 
-	display = hub75.New(machine.SPI0, 11, 12, 6, 10, 18, 20)
+	p11 := machine.Pin(11)
+	p12 := machine.Pin(12)
+	p6 := machine.Pin(6)
+	p10 := machine.Pin(10)
+	p18 := machine.Pin(18)
+	p20 := machine.Pin(20)
+
+	p11.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	p12.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	p6.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	p10.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	p18.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	p20.Configure(machine.PinConfig{Mode: machine.PinOutput})
+
+	display = hub75.New(machine.SPI0, p11, p12, p6, p10, p18, p20)
 	display.Configure(hub75.Config{
 		Width:      64,
 		Height:     32,

--- a/examples/shiftregister/main.go
+++ b/examples/shiftregister/main.go
@@ -8,6 +8,10 @@ import (
 )
 
 func main() {
+	machine.PA6.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.PA7.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.PB6.Configure(machine.PinConfig{Mode: machine.PinOutput})
+
 	d := shiftregister.New(
 		shiftregister.EIGHT_BITS,
 		machine.PA6, // D12 Pin latch connected to ST_CP of 74HC595 (12)

--- a/examples/ssd1306/spi_128x64/main.go
+++ b/examples/ssd1306/spi_128x64/main.go
@@ -9,6 +9,10 @@ import (
 )
 
 func main() {
+	machine.P8.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.P7.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.P9.Configure(machine.PinConfig{Mode: machine.PinOutput})
+
 	machine.SPI0.Configure(machine.SPIConfig{
 		Frequency: 8000000,
 	})

--- a/examples/ssd1331/main.go
+++ b/examples/ssd1331/main.go
@@ -9,6 +9,10 @@ import (
 )
 
 func main() {
+	machine.P6.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.P7.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.P8.Configure(machine.PinConfig{Mode: machine.PinOutput})
+
 	machine.SPI0.Configure(machine.SPIConfig{
 		Frequency: 8000000,
 	})

--- a/examples/ssd1351/main.go
+++ b/examples/ssd1351/main.go
@@ -9,6 +9,12 @@ import (
 )
 
 func main() {
+	machine.D18.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.D17.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.D16.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.D4.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.D19.Configure(machine.PinConfig{Mode: machine.PinOutput})
+
 	machine.SPI1.Configure(machine.SPIConfig{
 		Frequency: 2000000,
 	})

--- a/examples/st7735/main.go
+++ b/examples/st7735/main.go
@@ -9,6 +9,11 @@ import (
 )
 
 func main() {
+	machine.P6.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.P7.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.P8.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.P9.Configure(machine.PinConfig{Mode: machine.PinOutput})
+
 	machine.SPI0.Configure(machine.SPIConfig{
 		Frequency: 8000000,
 	})

--- a/examples/st7789/main.go
+++ b/examples/st7789/main.go
@@ -23,6 +23,10 @@ func main() {
 	//	machine.TFT_DC,
 	//	machine.TFT_CS,
 	//	machine.TFT_LITE)
+	machine.P6.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.P7.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.P8.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.P9.Configure(machine.PinConfig{Mode: machine.PinOutput})
 
 	machine.SPI0.Configure(machine.SPIConfig{
 		Frequency: 8000000,

--- a/examples/waveshare-epd/epd2in13/main.go
+++ b/examples/waveshare-epd/epd2in13/main.go
@@ -13,6 +13,11 @@ import (
 var display epd2in13.Device
 
 func main() {
+	machine.P6.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.P7.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.P8.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.P9.Configure(machine.PinConfig{Mode: machine.PinOutput})
+
 	machine.SPI0.Configure(machine.SPIConfig{
 		Frequency: 8000000,
 		Mode:      0,

--- a/examples/waveshare-epd/epd2in13x/main.go
+++ b/examples/waveshare-epd/epd2in13x/main.go
@@ -11,6 +11,11 @@ import (
 var display epd2in13x.Device
 
 func main() {
+	machine.P6.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.P7.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.P8.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.P9.Configure(machine.PinConfig{Mode: machine.PinOutput})
+
 	machine.SPI0.Configure(machine.SPIConfig{
 		Frequency: 8000000,
 		Mode:      0,

--- a/examples/waveshare-epd/epd4in2/main.go
+++ b/examples/waveshare-epd/epd4in2/main.go
@@ -13,6 +13,11 @@ import (
 var display epd4in2.Device
 
 func main() {
+	machine.P6.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.P7.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.P8.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.P9.Configure(machine.PinConfig{Mode: machine.PinOutput})
+
 	machine.SPI0.Configure(machine.SPIConfig{
 		Frequency: 8000000,
 		Mode:      0,

--- a/hcsr04/hcsr04.go
+++ b/hcsr04/hcsr04.go
@@ -5,30 +5,31 @@
 package hcsr04
 
 import (
-	"machine"
 	"time"
+
+	"tinygo.org/x/drivers"
 )
 
 const TIMEOUT = 23324 // max sensing distance (4m)
 
 // Device holds the pins
 type Device struct {
-	trigger machine.Pin
-	echo    machine.Pin
+	trigger drivers.Pin
+	echo    drivers.Pin
 }
 
-// New returns a new ultrasonic driver given 2 pins
-func New(trigger, echo machine.Pin) Device {
+// New returns a new ultrasonic driver given 2 pins.
+// trigger needs to be configured as an output pin,
+// echo needs to be configured as an input pin.
+func New(trigger, echo drivers.Pin) Device {
 	return Device{
 		trigger: trigger,
 		echo:    echo,
 	}
 }
 
-// Configure configures the pins of the Device
+// Configures the Device
 func (d *Device) Configure() {
-	d.trigger.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.echo.Configure(machine.PinConfig{Mode: machine.PinInput})
 }
 
 // ReadDistance returns the distance of the object in mm

--- a/hcsr04/hcsr04_test.go
+++ b/hcsr04/hcsr04_test.go
@@ -1,0 +1,16 @@
+package hcsr04
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"tinygo.org/x/drivers/tester"
+)
+
+func TestDefaultEasyStepper(t *testing.T) {
+	c := qt.New(t)
+	pin1 := tester.NewPin(c)
+	pin2 := tester.NewPin(c)
+	dev := New(pin1, pin2)
+	c.Assert(dev, qt.Not(qt.IsNil))
+}

--- a/hub75/hub75.go
+++ b/hub75/hub75.go
@@ -7,7 +7,6 @@ package hub75 // import "tinygo.org/x/drivers/hub75"
 
 import (
 	"image/color"
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers"
@@ -24,12 +23,12 @@ type Config struct {
 
 type Device struct {
 	bus               drivers.SPI
-	a                 machine.Pin
-	b                 machine.Pin
-	c                 machine.Pin
-	d                 machine.Pin
-	oe                machine.Pin
-	lat               machine.Pin
+	a                 drivers.Pin
+	b                 drivers.Pin
+	c                 drivers.Pin
+	d                 drivers.Pin
+	oe                drivers.Pin
+	lat               drivers.Pin
 	width             int16
 	height            int16
 	brightness        uint8
@@ -53,15 +52,9 @@ type Device struct {
 	displayColor      uint16
 }
 
-// New returns a new HUB75 driver. Pass in a fully configured SPI bus.
-func New(b drivers.SPI, latPin, oePin, aPin, bPin, cPin, dPin machine.Pin) Device {
-	aPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	bPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	cPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	dPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	oePin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	latPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-
+// New returns a new HUB75 driver. Pass in a fully configured SPI bus, and
+// all pins configured as output.
+func New(b drivers.SPI, latPin, oePin, aPin, bPin, cPin, dPin drivers.Pin) Device {
 	return Device{
 		bus: b,
 		a:   aPin,

--- a/hub75/hub75_test.go
+++ b/hub75/hub75_test.go
@@ -1,0 +1,21 @@
+package hub75
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"tinygo.org/x/drivers/tester"
+)
+
+func TestDefaultHub75(t *testing.T) {
+	c := qt.New(t)
+	bus := tester.NewSPIBus(c)
+	pin1 := tester.NewPin(c)
+	pin2 := tester.NewPin(c)
+	pin3 := tester.NewPin(c)
+	pin4 := tester.NewPin(c)
+	pin5 := tester.NewPin(c)
+	pin6 := tester.NewPin(c)
+	dev := New(bus, pin1, pin2, pin3, pin4, pin5, pin6)
+	c.Assert(dev, qt.Not(qt.IsNil))
+}

--- a/pcd8544/pcd8544.go
+++ b/pcd8544/pcd8544.go
@@ -7,7 +7,6 @@ package pcd8544 // import "tinygo.org/x/drivers/pcd8544"
 import (
 	"errors"
 	"image/color"
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers"
@@ -16,9 +15,9 @@ import (
 // Device wraps an SPI connection.
 type Device struct {
 	bus        drivers.SPI
-	dcPin      machine.Pin
-	rstPin     machine.Pin
-	scePin     machine.Pin
+	dcPin      drivers.Pin
+	rstPin     drivers.Pin
+	scePin     drivers.Pin
 	buffer     []byte
 	width      int16
 	height     int16
@@ -31,7 +30,7 @@ type Config struct {
 }
 
 // New creates a new PCD8544 connection. The SPI bus must already be configured.
-func New(bus drivers.SPI, dcPin, rstPin, scePin machine.Pin) *Device {
+func New(bus drivers.SPI, dcPin, rstPin, scePin drivers.Pin) *Device {
 	return &Device{
 		bus:    bus,
 		dcPin:  dcPin,

--- a/pcd8544/pcd8544_test.go
+++ b/pcd8544/pcd8544_test.go
@@ -1,0 +1,18 @@
+package pcd8544
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"tinygo.org/x/drivers/tester"
+)
+
+func TestDefaultPCD8544(t *testing.T) {
+	c := qt.New(t)
+	bus := tester.NewSPIBus(c)
+	pin1 := tester.NewPin(c)
+	pin2 := tester.NewPin(c)
+	pin3 := tester.NewPin(c)
+	dev := New(bus, pin1, pin2, pin3)
+	c.Assert(dev, qt.Not(qt.IsNil))
+}

--- a/pin.go
+++ b/pin.go
@@ -1,0 +1,20 @@
+package drivers
+
+// Pin represents a GPIO pin. It is implemented by the machine.Pin type.
+type Pin interface {
+	// Get gets the current GPIO pin value
+	Get() bool
+
+	// Set sets the GPIO pin to either high if true, or low if false
+	Set(bool)
+
+	// High sets this GPIO pin to high, assuming it has been configured as an output
+	// pin. It is hardware dependent (and often undefined) what happens if you set a
+	// pin to high that is not configured as an output pin.
+	High()
+
+	// Low sets this GPIO pin to low, assuming it has been configured as an output
+	// pin. It is hardware dependent (and often undefined) what happens if you set a
+	// pin to low that is not configured as an output pin.
+	Low()
+}

--- a/shiftregister/shiftregister.go
+++ b/shiftregister/shiftregister.go
@@ -1,9 +1,7 @@
 // Package shiftregister is for 8bit shift output register using 3 GPIO pins like SN74ALS164A, SN74AHC594, SN74AHC595, ...
 package shiftregister
 
-import (
-	"machine"
-)
+import "tinygo.org/x/drivers"
 
 type NumberBit int8
 
@@ -16,7 +14,7 @@ const (
 
 // Device holds pin number
 type Device struct {
-	latch, clock, out machine.Pin // IC wiring
+	latch, clock, out drivers.Pin // IC wiring
 	bits              NumberBit   // Pin number
 	mask              uint32      // keep all pins state
 }
@@ -28,8 +26,9 @@ type ShiftPin struct {
 	d    *Device // Reference to the register
 }
 
-// New returns a new shift output register device
-func New(Bits NumberBit, Latch, Clock, Out machine.Pin) *Device {
+// New returns a new shift output register device.
+// You must configure all pins as output before calling.
+func New(Bits NumberBit, Latch, Clock, Out drivers.Pin) *Device {
 	return &Device{
 		latch: Latch,
 		clock: Clock,
@@ -40,9 +39,6 @@ func New(Bits NumberBit, Latch, Clock, Out machine.Pin) *Device {
 
 // Configure set hardware configuration
 func (d *Device) Configure() {
-	d.latch.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.clock.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.out.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	d.latch.High()
 }
 

--- a/shiftregister/shiftregister_test.go
+++ b/shiftregister/shiftregister_test.go
@@ -1,0 +1,17 @@
+package shiftregister
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"tinygo.org/x/drivers/tester"
+)
+
+func TestDefaultShiftregister(t *testing.T) {
+	c := qt.New(t)
+	pin1 := tester.NewPin(c)
+	pin2 := tester.NewPin(c)
+	pin3 := tester.NewPin(c)
+	dev := New(EIGHT_BITS, pin1, pin2, pin3)
+	c.Assert(dev, qt.Not(qt.IsNil))
+}

--- a/ssd1306/ssd1306.go
+++ b/ssd1306/ssd1306.go
@@ -7,7 +7,6 @@ package ssd1306 // import "tinygo.org/x/drivers/ssd1306"
 import (
 	"errors"
 	"image/color"
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers"
@@ -38,9 +37,9 @@ type I2CBus struct {
 
 type SPIBus struct {
 	wire     drivers.SPI
-	dcPin    machine.Pin
-	resetPin machine.Pin
-	csPin    machine.Pin
+	dcPin    drivers.Pin
+	resetPin drivers.Pin
+	csPin    drivers.Pin
 }
 
 type Buser interface {
@@ -62,10 +61,7 @@ func NewI2C(bus drivers.I2C) Device {
 }
 
 // NewSPI creates a new SSD1306 connection. The SPI wire must already be configured.
-func NewSPI(bus drivers.SPI, dcPin, resetPin, csPin machine.Pin) Device {
-	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	resetPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+func NewSPI(bus drivers.SPI, dcPin, resetPin, csPin drivers.Pin) Device {
 	return Device{
 		bus: &SPIBus{
 			wire:     bus,

--- a/ssd1306/ssd1306_test.go
+++ b/ssd1306/ssd1306_test.go
@@ -1,0 +1,25 @@
+package ssd1306
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"tinygo.org/x/drivers/tester"
+)
+
+func TestDefaultSSD1306I2C(t *testing.T) {
+	c := qt.New(t)
+	bus := tester.NewI2CBus(c)
+	dev := NewI2C(bus)
+	c.Assert(dev, qt.Not(qt.IsNil))
+}
+
+func TestDefaultSSD1306SPI(t *testing.T) {
+	c := qt.New(t)
+	bus := tester.NewSPIBus(c)
+	pin1 := tester.NewPin(c)
+	pin2 := tester.NewPin(c)
+	pin3 := tester.NewPin(c)
+	dev := NewSPI(bus, pin1, pin2, pin3)
+	c.Assert(dev, qt.Not(qt.IsNil))
+}

--- a/ssd1331/ssd1331.go
+++ b/ssd1331/ssd1331.go
@@ -6,7 +6,6 @@ package ssd1331 // import "tinygo.org/x/drivers/ssd1331"
 
 import (
 	"image/color"
-	"machine"
 
 	"errors"
 	"time"
@@ -20,9 +19,9 @@ type Rotation uint8
 // Device wraps an SPI connection.
 type Device struct {
 	bus         drivers.SPI
-	dcPin       machine.Pin
-	resetPin    machine.Pin
-	csPin       machine.Pin
+	dcPin       drivers.Pin
+	resetPin    drivers.Pin
+	csPin       drivers.Pin
 	width       int16
 	height      int16
 	batchLength int16
@@ -37,10 +36,7 @@ type Config struct {
 }
 
 // New creates a new SSD1331 connection. The SPI wire must already be configured.
-func New(bus drivers.SPI, resetPin, dcPin, csPin machine.Pin) Device {
-	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	resetPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+func New(bus drivers.SPI, resetPin, dcPin, csPin drivers.Pin) Device {
 	return Device{
 		bus:      bus,
 		dcPin:    dcPin,

--- a/ssd1331/ssd1331_test.go
+++ b/ssd1331/ssd1331_test.go
@@ -1,0 +1,18 @@
+package ssd1331
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"tinygo.org/x/drivers/tester"
+)
+
+func TestDefaultSSD1331(t *testing.T) {
+	c := qt.New(t)
+	bus := tester.NewSPIBus(c)
+	pin1 := tester.NewPin(c)
+	pin2 := tester.NewPin(c)
+	pin3 := tester.NewPin(c)
+	dev := New(bus, pin1, pin2, pin3)
+	c.Assert(dev, qt.Not(qt.IsNil))
+}

--- a/ssd1351/ssd1351.go
+++ b/ssd1351/ssd1351.go
@@ -7,7 +7,6 @@ package ssd1351 // import "tinygo.org/x/drivers/ssd1351"
 import (
 	"errors"
 	"image/color"
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers"
@@ -21,11 +20,11 @@ var (
 // Device wraps an SPI connection.
 type Device struct {
 	bus          drivers.SPI
-	dcPin        machine.Pin
-	resetPin     machine.Pin
-	csPin        machine.Pin
-	enPin        machine.Pin
-	rwPin        machine.Pin
+	dcPin        drivers.Pin
+	resetPin     drivers.Pin
+	csPin        drivers.Pin
+	enPin        drivers.Pin
+	rwPin        drivers.Pin
 	width        int16
 	height       int16
 	rowOffset    int16
@@ -42,7 +41,7 @@ type Config struct {
 }
 
 // New creates a new SSD1351 connection. The SPI wire must already be configured.
-func New(bus drivers.SPI, resetPin, dcPin, csPin, enPin, rwPin machine.Pin) Device {
+func New(bus drivers.SPI, resetPin, dcPin, csPin, enPin, rwPin drivers.Pin) Device {
 	return Device{
 		bus:      bus,
 		dcPin:    dcPin,
@@ -72,13 +71,6 @@ func (d *Device) Configure(cfg Config) {
 	if d.height > d.width {
 		d.bufferLength = d.height
 	}
-
-	// configure GPIO pins
-	d.dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.resetPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.enPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.rwPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
 
 	// reset the device
 	d.resetPin.High()

--- a/ssd1351/ssd1351_test.go
+++ b/ssd1351/ssd1351_test.go
@@ -1,0 +1,20 @@
+package ssd1351
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"tinygo.org/x/drivers/tester"
+)
+
+func TestDefaultSSD1351(t *testing.T) {
+	c := qt.New(t)
+	bus := tester.NewSPIBus(c)
+	pin1 := tester.NewPin(c)
+	pin2 := tester.NewPin(c)
+	pin3 := tester.NewPin(c)
+	pin4 := tester.NewPin(c)
+	pin5 := tester.NewPin(c)
+	dev := New(bus, pin1, pin2, pin3, pin4, pin5)
+	c.Assert(dev, qt.Not(qt.IsNil))
+}

--- a/st7735/st7735.go
+++ b/st7735/st7735.go
@@ -6,7 +6,6 @@ package st7735 // import "tinygo.org/x/drivers/st7735"
 
 import (
 	"image/color"
-	"machine"
 	"time"
 
 	"errors"
@@ -20,10 +19,10 @@ type Rotation uint8
 // Device wraps an SPI connection.
 type Device struct {
 	bus          drivers.SPI
-	dcPin        machine.Pin
-	resetPin     machine.Pin
-	csPin        machine.Pin
-	blPin        machine.Pin
+	dcPin        drivers.Pin
+	resetPin     drivers.Pin
+	csPin        drivers.Pin
+	blPin        drivers.Pin
 	width        int16
 	height       int16
 	columnOffset int16
@@ -46,11 +45,7 @@ type Config struct {
 }
 
 // New creates a new ST7735 connection. The SPI wire must already be configured.
-func New(bus drivers.SPI, resetPin, dcPin, csPin, blPin machine.Pin) Device {
-	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	resetPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	blPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+func New(bus drivers.SPI, resetPin, dcPin, csPin, blPin drivers.Pin) Device {
 	return Device{
 		bus:      bus,
 		dcPin:    dcPin,

--- a/st7735/st7735_test.go
+++ b/st7735/st7735_test.go
@@ -1,0 +1,19 @@
+package st7735
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"tinygo.org/x/drivers/tester"
+)
+
+func TestDefaultST7735(t *testing.T) {
+	c := qt.New(t)
+	bus := tester.NewSPIBus(c)
+	pin1 := tester.NewPin(c)
+	pin2 := tester.NewPin(c)
+	pin3 := tester.NewPin(c)
+	pin4 := tester.NewPin(c)
+	dev := New(bus, pin1, pin2, pin3, pin4)
+	c.Assert(dev, qt.Not(qt.IsNil))
+}

--- a/st7789/st7789.go
+++ b/st7789/st7789.go
@@ -7,7 +7,6 @@ package st7789 // import "tinygo.org/x/drivers/st7789"
 
 import (
 	"image/color"
-	"machine"
 	"math"
 	"time"
 
@@ -23,10 +22,10 @@ type FrameRate uint8
 // Device wraps an SPI connection.
 type Device struct {
 	bus             drivers.SPI
-	dcPin           machine.Pin
-	resetPin        machine.Pin
-	csPin           machine.Pin
-	blPin           machine.Pin
+	dcPin           drivers.Pin
+	resetPin        drivers.Pin
+	csPin           drivers.Pin
+	blPin           drivers.Pin
 	width           int16
 	height          int16
 	columnOffsetCfg int16
@@ -52,11 +51,7 @@ type Config struct {
 }
 
 // New creates a new ST7789 connection. The SPI wire must already be configured.
-func New(bus drivers.SPI, resetPin, dcPin, csPin, blPin machine.Pin) Device {
-	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	resetPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	blPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+func New(bus drivers.SPI, resetPin, dcPin, csPin, blPin drivers.Pin) Device {
 	return Device{
 		bus:      bus,
 		dcPin:    dcPin,

--- a/st7789/st7789_test.go
+++ b/st7789/st7789_test.go
@@ -1,0 +1,19 @@
+package st7789
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"tinygo.org/x/drivers/tester"
+)
+
+func TestDefaultST7735(t *testing.T) {
+	c := qt.New(t)
+	bus := tester.NewSPIBus(c)
+	pin1 := tester.NewPin(c)
+	pin2 := tester.NewPin(c)
+	pin3 := tester.NewPin(c)
+	pin4 := tester.NewPin(c)
+	dev := New(bus, pin1, pin2, pin3, pin4)
+	c.Assert(dev, qt.Not(qt.IsNil))
+}

--- a/tester/pin.go
+++ b/tester/pin.go
@@ -1,0 +1,30 @@
+package tester
+
+// Pin implements the Pin interface in memory for testing.
+type Pin struct {
+	c Failer
+}
+
+// NewPin returns an Pin mock Pin instance that uses c to flag errors
+// if they happen.
+func NewPin(c Failer) *Pin {
+	return &Pin{
+		c: c,
+	}
+}
+
+func (p *Pin) Get() bool {
+	return false
+}
+
+func (p *Pin) Set(v bool) {
+	return
+}
+
+func (p *Pin) High() {
+
+}
+
+func (p *Pin) Low() {
+
+}

--- a/tester/spi.go
+++ b/tester/spi.go
@@ -1,0 +1,26 @@
+package tester
+
+// SPIBus implements the SPI interface in memory for testing.
+type SPIBus struct {
+	c Failer
+	//devices []*I2CDevice
+}
+
+// NewSPIBus returns an SPIBus mock SPI instance that uses c to flag errors
+// if they happen. After creating a SPI instance, add devices
+// to it with addDevice before using NewSPIBus interface.
+func NewSPIBus(c Failer) *SPIBus {
+	return &SPIBus{
+		c: c,
+	}
+}
+
+// Tx is a mock implementation of Tx for testing.
+func (s *SPIBus) Tx(w, r []byte) error {
+	return nil
+}
+
+// Transfer is a mock implementation of Transfer for testing.
+func (s *SPIBus) Transfer(b byte) (byte, error) {
+	return 0, nil
+}

--- a/waveshare-epd/epd2in13/epd2in13.go
+++ b/waveshare-epd/epd2in13/epd2in13.go
@@ -7,7 +7,6 @@ package epd2in13 // import "tinygo.org/x/drivers/waveshare-epd/epd2in13"
 import (
 	"errors"
 	"image/color"
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers"
@@ -22,10 +21,10 @@ type Config struct {
 
 type Device struct {
 	bus          drivers.SPI
-	cs           machine.Pin
-	dc           machine.Pin
-	rst          machine.Pin
-	busy         machine.Pin
+	cs           drivers.Pin
+	dc           drivers.Pin
+	rst          drivers.Pin
+	busy         drivers.Pin
 	logicalWidth int16
 	width        int16
 	height       int16
@@ -53,11 +52,7 @@ var lutPartialUpdate = [30]uint8{
 }
 
 // New returns a new epd2in13x driver. Pass in a fully configured SPI bus.
-func New(bus drivers.SPI, csPin, dcPin, rstPin, busyPin machine.Pin) Device {
-	csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	rstPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	busyPin.Configure(machine.PinConfig{Mode: machine.PinInput})
+func New(bus drivers.SPI, csPin, dcPin, rstPin, busyPin drivers.Pin) Device {
 	return Device{
 		bus:  bus,
 		cs:   csPin,

--- a/waveshare-epd/epd2in13/epd2in13_test.go
+++ b/waveshare-epd/epd2in13/epd2in13_test.go
@@ -1,0 +1,19 @@
+package epd2in13
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"tinygo.org/x/drivers/tester"
+)
+
+func TestDefaultEPD2IN13(t *testing.T) {
+	c := qt.New(t)
+	bus := tester.NewSPIBus(c)
+	pin1 := tester.NewPin(c)
+	pin2 := tester.NewPin(c)
+	pin3 := tester.NewPin(c)
+	pin4 := tester.NewPin(c)
+	dev := New(bus, pin1, pin2, pin3, pin4)
+	c.Assert(dev, qt.Not(qt.IsNil))
+}

--- a/waveshare-epd/epd2in13x/edp2in13x_test.go
+++ b/waveshare-epd/epd2in13x/edp2in13x_test.go
@@ -1,0 +1,19 @@
+package epd2in13x
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"tinygo.org/x/drivers/tester"
+)
+
+func TestDefaultEPD2IN13X(t *testing.T) {
+	c := qt.New(t)
+	bus := tester.NewSPIBus(c)
+	pin1 := tester.NewPin(c)
+	pin2 := tester.NewPin(c)
+	pin3 := tester.NewPin(c)
+	pin4 := tester.NewPin(c)
+	dev := New(bus, pin1, pin2, pin3, pin4)
+	c.Assert(dev, qt.Not(qt.IsNil))
+}

--- a/waveshare-epd/epd2in13x/epd2in13x.go
+++ b/waveshare-epd/epd2in13x/epd2in13x.go
@@ -7,7 +7,6 @@ package epd2in13x // import "tinygo.org/x/drivers/waveshare-epd/epd2in13x"
 import (
 	"errors"
 	"image/color"
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers"
@@ -21,10 +20,10 @@ type Config struct {
 
 type Device struct {
 	bus          drivers.SPI
-	cs           machine.Pin
-	dc           machine.Pin
-	rst          machine.Pin
-	busy         machine.Pin
+	cs           drivers.Pin
+	dc           drivers.Pin
+	rst          drivers.Pin
+	busy         drivers.Pin
 	width        int16
 	height       int16
 	buffer       [][]uint8
@@ -34,11 +33,7 @@ type Device struct {
 type Color uint8
 
 // New returns a new epd2in13x driver. Pass in a fully configured SPI bus.
-func New(bus drivers.SPI, csPin, dcPin, rstPin, busyPin machine.Pin) Device {
-	csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	rstPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	busyPin.Configure(machine.PinConfig{Mode: machine.PinInput})
+func New(bus drivers.SPI, csPin, dcPin, rstPin, busyPin drivers.Pin) Device {
 	return Device{
 		bus:  bus,
 		cs:   csPin,

--- a/waveshare-epd/epd4in2/epd4in2.go
+++ b/waveshare-epd/epd4in2/epd4in2.go
@@ -10,7 +10,6 @@ package epd4in2
 
 import (
 	"image/color"
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers"
@@ -25,10 +24,10 @@ type Config struct {
 
 type Device struct {
 	bus          drivers.SPI
-	cs           machine.Pin
-	dc           machine.Pin
-	rst          machine.Pin
-	busy         machine.Pin
+	cs           drivers.Pin
+	dc           drivers.Pin
+	rst          drivers.Pin
+	busy         drivers.Pin
 	logicalWidth int16
 	width        int16
 	height       int16
@@ -40,11 +39,7 @@ type Device struct {
 type Rotation uint8
 
 // New returns a new epd4in2 driver. Pass in a fully configured SPI bus.
-func New(bus drivers.SPI, csPin, dcPin, rstPin, busyPin machine.Pin) Device {
-	csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	rstPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	busyPin.Configure(machine.PinConfig{Mode: machine.PinInput})
+func New(bus drivers.SPI, csPin, dcPin, rstPin, busyPin drivers.Pin) Device {
 	return Device{
 		bus:  bus,
 		cs:   csPin,

--- a/waveshare-epd/epd4in2/epd4in2_test.go
+++ b/waveshare-epd/epd4in2/epd4in2_test.go
@@ -1,0 +1,19 @@
+package epd4in2
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"tinygo.org/x/drivers/tester"
+)
+
+func TestDefaultEPD4IN2(t *testing.T) {
+	c := qt.New(t)
+	bus := tester.NewSPIBus(c)
+	pin1 := tester.NewPin(c)
+	pin2 := tester.NewPin(c)
+	pin3 := tester.NewPin(c)
+	pin4 := tester.NewPin(c)
+	dev := New(bus, pin1, pin2, pin3, pin4)
+	c.Assert(dev, qt.Not(qt.IsNil))
+}


### PR DESCRIPTION
This PR implements the `drivers.Pin` interface so that many drivers can remove another dependency on the machine package.

The following drivers however still use `machine.Pin` each for various reasons:

- HD44780
- ILI9341
- L293x
- L9110x
- MCP3008
- microbitmatrix
- shifter
- wifinina
- ws2812

Each of these will require some resolution or just leave them how they are.
 
The drivers that use the new pin interface each has a very rudimentary unit test in place to serve as a starting point for more complete testing of that driver.

The new `make unit-test` task run the units for all drivers except those that have dependencies on `machine`.