### PR TITLE
Option1: Mock with variable stride

### DIFF
--- a/adt7410/adt7410_test.go
+++ b/adt7410/adt7410_test.go
@@ -18,6 +18,7 @@ func TestWhoAmI(t *testing.T) {
 	c := qt.New(t)
 	bus := tester.NewI2CBus(c)
 	fake := tester.NewI2CDevice(c, Address)
+	fake.Configure(tester.I2CConfig{})
 	copy(fake.Registers[:], defaultRegisters())
 	bus.AddDevice(fake)
 

--- a/lis2mdl/lis2mdl_test.go
+++ b/lis2mdl/lis2mdl_test.go
@@ -18,6 +18,7 @@ func TestWhoAmI(t *testing.T) {
 	c := qt.New(t)
 	bus := tester.NewI2CBus(c)
 	fake := tester.NewI2CDevice(c, ADDRESS)
+	fake.Configure(tester.I2CConfig{})
 	copy(fake.Registers[:], defaultRegisters())
 	bus.AddDevice(fake)
 

--- a/mcp23017/device_test.go
+++ b/mcp23017/device_test.go
@@ -213,6 +213,7 @@ func TestInitWithError(t *testing.T) {
 
 func newDevice(bus *tester.I2CBus, addr uint8) *tester.I2CDevice {
 	fdev := bus.NewDevice(addr)
+	fdev.Configure(tester.I2CConfig{})
 	// IODIRA and IODIRB are all ones by default.
 	fdev.Registers[rIODIR] = 0xff
 	fdev.Registers[rIODIR|portB] = 0xff


### PR DESCRIPTION
Has a common i2c mock implementation, but allows configurable register sizes.