### PR TITLE
modules: switch to use tinygo-org version of tinyfs package

### DIFF
--- a/examples/sdcard/tinyfs/console/console.go
+++ b/examples/sdcard/tinyfs/console/console.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tinygo-org/tinyfs"
+	"tinygo.org/x/tinyfs"
 )
 
 const consoleBufLen = 64

--- a/examples/sdcard/tinyfs/main.go
+++ b/examples/sdcard/tinyfs/main.go
@@ -5,9 +5,9 @@ import (
 	"machine"
 	"time"
 
-	"github.com/tinygo-org/tinyfs/fatfs"
 	"tinygo.org/x/drivers/examples/sdcard/tinyfs/console"
 	"tinygo.org/x/drivers/sdcard"
+	"tinygo.org/x/tinyfs/fatfs"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/eclipse/paho.mqtt.golang v1.2.0
 	github.com/frankban/quicktest v1.10.2
-	github.com/tinygo-org/tinyfs v0.0.0-20210620184125-5b00ebcf68bb
-	tinygo.org/x/tinyfont v0.2.1 // indirect
-	tinygo.org/x/tinyterm v0.1.0 // indirect
+	tinygo.org/x/tinyfont v0.2.1
+	tinygo.org/x/tinyfs v0.1.0
+	tinygo.org/x/tinyterm v0.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -10,12 +10,6 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/tinygo-org/tinyfs v0.0.0-20210514004344-b02c062d12c9 h1:66or7MohOph3xr3gMGCXceLkd+MBoUbV/rPPjl8iQOU=
-github.com/tinygo-org/tinyfs v0.0.0-20210514004344-b02c062d12c9/go.mod h1:HGuyo42bGd1zWSuS1gwgyyjN36ZZMlEpwM0vSrglmXc=
-github.com/tinygo-org/tinyfs v0.0.0-20210514090915-924e60a7bcf8 h1:pYwuKe1XuNeJnGV1UjeZ0FhuZ5+lapIq1NUmGacbBwo=
-github.com/tinygo-org/tinyfs v0.0.0-20210514090915-924e60a7bcf8/go.mod h1:HGuyo42bGd1zWSuS1gwgyyjN36ZZMlEpwM0vSrglmXc=
-github.com/tinygo-org/tinyfs v0.0.0-20210620184125-5b00ebcf68bb h1:lgwaY6CLUvZoH4DMwHn3vKjYRx6npRX1FwjWuJEpZao=
-github.com/tinygo-org/tinyfs v0.0.0-20210620184125-5b00ebcf68bb/go.mod h1:HGuyo42bGd1zWSuS1gwgyyjN36ZZMlEpwM0vSrglmXc=
 github.com/valyala/fastjson v1.6.3/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -24,5 +18,7 @@ tinygo.org/x/drivers v0.15.1/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2
 tinygo.org/x/drivers v0.16.0/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2aI=
 tinygo.org/x/tinyfont v0.2.1 h1:FAaemBzw8wsfhAtG6fWW+QjyWw/K8YqEeiWo4N1pv4o=
 tinygo.org/x/tinyfont v0.2.1/go.mod h1:eLqnYSrFRjt5STxWaMeOWJTzrKhXqpWw7nU3bPfKOAM=
+tinygo.org/x/tinyfs v0.1.0 h1:yx1Tq9L60rpCm6HURo45x+Tnag+O9RGSbQfgeCb6XYU=
+tinygo.org/x/tinyfs v0.1.0/go.mod h1:ysc8Y92iHfhTXeyEM9+c7zviUQ4fN9UCFgSOFfMWv20=
 tinygo.org/x/tinyterm v0.1.0 h1:80i+j+KWoxCFa/Xfp6pWbh79x+8zUdMXC1vaKj2QhkY=
 tinygo.org/x/tinyterm v0.1.0/go.mod h1:/DDhNnGwNF2/tNgHywvyZuCGnbH3ov49Z/6e8LPLRR4=


### PR DESCRIPTION
This PR switches to use the tinygo-org version of the tinyfs package, as discussed in https://github.com/tinygo-org/tinyfs/issues/7#issuecomment-868954816