### PR TITLE
hd44780: add a mode to work with boards where the RW pin is grounded

### DIFF
--- a/hd44780/gpio.go
+++ b/hd44780/gpio.go
@@ -57,9 +57,16 @@ func (g *GPIO) SetCommandMode(set bool) {
 	}
 }
 
+// WriteOnly is true if you passed rw in as machine.NoPin
+func (g *GPIO) WriteOnly() bool {
+	return g.rw == machine.NoPin
+}
+
 // Write writes len(data) bytes from data to display driver
 func (g *GPIO) Write(data []byte) (n int, err error) {
-	g.rw.Low()
+	if !g.WriteOnly() {
+		g.rw.Low()
+	}
 	for _, d := range data {
 		g.write(d)
 		n++
@@ -88,6 +95,9 @@ func (g *GPIO) write4BitMode(data byte) {
 func (g *GPIO) Read(data []byte) (n int, err error) {
 	if len(data) == 0 {
 		return 0, errors.New("length greater than 0 is required")
+	}
+	if g.WriteOnly() {
+		return 0, errors.New("Read not supported if RW not wired")
 	}
 	g.rw.High()
 	g.reconfigureGPIOMode(machine.PinInput)


### PR DESCRIPTION
On some HD44780 boards (eg the Keyestudio LCD1602 expansion shield),
the RW pin isn't brought out and is permanently grounded.

This means that the board can't be read from, and in particular the
busy status can't be read.

This patch adapts the package to work with boards like these.

To signal this to the package, set the RW pin to machine.NoPin.

The package will then disallow all reading and use adjustable timing
based writing. The timing can be adjusted the configuration.
