### PR TITLE
sdcard: add write functionality to examples/sdcard/tinyfs

### DIFF
--- a/examples/sdcard/tinyfs/console/console.go
+++ b/examples/sdcard/tinyfs/console/console.go
@@ -35,6 +35,7 @@ var (
 	commands = map[string]cmdfunc{
 		"":        noop,
 		"dbg":     dbg,
+		"help":    help,
 		"lsblk":   lsblk,
 		"mount":   mount,
 		"umount":  umount,
@@ -159,6 +160,28 @@ func runCommand(line string) {
 }
 
 func noop(argv []string) {}
+
+func help(argv []string) {
+	fmt.Printf("help\r\n")
+	fmt.Printf("  show help\r\n")
+	fmt.Printf("dbg\r\n")
+	fmt.Printf("  toggle debug mode\r\n")
+	fmt.Printf("xxd <hex address, ex: 0xA0> <size of hexdump in bytes>\r\n")
+	fmt.Printf("  hexdump the specified address\r\n")
+	fmt.Printf("ls <target file>\r\n")
+	fmt.Printf("  list information\r\n")
+	fmt.Printf("samples\r\n")
+	fmt.Printf("  write some files in the root directory\r\n")
+	fmt.Printf("mkdir <target dir>\r\n")
+	fmt.Printf("  create directory\r\n")
+	fmt.Printf("cat <target file>\r\n")
+	fmt.Printf("  print the contents of file\r\n")
+	fmt.Printf("create <target file>\r\n")
+	fmt.Printf("  create file\r\n")
+	fmt.Printf("write <target file>\r\n")
+	fmt.Printf("  write to file (press CTRL-D to exit)\r\n")
+	fmt.Printf("rm\r\n")
+}
 
 func dbg(argv []string) {
 	if debug {
@@ -421,7 +444,7 @@ func cat(argv []string) {
 		println("Trying to cat to " + tgt)
 	}
 	if tgt == "" {
-		println("Usage: cat <target dir>")
+		println("Usage: cat <target file>")
 		return
 	}
 	if debug {

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.15
 require (
 	github.com/eclipse/paho.mqtt.golang v1.2.0
 	github.com/frankban/quicktest v1.10.2
-	github.com/tinygo-org/tinyfs v0.0.0-20210514090915-924e60a7bcf8
+	github.com/tinygo-org/tinyfs v0.0.0-20210620184125-5b00ebcf68bb
 )

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/tinygo-org/tinyfs v0.0.0-20210514004344-b02c062d12c9 h1:66or7MohOph3x
 github.com/tinygo-org/tinyfs v0.0.0-20210514004344-b02c062d12c9/go.mod h1:HGuyo42bGd1zWSuS1gwgyyjN36ZZMlEpwM0vSrglmXc=
 github.com/tinygo-org/tinyfs v0.0.0-20210514090915-924e60a7bcf8 h1:pYwuKe1XuNeJnGV1UjeZ0FhuZ5+lapIq1NUmGacbBwo=
 github.com/tinygo-org/tinyfs v0.0.0-20210514090915-924e60a7bcf8/go.mod h1:HGuyo42bGd1zWSuS1gwgyyjN36ZZMlEpwM0vSrglmXc=
+github.com/tinygo-org/tinyfs v0.0.0-20210620184125-5b00ebcf68bb h1:lgwaY6CLUvZoH4DMwHn3vKjYRx6npRX1FwjWuJEpZao=
+github.com/tinygo-org/tinyfs v0.0.0-20210620184125-5b00ebcf68bb/go.mod h1:HGuyo42bGd1zWSuS1gwgyyjN36ZZMlEpwM0vSrglmXc=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 tinygo.org/x/drivers v0.16.0/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2aI=


### PR DESCRIPTION
Update tinyfs to add write functionality.

See :  https://github.com/tinygo-org/tinyfs/pull/5

I have also implemented the help command in examples/sdcard/tinyfs.
This change is not originally necessary, but I added it because I think the write command is confusing.