### PR TITLE
all: do not use machine.TWI_FREQ_* constants

### DIFF
--- a/examples/adt7410/main.go
+++ b/examples/adt7410/main.go
@@ -15,7 +15,7 @@ var (
 
 func main() {
 
-	i2c.Configure(machine.I2CConfig{Frequency: machine.TWI_FREQ_400KHZ})
+	i2c.Configure(machine.I2CConfig{Frequency: 400e3})
 	sensor.Configure()
 
 	for {

--- a/examples/hd44780i2c/main.go
+++ b/examples/hd44780i2c/main.go
@@ -14,7 +14,7 @@ func main() {
 	// use 3.3V (and may be damaged by 5V).
 
 	machine.I2C0.Configure(machine.I2CConfig{
-		Frequency: machine.TWI_FREQ_400KHZ,
+		Frequency: 400e3,
 	})
 
 	lcd := hd44780i2c.New(machine.I2C0, 0x27) // some modules have address 0x3F

--- a/examples/mcp23017-multiple/main.go
+++ b/examples/mcp23017-multiple/main.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	err := machine.I2C0.Configure(machine.I2CConfig{
-		Frequency: machine.TWI_FREQ_400KHZ,
+		Frequency: 400e3,
 	})
 	if err != nil {
 		panic(err)

--- a/examples/mcp23017/main.go
+++ b/examples/mcp23017/main.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 	err := machine.I2C0.Configure(machine.I2CConfig{
-		Frequency: machine.TWI_FREQ_400KHZ,
+		Frequency: 400e3,
 	})
 	if err != nil {
 		panic(err)

--- a/examples/ssd1306/i2c_128x32/main.go
+++ b/examples/ssd1306/i2c_128x32/main.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	machine.I2C0.Configure(machine.I2CConfig{
-		Frequency: machine.TWI_FREQ_400KHZ,
+		Frequency: 400e3,
 	})
 
 	display := ssd1306.NewI2C(machine.I2C0)

--- a/examples/tmp102/main.go
+++ b/examples/tmp102/main.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	machine.I2C0.Configure(machine.I2CConfig{
-		Frequency: machine.TWI_FREQ_400KHZ,
+		Frequency: 400e3,
 	})
 
 	thermo := tmp102.New(machine.I2C0)


### PR DESCRIPTION
These constants were always a bit weird:

  * they use an uncommon name (TWI instead of I2C)
  * they don't follow Go naming conventions (CamelCase)
  * the constants don't provide much value: their name is their value (100KHZ => 100e3).

Therefore, I propose we remove them and replace them with regular numeric constants. Also see https://github.com/tinygo-org/tinygo/pull/1617.