### PR TITLE
WS2812: Disable interrupts before sending data

### DIFF
--- a/ws2812/ws2812_avr.go
+++ b/ws2812/ws2812_avr.go
@@ -7,6 +7,7 @@ package ws2812
 import (
 	"device/avr"
 	"machine"
+	"runtime/interrupt"
 )
 
 // Send a single byte using the WS2812 protocol.
@@ -17,6 +18,7 @@ func (d Device) WriteByte(c byte) error {
 	// Probably this is about pointer registers, which are very limited on AVR.
 	port, maskSet := d.Pin.PortMaskSet()
 	_, maskClear := d.Pin.PortMaskClear()
+	mask := interrupt.Disable()
 
 	switch machine.CPUFrequency() {
 	case 16e6: // 16MHz
@@ -51,8 +53,10 @@ func (d Device) WriteByte(c byte) error {
 			"maskClear": maskClear,
 			"portClear": port,
 		})
+		interrupt.Restore(mask)
 		return nil
 	default:
+		interrupt.Restore(mask)
 		return errUnknownClockSpeed
 	}
 }

--- a/ws2812/ws2812_m0_16m.go
+++ b/ws2812/ws2812_m0_16m.go
@@ -7,6 +7,7 @@ package ws2812
 
 import (
 	"device/arm"
+	"runtime/interrupt"
 )
 
 // Send a single byte using the WS2812 protocol.
@@ -14,6 +15,7 @@ func (d Device) WriteByte(c byte) error {
 	// For the Cortex-M0 at 16MHz
 	portSet, maskSet := d.Pin.PortMaskSet()
 	portClear, maskClear := d.Pin.PortMaskClear()
+	mask := interrupt.Disable()
 
 	// See:
 	// https://wp.josh.com/2014/05/13/ws2812-neopixels-are-not-so-finicky-once-you-get-to-know-them/
@@ -48,5 +50,6 @@ func (d Device) WriteByte(c byte) error {
 		"maskClear": maskClear,
 		"portClear": portClear,
 	})
+	interrupt.Restore(mask)
 	return nil
 }

--- a/ws2812/ws2812_m0_48m.go
+++ b/ws2812/ws2812_m0_48m.go
@@ -7,6 +7,7 @@ package ws2812
 
 import (
 	"device/arm"
+	"runtime/interrupt"
 )
 
 // Send a single byte using the WS2812 protocol.
@@ -14,6 +15,7 @@ func (d Device) WriteByte(c byte) error {
 	// For the Cortex-M0 at 48MHz
 	portSet, maskSet := d.Pin.PortMaskSet()
 	portClear, maskClear := d.Pin.PortMaskClear()
+	mask := interrupt.Disable()
 
 	// See:
 	// https://wp.josh.com/2014/05/13/ws2812-neopixels-are-not-so-finicky-once-you-get-to-know-them/
@@ -77,5 +79,6 @@ func (d Device) WriteByte(c byte) error {
 		"maskClear": maskClear,
 		"portClear": portClear,
 	})
+	interrupt.Restore(mask)
 	return nil
 }

--- a/ws2812/ws2812_m4_120m.go
+++ b/ws2812/ws2812_m4_120m.go
@@ -8,6 +8,7 @@ package ws2812
 
 import (
 	"device/arm"
+	"runtime/interrupt"
 )
 
 // Send a single byte using the WS2812 protocol.
@@ -15,6 +16,7 @@ func (d Device) WriteByte(c byte) error {
 	// For the Cortex-M4 at 120MHz
 	portSet, maskSet := d.Pin.PortMaskSet()
 	portClear, maskClear := d.Pin.PortMaskClear()
+	mask := interrupt.Disable()
 
 	// See:
 	// https://wp.josh.com/2014/05/13/ws2812-neopixels-are-not-so-finicky-once-you-get-to-know-them/
@@ -169,5 +171,6 @@ func (d Device) WriteByte(c byte) error {
 		"maskClear": maskClear,
 		"portClear": portClear,
 	})
+	interrupt.Restore(mask)
 	return nil
 }

--- a/ws2812/ws2812_m4_64m.go
+++ b/ws2812/ws2812_m4_64m.go
@@ -7,6 +7,7 @@ package ws2812
 
 import (
 	"device/arm"
+	"runtime/interrupt"
 )
 
 // Send a single byte using the WS2812 protocol.
@@ -14,6 +15,7 @@ func (d Device) WriteByte(c byte) error {
 	// For the Cortex-M4 at 64MHz
 	portSet, maskSet := d.Pin.PortMaskSet()
 	portClear, maskClear := d.Pin.PortMaskClear()
+	mask := interrupt.Disable()
 
 	// See:
 	// https://wp.josh.com/2014/05/13/ws2812-neopixels-are-not-so-finicky-once-you-get-to-know-them/
@@ -106,5 +108,6 @@ func (d Device) WriteByte(c byte) error {
 		"maskClear": maskClear,
 		"portClear": portClear,
 	})
+	interrupt.Restore(mask)
 	return nil
 }

--- a/ws2812/ws2812_xtensa.go
+++ b/ws2812/ws2812_xtensa.go
@@ -5,12 +5,14 @@ package ws2812
 import (
 	"device"
 	"machine"
+	"runtime/interrupt"
 	"unsafe"
 )
 
 func (d Device) WriteByte(c byte) error {
 	portSet, maskSet := d.Pin.PortMaskSet()
 	portClear, maskClear := d.Pin.PortMaskClear()
+	mask := interrupt.Disable()
 
 	switch machine.CPUFrequency() {
 	case 160e6: // 160MHz
@@ -220,6 +222,7 @@ func (d Device) WriteByte(c byte) error {
 			"maskClear": maskClear,
 			"portClear": uintptr(unsafe.Pointer(portClear)),
 		})
+		interrupt.Restore(mask)
 		return nil
 	case 80e6: // 80MHz
 		// See docs for 160MHz.
@@ -336,8 +339,10 @@ func (d Device) WriteByte(c byte) error {
 			"maskClear": maskClear,
 			"portClear": uintptr(unsafe.Pointer(portClear)),
 		})
+		interrupt.Restore(mask)
 		return nil
 	default:
+		interrupt.Restore(mask)
 		return errUnknownClockSpeed
 	}
 }


### PR DESCRIPTION
This PR disables interrupts on M0 and M4 processors before sending data to the WS2812. Interrupts are re-enabled after all data is sent.

Currently the WS2812 driver causes intermittent flashes on incorrect LEDs in the strip (tested on a Circuit Playground Express, and also reported by @ewwaller in this [issue](https://github.com/tinygo-org/drivers/issues/204)).

Disabling interrupts solved this problem on a Circuit Playground Express, but I am unable to test on other boards. Because @ewwaller also reported this issue and fix for an M4 board, I went ahead and added this code to all M0 and M4 processors. Also, the Adafruit NeoPixel Arduino library disables interrupts as well.