### PR TITLE
ws2812: rename the pin to ws2812

### DIFF
--- a/examples/ws2812/others.go
+++ b/examples/ws2812/others.go
@@ -6,5 +6,5 @@ import "machine"
 
 // Replace neo and led in the code below to match the pin
 // that you are using if different.
-var neo machine.Pin = machine.NEOPIXELS
+var neo machine.Pin = machine.WS2812
 var led = machine.LED


### PR DESCRIPTION
Changed the name of the pin from NEOPIXELS to WS2812.
This means that most boards with WS2812 can try examples without changing the source code.
I tried it with feather-nrf52840-sense, and it worked fine!

see.
https://github.com/tinygo-org/tinygo/pull/1940