### PR TITLE
P1AM base controller driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,8 @@ smoke-test:
 	@md5sum ./build/test.hex
 	tinygo build -size short -o ./build/test.hex -target=itsybitsy-m0 ./examples/mpu6050/main.go
 	@md5sum ./build/test.hex
+	tinygo build -size short -o ./build/test.hex -target=p1am-100 ./examples/p1am/main.go
+	@md5sum ./build/test.hex
 	tinygo build -size short -o ./build/test.hex -target=microbit ./examples/pcd8544/setbuffer/main.go
 	@md5sum ./build/test.hex
 	tinygo build -size short -o ./build/test.hex -target=microbit ./examples/pcd8544/setpixel/main.go

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ endif
 DRIVERS = $(wildcard */)
 NOTESTS = build examples flash semihosting pcd8544 shiftregister st7789 microphone mcp3008 gps microbitmatrix \
 		hcsr04 ssd1331 ws2812 thermistor apa102 easystepper ssd1351 ili9341 wifinina shifter hub75 \
-		hd44780 buzzer ssd1306 espat l9110x st7735 bmi160 l293x dht keypad4x4 max72xx 
+		hd44780 buzzer ssd1306 espat l9110x st7735 bmi160 l293x dht keypad4x4 max72xx p1am
 TESTS = $(filter-out $(addsuffix /%,$(NOTESTS)),$(DRIVERS))
 
 unit-test:

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The following 58 devices are supported.
 | [Microphone - PDM](https://cdn-learn.adafruit.com/assets/assets/000/049/977/original/MP34DT01-M.pdf) | I2S/PDM |
 | [MMA8653 accelerometer](https://www.nxp.com/docs/en/data-sheet/MMA8653FC.pdf) | I2C |
 | [MPU6050 accelerometer/gyroscope](https://store.invensense.com/datasheets/invensense/MPU-6050_DataSheet_V3%204.pdf) | I2C |
+| [P1AM-100 Base Controller](https://facts-engineering.github.io/modules/P1AM-100/P1AM-100.html) | SPI |
 | [PCD8544 display](http://eia.udg.edu/~forest/PCD8544_1.pdf) | SPI |
 | [Resistive Touchscreen (4-wire)](http://ww1.microchip.com/downloads/en/Appnotes/doc8091.pdf) | GPIO |
 | [Semihosting](https://wiki.segger.com/Semihosting) | Debug |

--- a/examples/p1am/main.go
+++ b/examples/p1am/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"machine"
+	"time"
+
+	"tinygo.org/x/drivers/p1am"
+)
+
+func main() {
+	for {
+		if err := loop(); err != nil {
+			fmt.Printf("loop failed, retrying: %v\n", err)
+			time.Sleep(500 * time.Millisecond)
+		}
+	}
+}
+func loop() error {
+	led := machine.LED
+	led.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	sw := machine.SWITCH
+	sw.Configure(machine.PinConfig{Mode: machine.PinInput})
+
+	if err := p1am.Controller.Initialize(); err != nil {
+		return fmt.Errorf("initializing controller: %w", err)
+	}
+
+	version, err := p1am.Controller.Version()
+	if err != nil {
+		return fmt.Errorf("fetching base controller version: %w", err)
+	}
+	fmt.Printf("Base controller version: %d.%d.%d\n", version[0], version[1], version[2])
+
+	for i := 1; i <= p1am.Controller.Slots; i++ {
+		slot := p1am.Controller.Slot(i)
+		fmt.Printf("Slot %d: ID 0x%08x, Props %+v\n", i, slot.ID, slot.Props)
+	}
+
+	slot1 := p1am.Controller.Slot(1)
+	var lastInput uint32
+	state := sw.Get()
+	for {
+		if active, err := p1am.Controller.Active(); err != nil || !active {
+			return fmt.Errorf("controller active %v: %v", active, err)
+		}
+		if state != sw.Get() {
+			state = sw.Get()
+			fmt.Printf("New switch state: %v\n", state)
+			if slot1.Props.DO > 0 {
+				if err := slot1.Channel(1).WriteDiscrete(state); err != nil {
+					return err
+				}
+			}
+		}
+		if slot1.Props.DI > 0 {
+			sstate, err := slot1.ReadDiscrete()
+			if err != nil {
+				return fmt.Errorf("reading slot: %w", err)
+			}
+			if sstate != lastInput {
+				lastInput = sstate
+				fmt.Printf("new DI state: %#b\n", sstate)
+			}
+		}
+		if state {
+			led.High()
+		} else {
+			led.Low()
+		}
+		time.Sleep(time.Millisecond * 10)
+	}
+	return nil
+}

--- a/p1am/defines.go
+++ b/p1am/defines.go
@@ -1,0 +1,157 @@
+package p1am
+
+//go:generate go run ./internal/cmd/gen_defines
+
+type ModuleProps struct {
+	ModuleID                                 uint32
+	DI, DO, AI, AO, Status, Config, DataSize byte
+	Name                                     string
+}
+
+var modules = []ModuleProps{
+	//{0x000000ID,di,do,ai,ao,st,cf,ds}
+	{0x00000000, 0, 0, 0, 0, 0, 0, 0, "Empty"}, //Empty first entry for defaultgs
+
+	{0x04A00081, 1, 0, 0, 0, 0, 0, 1, "P1-08ND3"}, //P1-08ND3
+
+	{0x04A00085, 1, 0, 0, 0, 0, 0, 1, "P1-08NA"}, //P1-08NA
+
+	{0x04A00087, 1, 0, 0, 0, 0, 0, 1, "P1-08SIM"}, //P1-08SIM
+
+	{0x04A00088, 1, 0, 0, 0, 0, 0, 1, "P1-08NE3"}, //P1-08NE3
+
+	{0x05200082, 2, 0, 0, 0, 0, 0, 1, "P1-16ND3"}, //P1-16ND3
+
+	{0x05200089, 2, 0, 0, 0, 0, 0, 1, "P1-16NE3"}, //P1-16NE3
+
+	{0x1403F481, 0, 0, 0, 32, 4, 4, 0xA0, "P1-04PWM"}, //P1-04PWM
+
+	{0x1404008D, 0, 1, 0, 0, 0, 0, 1, "P1-08TA"}, //P1-08TA
+
+	{0x1404008F, 0, 1, 0, 0, 0, 0, 1, "P1-08TRS"}, //P1-08TRS
+
+	{0x14040091, 0, 2, 0, 0, 0, 0, 1, "P1-16TR"}, //P1-16TR
+
+	{0x14050081, 0, 1, 0, 0, 0, 0, 1, "P1-08TD1"}, //P1-08TD1
+
+	{0x14050082, 0, 1, 0, 0, 0, 0, 1, "P1-08TD2"}, //P1-08TD2
+
+	{0x14080085, 0, 2, 0, 0, 0, 0, 1, "P1-15TD1"}, //P1-15TD1
+
+	{0x14080086, 0, 2, 0, 0, 0, 0, 1, "P1-15TD2"}, //P1-15TD2
+
+	{0x24A50081, 1, 1, 0, 0, 0, 0, 1, "P1-16CDR"}, //P1-16CDR
+
+	{0x24A50082, 1, 1, 0, 0, 0, 0, 1, "P1-15CDD1"}, //P1-15CDD1
+
+	{0x24A50083, 1, 1, 0, 0, 0, 0, 1, "P1-15CDD2"}, //P1-15CDD2
+
+	{0x34605581, 0, 0, 16, 0, 12, 18, 16, "P1-04AD"}, //P1-04AD
+
+	{0x34605588, 0, 0, 16, 0, 12, 8, 16, "P1-04RTD"}, //P1-04RTD
+
+	{0x3460558F, 0, 0, 16, 0, 12, 2, 12, "P1-04ADL-1"}, //P1-04ADL-1
+
+	{0x34605590, 0, 0, 16, 0, 12, 2, 12, "P1-04ADL-2"}, //P1-04ADL-2
+
+	{0x34608C81, 0, 0, 16, 0, 12, 20, 32, "P1-04THM"}, //P1-04THM
+
+	{0x34608C8E, 0, 0, 16, 0, 12, 8, 32, "P1-04NTC"}, //P1-04NTC
+
+	{0x34A0558A, 0, 0, 32, 0, 12, 2, 12, "P1-08ADL-1"}, //P1-08ADL-1
+
+	{0x34A0558B, 0, 0, 32, 0, 12, 2, 12, "P1-08ADL-2"}, //P1-08ADL-2
+
+	{0x34A5A481, 2, 0, 36, 36, 4, 12, 0xC0, "P1-02HSC"}, //P1-02HSC
+
+	{0x44035583, 0, 0, 0, 16, 4, 0, 12, "P1-04DAL-1"}, //P1-04DAL-1
+
+	{0x44035584, 0, 0, 0, 16, 4, 0, 12, "P1-04DAL-2"}, //P1-04DAL-2
+
+	{0x44055588, 0, 0, 0, 32, 4, 0, 12, "P1-08DAL-1"}, //P1-08DAL-1
+
+	{0x44055589, 0, 0, 0, 32, 4, 0, 12, "P1-08DAL-2"}, //P1-08DAL-2
+
+	{0x5461A783, 0, 0, 16, 8, 12, 2, 12, "P1-4ADL2DAL-1"}, //P1-4ADL2DAL-1
+
+	{0x5461A784, 0, 0, 16, 8, 12, 2, 12, "P1-4ADL2DAL-2"}, //P1-4ADL2DAL-2
+
+	{0xFFFFFFFF, 0, 0, 0, 0, 0, 0, 0, "BAD SLOT"}, //empty in case no modules are defined.
+
+	{0x00000000, 0, 0, 0, 0, 0, 0, 0, "BAD SLOT"}, //empty in case no modules are defined.
+}
+
+var defaultConfig = map[uint32][]byte{
+	0x34605590:// P1_04ADL_2_DEFAULT_CONFIG
+	{0x40, 0x03},
+	0x34608C8E: // P1_04NTC_DEFAULT_CONFIG
+	{0x40, 0x03, 0x60, 0x05,
+		0x20, 0x00, 0x80, 0x02},
+	0x34608C81: // P1_04THM_DEFAULT_CONFIG
+	{0x40, 0x03, 0x60, 0x05,
+		0x21, 0x00, 0x22, 0x00,
+		0x23, 0x00, 0x24, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00},
+	0x34605588: // P1_04RTD_DEFAULT_CONFIG
+	{0x40, 0x03, 0x60, 0x05,
+		0x20, 0x01, 0x80, 0x00},
+	0x34605581: // P1_04AD_DEFAULT_CONFIG
+	{0x40, 0x03, 0x00, 0x00,
+		0x20, 0x03, 0x00, 0x00,
+		0x21, 0x03, 0x00, 0x00,
+		0x22, 0x03, 0x00, 0x00,
+		0x23, 0x03},
+	0x3460558F:// P1_04ADL_1_DEFAULT_CONFIG
+	{0x40, 0x03},
+	0x34A0558A:// P1_08ADL_1_DEFAULT_CONFIG
+	{0x40, 0x07},
+	0x34A0558B:// P1_08ADL_2_DEFAULT_CONFIG
+	{0x40, 0x07},
+	0x5461A783:// P1_04ADL2DAL_1_DEFAULT_CONFIG
+	{0x40, 0x03},
+	0x5461A784:// P1_04ADL2DAL_2_DEFAULT_CONFIG
+	{0x40, 0x03},
+	0x1403F481:// P1_04PWM_DEFAULT_CONFIG
+	{0x02, 0x02, 0x02, 0x02},
+	0x34A5A481: // P1_02HSC_DEFAULT_CONFIG
+	{0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01,
+		0x00, 0x00, 0x00, 0x01},
+}
+
+const NUMBER_OF_MODULES = 15 //Current max 15 Modules
+const SWITCH_BUILTIN = 31
+const baseEnable = 33
+const MOD_HDR = 0x02
+const VERSION_HDR = 0x03
+const ACTIVE_HDR = 0x04
+const DROPOUT_HDR = 0x05
+const CFG_HDR = 0x10
+const READ_CFG_HDR = 0x11
+const PETWD_HDR = 0x30
+const STARTWD_HDR = 0x31
+const STOPWD_HDR = 0x32
+const CONFIGWD_HDR = 0x33
+const READ_STATUS_HDR = 0x40
+const READ_DISCRETE_HDR = 0x50
+const READ_ANALOG_HDR = 0x51
+const READ_BLOCK_HDR = 0x52
+const WRITE_DISCRETE_HDR = 0x60
+const WRITE_ANALOG_HDR = 0x61
+const WRITE_BLOCK_HDR = 0x62
+const FW_UPDATE_HDR = 0xAA
+const DUMMY = 0xFF
+const EMPTY_SLOT_ID = 0xFFFFFFFE
+const MAX_TIMEOUT = 0xFFFFFFFF
+const DISCRETE_IN_BLOCK = 0
+const ANALOG_IN_BLOCK = 1
+const DISCRETE_OUT_BLOCK = 2
+const ANALOG_OUT_BLOCK = 3
+const STATUS_IN_BLOCK = 4
+const MISSING24V_STATUS = 3
+const BURNOUT_STATUS = 5
+const UNDER_RANGE_STATUS = 7
+const OVER_RANGE_STATUS = 11
+const TOGGLE = 0x01
+const HOLD = 0x00

--- a/p1am/internal/cmd/gen_defines/main.go
+++ b/p1am/internal/cmd/gen_defines/main.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"go/format"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"text/template"
+)
+
+var tmpl = template.Must(template.New("main").Parse(`package p1am
+
+//go:generate go run ./internal/cmd/gen_defines
+
+type ModuleProps struct {
+	ModuleID                                 uint32
+	DI, DO, AI, AO, Status, Config, DataSize byte
+	Name                                     string
+}
+
+var modules = []ModuleProps{
+{{.MDB -}}
+}
+
+var defaultConfig = map[uint32][]byte{
+	{{range .Configs -}}
+	0x{{.ID}}: // {{.Name}}
+	{{index $.DefaultConfigs .Name}},
+	{{end}}
+}
+
+{{range .Defines}}
+const {{.Name}} = {{.Value}}{{.Comment -}}
+{{end}}
+`))
+
+func findLibrary() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, dir := range []string{
+		"Documents/Arduino",
+		"Arduino",
+	} {
+		dir = filepath.Join(home, dir, "libraries/P1AM/src")
+		if _, err := os.Stat(dir); err == nil {
+			return dir
+		}
+	}
+	return ""
+}
+
+func definitions(path string, delim string) []string {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return strings.Split(string(data), delim)
+}
+
+var (
+	mdbRE    = regexp.MustCompile(`(?s)mdb\[\] = \{\s*(.+)\}`)
+	configRE = regexp.MustCompile(`(?s)const char (.*?)\[\] = (.+)`)
+	caseRE   = regexp.MustCompile(`(?s)case 0x([^:]+):\s+return \(char\*\)(.+)`)
+	defineRE = regexp.MustCompile(`(?ms)^\s*#define (\S+)\s+(\d+|0x[0-9a-fA-F]+)(\s+.*?)?\s*$`)
+)
+
+func main() {
+	base := findLibrary()
+	if base == "" {
+		log.Fatal("can't find Arduino library")
+	}
+	var data = struct {
+		MDB            string
+		DefaultConfigs map[string]string
+		Configs        []struct {
+			ID   string
+			Name string
+		}
+		Defines []struct {
+			Name    string
+			Value   string
+			Comment string
+		}
+	}{
+		DefaultConfigs: make(map[string]string),
+	}
+	for _, line := range definitions(filepath.Join(base, "Module_List.h"), ";") {
+		if matches := mdbRE.FindStringSubmatch(line); matches != nil {
+			data.MDB = regexp.MustCompile(`}\s*//`).ReplaceAllString(matches[1], `}, //`)
+		}
+		if matches := configRE.FindStringSubmatch(line); matches != nil {
+			data.DefaultConfigs[matches[1]] = matches[2]
+		}
+	}
+
+	for _, line := range definitions(filepath.Join(base, "P1AM.cpp"), ";") {
+		if matches := caseRE.FindStringSubmatch(line); matches != nil {
+			data.Configs = append(data.Configs, struct{ ID, Name string }{
+				ID:   matches[1],
+				Name: matches[2],
+			})
+		}
+	}
+
+	for _, line := range definitions(filepath.Join(base, "defines.h"), "\n") {
+		if matches := defineRE.FindStringSubmatch(line); matches != nil {
+			data.Defines = append(data.Defines, struct{ Name, Value, Comment string }{
+				Name:    matches[1],
+				Value:   matches[2],
+				Comment: matches[3],
+			})
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, &data); err != nil {
+		log.Fatal(err)
+	}
+	formatted, err := format.Source(buf.Bytes())
+	if err != nil {
+		log.Printf("failed to compile %s", buf.Bytes())
+		log.Fatal(err)
+	}
+	if err := ioutil.WriteFile("defines.go", formatted, 0666); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/p1am/p1am.go
+++ b/p1am/p1am.go
@@ -1,0 +1,286 @@
+// Driver for the P1AM-100 base controller.
+//
+// This is an embedded device on the P1AM-100 board.
+// Based on v1.0.1 of the Arduino library: https://github.com/facts-engineering/P1AM/tree/1.0.1
+
+package p1am
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"machine"
+	"time"
+)
+
+type P1AM struct {
+	bus                                        machine.SPI
+	slaveSelectPin, slaveAckPin, baseEnablePin machine.Pin
+
+	// SkipAutoConfig will skip loading a default configuration into each module.
+	SkipAutoConfig bool
+
+	Slots int
+	// Access slots via Slot()
+	slots []Slot
+}
+
+var Controller = P1AM{
+	bus:            machine.SPI0,
+	slaveSelectPin: machine.BASE_SLAVE_SELECT_PIN,
+	slaveAckPin:    machine.BASE_SLAVE_ACK_PIN,
+	baseEnablePin:  machine.BASE_ENABLE_PIN,
+}
+
+type baseSlotConstants struct {
+	DI, DO, AI, AO, Status, Config, DataSize byte
+}
+
+func (p *P1AM) Initialize() error {
+	p.slaveSelectPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	p.slaveAckPin.Configure(machine.PinConfig{Mode: machine.PinInput})
+	p.baseEnablePin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+
+	if err := p.bus.Configure(machine.SPIConfig{
+		Frequency: 1000000,
+		Mode:      2,
+		LSBFirst:  false,
+	}); err != nil {
+		return err
+	}
+
+	p.SetEnabled(true)
+	time.Sleep(100 * time.Millisecond)
+
+	if err := p.waitAck(5 * time.Second); err != nil {
+		return errors.New("no base controller activity; check external supply connection")
+	}
+
+	for i := 0; i < 5; i++ {
+		if err := p.handleHDR(MOD_HDR); err == nil {
+			time.Sleep(5 * time.Millisecond)
+			slots, err := p.spiSendRecvByte(0xFF)
+			if err == nil && slots > 0 && slots <= 15 {
+				p.Slots = int(slots)
+				break
+			}
+		}
+		if i > 2 {
+			// Try restarting the base controller
+			p.SetEnabled(false)
+			time.Sleep(10 * time.Millisecond)
+			p.SetEnabled(true)
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	if p.Slots <= 0 || p.Slots > 15 {
+		return errors.New("zero modules in the base")
+	}
+
+	moduleIDs := make([]uint32, p.Slots)
+
+	p.waitAck(200 * time.Millisecond)
+	if err := binary.Read(p, binary.LittleEndian, &moduleIDs); err != nil {
+		return err
+	}
+
+	baseConstants := make([]baseSlotConstants, p.Slots)
+	p.slots = make([]Slot, p.Slots)
+
+	for i := 1; i <= p.Slots; i++ {
+		slot := p.Slot(i)
+		slot.p = p
+		slot.slot = byte(i)
+		slot.ID = moduleIDs[i-1]
+		// What if 0xFFFFFFFF isn't at position -2?
+		slot.Props = &modules[len(modules)-2]
+		for j := 0; j < len(modules); j++ {
+			if modules[j].ModuleID == slot.ID {
+				slot.Props = &modules[j]
+			}
+			bc := &baseConstants[i-1]
+			bc.DI = slot.Props.DI
+			bc.DO = slot.Props.DO
+			bc.AI = slot.Props.AI
+			bc.AO = slot.Props.AO
+			bc.Status = slot.Props.Status
+			bc.Config = slot.Props.Config
+			bc.DataSize = slot.Props.DataSize
+		}
+	}
+
+	p.waitAck(200 * time.Millisecond)
+	if err := binary.Write(p, binary.LittleEndian, &baseConstants); err != nil {
+		return err
+	}
+
+	if !p.SkipAutoConfig {
+		for i := 1; i <= p.Slots; i++ {
+			s := p.Slot(i)
+			if s.Props.Config > 0 {
+				cfg := defaultConfig[s.ID]
+				if cfg != nil {
+					s.Configure(cfg)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (p *P1AM) Active() (bool, error) {
+	if _, err := p.spiSendRecvByte(ACTIVE_HDR); err != nil {
+		return false, err
+	}
+	if err := p.waitAck(200 * time.Millisecond); err != nil {
+		return false, err
+	}
+	buf, err := p.spiSendRecvByte(DUMMY)
+	defer p.dataSync()
+	return buf != 0, err
+}
+
+func (p *P1AM) Slot(i int) *Slot {
+	if i < 1 || i > p.Slots {
+		return nil
+	}
+	return &p.slots[i-1]
+}
+
+type Slot struct {
+	p    *P1AM
+	slot byte
+	ID   uint32
+	// TODO: Embed this?
+	Props *ModuleProps
+}
+
+func (s *Slot) Configure(data []byte) error {
+	if s == nil {
+		return errors.New("invalid slot")
+	}
+	if len(data) != int(s.Props.Config) {
+		return fmt.Errorf("expected %d config bytes, got %d", s.Props.Config, len(data))
+	}
+
+	if len(data) == 0 {
+		return errors.New("no config bytes")
+	}
+
+	out := make([]byte, len(data)+2)
+	out[0] = CFG_HDR
+	out[1] = s.slot
+	copy(out[2:], data)
+
+	if err := s.p.spiSendRecvBuf(out, nil); err != nil {
+		return err
+	}
+	time.Sleep(100 * time.Millisecond)
+	s.p.dataSync()
+	s.p.dataSync()
+	return nil
+}
+
+const ackTimeout = 200 * time.Millisecond
+
+func awaitPin(pin machine.Pin, state bool, timeout time.Duration) bool {
+	start := time.Now()
+	for pin.Get() != state {
+		time.Sleep(100 * time.Microsecond)
+		if time.Since(start) > timeout {
+			return false
+		}
+	}
+	return true
+	// TODO: Use channels when https://github.com/tinygo-org/tinygo/pull/1402 is merged.
+	// edge := machine.PinRising
+	// if state {
+	// 	edge = machine.PinFalling
+	// }
+	// ch := make(chan struct{}, 1)
+	// defer close(ch)
+	// pin.SetInterrupt(edge, func(machine.Pin) {
+	// 	ch <- struct{}{}
+	// })
+	// defer pin.SetInterrupt(0, nil)
+	// select {
+	// case <-ch:
+	// 	return true
+	// case <-time.After(timeout):
+	// 	return false
+	// }
+}
+
+var dataSyncErr = errors.New("base sync timeout")
+
+func (p *P1AM) dataSync() error {
+	if !awaitPin(p.slaveAckPin, true, ackTimeout) {
+		return dataSyncErr
+	}
+	time.Sleep(time.Microsecond)
+	if !awaitPin(p.slaveAckPin, false, ackTimeout) {
+		return dataSyncErr
+	}
+	time.Sleep(time.Microsecond)
+	if !awaitPin(p.slaveAckPin, true, ackTimeout) {
+		return dataSyncErr
+	}
+	time.Sleep(time.Microsecond)
+	return nil
+}
+
+func (p *P1AM) handleHDR(HDR byte) error {
+	for !p.slaveAckPin.Get() {
+	}
+	if _, err := p.spiSendRecvByte(HDR); err != nil {
+		return err
+	}
+	return p.spiTimeout(MAX_TIMEOUT*time.Millisecond, HDR, 2*time.Second)
+}
+
+func (p *P1AM) Read(data []byte) (int, error) {
+	return len(data), p.spiSendRecvBuf(nil, data)
+}
+
+func (p *P1AM) Write(data []byte) (int, error) {
+	return len(data), p.spiSendRecvBuf(data, nil)
+}
+
+func (p *P1AM) spiSendRecvBuf(w, r []byte) error {
+	p.slaveSelectPin.Low()
+	defer p.slaveSelectPin.High()
+	return p.bus.Tx(w, r)
+}
+
+func (p *P1AM) spiSendRecvByte(data byte) (byte, error) {
+	p.slaveSelectPin.Low()
+	defer p.slaveSelectPin.High()
+	return p.bus.Transfer(data)
+}
+
+func (p *P1AM) waitAck(timeout time.Duration) error {
+	return p.spiTimeout(timeout, 0, 0)
+}
+
+var timeoutErr = errors.New("timeout")
+
+func (p *P1AM) spiTimeout(timeout time.Duration, resendMsg byte, retryPeriod time.Duration) error {
+	end := time.Now().Add(timeout)
+	retry := time.Now().Add(retryPeriod)
+	for time.Now().Before(end) {
+		if p.slaveAckPin.Get() {
+			time.Sleep(50 * time.Microsecond)
+			return nil
+		}
+		if retryPeriod > 0 && time.Now().After(retry) {
+			p.spiSendRecvByte(resendMsg)
+			retry = retry.Add(retryPeriod)
+		}
+	}
+	return timeoutErr
+}
+
+func (p *P1AM) SetEnabled(enabled bool) {
+	p.baseEnablePin.Set(enabled)
+}

--- a/p1am/p1am.go
+++ b/p1am/p1am.go
@@ -129,6 +129,21 @@ func (p *P1AM) Initialize() error {
 	return nil
 }
 
+func (p *P1AM) Version() ([3]byte, error) {
+	if err := p.handleHDR(VERSION_HDR); err != nil {
+		return [3]byte{}, err
+	}
+	var buf [4]byte
+	if err := p.spiSendRecvBuf(nil, buf[:]); err != nil {
+		return [3]byte{}, err
+	}
+	return [3]byte{
+		byte(buf[1] >> 4),
+		byte(buf[1] & 0xF),
+		byte(buf[0]),
+	}, p.dataSync()
+}
+
 func (p *P1AM) Active() (bool, error) {
 	if _, err := p.spiSendRecvByte(ACTIVE_HDR); err != nil {
 		return false, err


### PR DESCRIPTION
This PR adds basic support for the P1AM base controller. This is an embedded peripheral that is present on the [P1AM-100 board](https://facts-engineering.github.io/modules/P1AM-100/P1AM-100.html). Since this is a built-in peripheral, there's no configuration available for what SPI port and pins to use, etc. I included an example program so you can see what the API is like. I don't have a full set of expansion modules, so I've only been able to test/implement digital I/O modules.