### PR TITLE
ws2812: add support for qtpy and atsame5x

### DIFF
--- a/examples/ws2812/arduino.go
+++ b/examples/ws2812/arduino.go
@@ -4,6 +4,7 @@ package main
 
 import "machine"
 
-// Replace neo in the code below to match the pin
+// Replace neo and led in the code below to match the pin
 // that you are using if different.
 var neo = machine.D2
+var led = machine.LED

--- a/examples/ws2812/digispark.go
+++ b/examples/ws2812/digispark.go
@@ -5,6 +5,7 @@ package main
 import "machine"
 
 // This is the pin assignment for the Digispark only.
-// Replace neo in the code below to match the pin
+// Replace neo and led in the code below to match the pin
 // that you are using if different.
 var neo machine.Pin = 0
+var led = machine.LED

--- a/examples/ws2812/main.go
+++ b/examples/ws2812/main.go
@@ -15,7 +15,6 @@ import (
 var leds [10]color.RGBA
 
 func main() {
-	led := machine.LED
 	led.Configure(machine.PinConfig{Mode: machine.PinOutput})
 
 	neo.Configure(machine.PinConfig{Mode: machine.PinOutput})

--- a/examples/ws2812/qtpy.go
+++ b/examples/ws2812/qtpy.go
@@ -1,4 +1,4 @@
-// +build !digispark,!arduino,!qtpy
+// +build qtpy
 
 package main
 
@@ -7,4 +7,10 @@ import "machine"
 // Replace neo and led in the code below to match the pin
 // that you are using if different.
 var neo machine.Pin = machine.NEOPIXELS
-var led = machine.LED
+var led = machine.NoPin
+
+func init() {
+	pwr := machine.NEOPIXELS_POWER
+	pwr.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	pwr.High()
+}

--- a/ws2812/ws2812_m4_120m.go
+++ b/ws2812/ws2812_m4_120m.go
@@ -1,4 +1,4 @@
-// +build atsamd51
+// +build atsamd51 atsame5x
 
 package ws2812
 


### PR DESCRIPTION
This PR allows qtpy and atsame5x to run examples/ws2812 without any changes.