### PR TITLE
ws2812: add tag for nrf52833

### DIFF
--- a/ws2812/ws2812_m4_64m.go
+++ b/ws2812/ws2812_m4_64m.go
@@ -1,4 +1,4 @@
-// +build nrf52 nrf52840
+// +build nrf52 nrf52840 nrf52833
 
 package ws2812
 


### PR DESCRIPTION
This PR adds the tag for the nrf52833 processor to the ws2812 driver. This will close #254 