### PR TITLE
all: use interfaces for UART objects

### DIFF
--- a/espat/espat.go
+++ b/espat/espat.go
@@ -20,17 +20,17 @@ package espat // import "tinygo.org/x/drivers/espat"
 
 import (
 	"errors"
-	"machine"
 	"strconv"
 	"strings"
 	"time"
 
+	"tinygo.org/x/drivers"
 	"tinygo.org/x/drivers/net"
 )
 
 // Device wraps UART connection to the ESP8266/ESP32.
 type Device struct {
-	bus machine.UART
+	bus drivers.UART
 
 	// command responses that come back from the ESP8266/ESP32
 	response []byte
@@ -43,7 +43,7 @@ type Device struct {
 var ActiveDevice *Device
 
 // New returns a new espat driver. Pass in a fully configured UART bus.
-func New(b machine.UART) *Device {
+func New(b drivers.UART) *Device {
 	return &Device{bus: b, response: make([]byte, 512), socketdata: make([]byte, 0, 1024)}
 }
 

--- a/gps/gps.go
+++ b/gps/gps.go
@@ -4,7 +4,6 @@ package gps // import "tinygo.org/x/drivers/gps"
 import (
 	"encoding/hex"
 	"errors"
-	"machine"
 	"strings"
 	"time"
 
@@ -21,13 +20,13 @@ type Device struct {
 	buffer   []byte
 	bufIdx   int
 	sentence strings.Builder
-	uart     *machine.UART
+	uart     drivers.UART
 	bus      drivers.I2C
 	address  uint16
 }
 
 // NewUART creates a new UART GPS connection. The UART must already be configured.
-func NewUART(uart *machine.UART) Device {
+func NewUART(uart drivers.UART) Device {
 	return Device{
 		uart:     uart,
 		buffer:   make([]byte, bufferSize),

--- a/uart.go
+++ b/uart.go
@@ -1,0 +1,12 @@
+package drivers
+
+import "io"
+
+// UART represents a UART connection. It is implemented by the machine.UART
+// type.
+type UART interface {
+	io.Reader
+	io.Writer
+
+	Buffered() int
+}


### PR DESCRIPTION
This makes it possible to replace UART objects with dummy implementations, for example. Or allows changing the `machine.UART` type to `*machine.UART` without breaking compatibility.

Similar to https://github.com/tinygo-org/drivers/pull/208 and https://github.com/tinygo-org/drivers/pull/193.