### PR TITLE
wifinina: avoid fmt dependency

### DIFF
--- a/examples/wifinina/connect/main.go
+++ b/examples/wifinina/connect/main.go
@@ -2,9 +2,8 @@
 package main
 
 import (
-	"encoding/binary"
-	"fmt"
 	"machine"
+	"strconv"
 	"time"
 
 	"tinygo.org/x/drivers/wifinina"
@@ -80,7 +79,7 @@ func printRSSI() {
 		println("Unknown (error: ", err.Error(), ")")
 		return
 	}
-	println(fmt.Sprintf("%d", rssi))
+	println(strconv.Itoa(int(rssi)))
 }
 
 func printIPs() {
@@ -113,20 +112,11 @@ func printTime() {
 
 func printMac() {
 	print("MAC: ")
-	b := make([]byte, 8)
 	mac, err := adaptor.GetMACAddress()
 	if err != nil {
 		println("Unknown (", err.Error(), ")")
 	}
-	binary.LittleEndian.PutUint64(b, uint64(mac))
-	macAddress := ""
-	for i := 5; i >= 0; i-- {
-		macAddress += fmt.Sprintf("%0X", b[i])
-		if i != 0 {
-			macAddress += ":"
-		}
-	}
-	println(macAddress)
+	println(mac.String())
 }
 
 // Wait for user to open serial console

--- a/wifinina/tcp.go
+++ b/wifinina/tcp.go
@@ -1,7 +1,7 @@
 package wifinina
 
 import (
-	"fmt"
+	"errors"
 	"strconv"
 	"time"
 
@@ -104,7 +104,7 @@ func (drv *Driver) connectSocket(addr, portStr string, mode uint8) error {
 func convertPort(portStr string) (uint16, error) {
 	p64, err := strconv.ParseUint(portStr, 10, 16)
 	if err != nil {
-		return 0, fmt.Errorf("could not convert port to uint16: %w", err)
+		return 0, errors.New("could not convert port to uint16: " + err.Error())
 	}
 	return uint16(p64), nil
 }
@@ -175,13 +175,13 @@ func (drv *Driver) Write(b []byte) (n int, err error) {
 	}
 	if drv.proto == ProtoModeUDP {
 		if err := drv.dev.StartClient("", drv.ip, drv.port, drv.sock, drv.proto); err != nil {
-			return 0, fmt.Errorf("error in startClient: %w", err)
+			return 0, errors.New("error in startClient: " + err.Error())
 		}
 		if _, err := drv.dev.InsertDataBuf(b, drv.sock); err != nil {
-			return 0, fmt.Errorf("error in insertDataBuf: %w", err)
+			return 0, errors.New("error in insertDataBuf: " + err.Error())
 		}
 		if _, err := drv.dev.SendUDPData(drv.sock); err != nil {
-			return 0, fmt.Errorf("error in sendUDPData: %w", err)
+			return 0, errors.New("error in sendUDPData: " + err.Error())
 		}
 		return len(b), nil
 	} else {


### PR DESCRIPTION
This avoids `fmt` package dependency in wifinina driver, that shrinks compiled flash size significantly.
`fmt` is still used for debug printouts yet happily optimised out by the compiler when debugging is disabled.

Backstory.
I've noticed my program is `70k` big on flash even after "z" optimisation.
According to `-size=full` output, `fmt` package was responsible for quite big chunk of that.
Odd, since I've specifically avoided `fmt` in my code.
Analysis shows `wifinina` depends on `fmt` and after eliminating this dependency, my code is `50k` now.

I had to use `strconv` to replace `fmt`, still the size decrease is significant.
Please tell if there's a better way to convert between bytes and string representation of bytes than `Itoa` and `Atoi`.

Example was updated too in this PR.

Some stats

Old example and old driver
```
tinygo build -target arduino-nano33 -size=full -o build.hex -opt=z .
   code  rodata    data     bss |   flash     ram | package
   ...
   9420     201       0       0 |    9621       0 | fmt
   ...
  55400       -    1384    4380 |   56784    5764 | (all)
```

New example and old driver
```
tinygo build -target arduino-nano33 -size=full -o build.hex -opt=z .
   code  rodata    data     bss |   flash     ram | package
   ...
   9440     201       0       0 |    9641       0 | fmt
   ...
  55496       -    1384    4380 |   56880    5764 | (all)
```

New example and new driver
```
tinygo build -target arduino-nano33 -size=full -o build.hex -opt=z .
   code  rodata    data     bss |   flash     ram | package
   ...
  30332       -    1360    4380 |   31692    5740 | (all)
```