### PR TITLE
ili9341: add standard SPI driver

### DIFF
--- a/examples/ili9341/pyportal_boing/main.go
+++ b/examples/ili9341/pyportal_boing/main.go
@@ -25,7 +25,7 @@ const (
 )
 
 var (
-	frameBuffer = [(graphics.BALLHEIGHT + 8) * (graphics.BALLWIDTH + 8)]uint16{}
+	frameBuffer = [(graphics.BALLHEIGHT + 8) * (graphics.BALLWIDTH + 8) * 2]uint8{}
 
 	startTime int64
 	frame     int64
@@ -179,7 +179,8 @@ func main() {
 						c = BGCOLOR
 					}
 				}
-				frameBuffer[y*int(width)+x] = c
+				frameBuffer[(y*int(width)+x)*2] = byte(c >> 8)
+				frameBuffer[(y*int(width)+x)*2+1] = byte(c)
 				bx1++ // Increment bitmap position counters (X axis)
 				bgx1++
 			}
@@ -190,7 +191,7 @@ func main() {
 			bgy++
 		}
 
-		display.DrawRGBBitmap(minx, miny, frameBuffer[:width*height], width, height)
+		display.DrawRGBBitmap8(minx, miny, frameBuffer[:width*height*2], width, height)
 
 		// Show approximate frame rate
 		frame++
@@ -215,11 +216,13 @@ func DrawBackground() {
 				b = graphics.Background[j*byteWidth+k/8]
 			}
 			if b&0x80 == 0 {
-				frameBuffer[k] = BGCOLOR
+				frameBuffer[2*k] = byte(BGCOLOR >> 8)
+				frameBuffer[2*k+1] = byte(BGCOLOR & 0xFF)
 			} else {
-				frameBuffer[k] = GRIDCOLOR
+				frameBuffer[2*k] = byte(GRIDCOLOR >> 8)
+				frameBuffer[2*k+1] = byte(GRIDCOLOR & 0xFF)
 			}
 		}
-		display.DrawRGBBitmap(0, j, frameBuffer[0:w], w, 1)
+		display.DrawRGBBitmap8(0, j, frameBuffer[0:w*2], w, 1)
 	}
 }

--- a/ili9341/ili9341.go
+++ b/ili9341/ili9341.go
@@ -160,6 +160,20 @@ func (d *Device) DrawRGBBitmap(x, y int16, data []uint16, w, h int16) error {
 	return nil
 }
 
+// DrawRGBBitmap8 copies an RGB bitmap to the internal buffer at given coordinates
+func (d *Device) DrawRGBBitmap8(x, y int16, data []uint8, w, h int16) error {
+	k, i := d.Size()
+	if x < 0 || y < 0 || w <= 0 || h <= 0 ||
+		x >= k || (x+w) > k || y >= i || (y+h) > i {
+		return errors.New("rectangle coordinates outside display area")
+	}
+	d.setWindow(x, y, w, h)
+	d.startWrite()
+	d.driver.write8sl(data)
+	d.endWrite()
+	return nil
+}
+
 // FillRectangle fills a rectangle at given coordinates with a color
 func (d *Device) FillRectangle(x, y, width, height int16, c color.RGBA) error {
 	k, i := d.Size()
@@ -300,7 +314,9 @@ func (d *Device) sendCommand(cmd byte, data []byte) {
 	d.dc.Low()
 	d.driver.write8(cmd)
 	d.dc.High()
-	d.driver.write8sl(data)
+	if data != nil {
+		d.driver.write8sl(data)
+	}
 	d.endWrite()
 }
 

--- a/ili9341/spi.go
+++ b/ili9341/spi.go
@@ -1,0 +1,71 @@
+// +build !atsamd51,!atsamd21
+
+package ili9341
+
+import (
+	"machine"
+)
+
+var buf [64]byte
+
+type spiDriver struct {
+	bus machine.SPI
+}
+
+func NewSPI(bus machine.SPI, dc, cs, rst machine.Pin) *Device {
+	return &Device{
+		dc:  dc,
+		cs:  cs,
+		rst: rst,
+		rd:  machine.NoPin,
+		driver: &spiDriver{
+			bus: bus,
+		},
+	}
+}
+
+func (pd *spiDriver) configure(config *Config) {
+}
+
+func (pd *spiDriver) write8(b byte) {
+	buf[0] = b
+	pd.bus.Tx(buf[:1], nil)
+}
+
+func (pd *spiDriver) write8n(b byte, n int) {
+	buf[0] = b
+	for i := 0; i < n; i++ {
+		pd.bus.Tx(buf[:1], nil)
+	}
+}
+
+func (pd *spiDriver) write8sl(b []byte) {
+	pd.bus.Tx(b, nil)
+}
+
+func (pd *spiDriver) write16(data uint16) {
+	buf[0] = uint8(data >> 8)
+	buf[1] = uint8(data)
+	pd.bus.Tx(buf[:2], nil)
+}
+
+func (pd *spiDriver) write16n(data uint16, n int) {
+	for i := 0; i < len(buf); i += 2 {
+		buf[i] = uint8(data >> 8)
+		buf[i+1] = uint8(data)
+	}
+
+	for i := 0; i < (n >> 5); i++ {
+		pd.bus.Tx(buf[:], nil)
+	}
+
+	pd.bus.Tx(buf[:n%64], nil)
+}
+
+func (pd *spiDriver) write16sl(data []uint16) {
+	for i, c := 0, len(data); i < c; i++ {
+		buf[0] = uint8(data[i] >> 8)
+		buf[1] = uint8(data[i])
+		pd.bus.Tx(buf[:2], nil)
+	}
+}


### PR DESCRIPTION
This PR adds a standard SPI driver for ili9341.
Unlike the approach in PR #242 , we tried to use the driver dedicated to each board if available.
For example, if there is no board-specific driver, such as the NRF52840, then the standard SPI driver is used.

The frame rate for `examples/ili9341/pyportal_boaring` is as follows

* specific driver
    * wioterminal (atsamd51)
        * 42 fps
* std-spi-driver
    * feather-nrf52840 (nrf52840)
        * 23 fps
    * feather-stm32f405 (stm32f405)
        * 30 fps

According to #196, the spi driver for stm32f405 seems to have a speed of 68 - 88 fps.
Once #196 is merged, the ili9341 on STM32F405 will run faster.
Until then, we can use the std-spi-driver.

* https://github.com/tinygo-org/drivers/pull/196#discussion_r487686223
