### PR TITLE
all: fix main package in examples

### DIFF
--- a/examples/hcsr04/main.go
+++ b/examples/hcsr04/main.go
@@ -1,4 +1,4 @@
-package hcsr04
+package main
 
 import (
 	"machine"

--- a/examples/ssd1331/main.go
+++ b/examples/ssd1331/main.go
@@ -1,4 +1,4 @@
-package ssd1331
+package main
 
 import (
 	"machine"

--- a/examples/ssd1351/main.go
+++ b/examples/ssd1351/main.go
@@ -1,4 +1,4 @@
-package ssd1351
+package main
 
 import (
 	"machine"


### PR DESCRIPTION
The package with the main function should always have the name main.
This was not the case in three packages.

This was silently allowed before, but since a TinyGo change
(https://github.com/tinygo-org/tinygo/pull/1592) this now results in a
linker failure.

Perhaps this should result in a better error message in TinyGo. However,
the example code also needs to be fixed, so hence this PR.