### PR TITLE
all: do not take the pointer of an I2C object

### DIFF
--- a/examples/adt7410/main.go
+++ b/examples/adt7410/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	i2c    = &machine.I2C0
+	i2c    = machine.I2C0
 	sensor = adt7410.New(i2c)
 )
 

--- a/examples/gps/i2c/main.go
+++ b/examples/gps/i2c/main.go
@@ -10,7 +10,7 @@ import (
 func main() {
 	println("GPS I2C Example")
 	machine.I2C0.Configure(machine.I2CConfig{})
-	ublox := gps.NewI2C(&machine.I2C0)
+	ublox := gps.NewI2C(machine.I2C0)
 	parser := gps.NewParser()
 	var fix gps.Fix
 	for {


### PR DESCRIPTION
This is in preparation of PR https://github.com/tinygo-org/tinygo/pull/1693, which makes `machine.I2C0` and similar objects of pointer type, so they can be freely passed around.