### PR TITLE
add first revision of new ENC28J60 driver

### DIFF
--- a/datagrammer.go
+++ b/datagrammer.go
@@ -1,0 +1,36 @@
+package drivers
+
+import (
+	"io"
+	"time"
+)
+
+// Datagrammer represents a reader/writer of data packets received over stream.
+// These packets are low level representations of what could be an Ethernet/IP/TCP transaction.
+// An example of an IC which implements this is the ENC28J60.
+type Datagrammer interface {
+	PacketWriter
+	PacketReader
+}
+
+// Packet represents a handle to a packet in an underlying stream of data.
+type Packet interface {
+	io.Reader
+	// Discard discards packet data. Reader is terminated as well.
+	// If reader already terminated then it should have no effect.
+	Discard() error
+}
+
+// PacketReader returns a handle to a packet. Ideally there should be no more
+// than one active handle at a time.
+type PacketReader interface {
+	// Returns a Reader that reads from the next packet.
+	NextPacket(deadline time.Time) (Packet, error)
+}
+
+// PacketWriter handles writes to buffer. Writes are not sent over stream until Flush is called.
+type PacketWriter interface {
+	io.Writer
+	// Flush writes buffer to the underlying stream.
+	Flush() error
+}

--- a/enc28j60/README.md
+++ b/enc28j60/README.md
@@ -1,0 +1,12 @@
+# Golang implementation of ENC28J60 IC
+
+See [pkg.go.dev](https://pkg.go.dev/tinygo.org/x/drivers) for more information
+## Writing this library
+
+When porting an arduino library, it might be of use to know some of the similarities between two languages.
+
+| C++       | Go |
+|----       |-----|
+| `uint8_t` | `byte` or `uint8` |
+| `*uint8_t`| `[]byte` or `[]uint8` |
+

--- a/enc28j60/conn.go
+++ b/enc28j60/conn.go
@@ -3,8 +3,6 @@ package enc28j60
 import (
 	"io"
 	"time"
-
-	swtch "github.com/soypat/ether-swtch"
 )
 
 // packet implements the Reader interface from ether-swtch library for datagram parsing.
@@ -17,7 +15,7 @@ type packet struct {
 // NextPacket returns a Packet which reads data from the
 // next packet in the FIFO queue. When one is done reading packet data, call
 // Discard on said packet and NextPacket will return the next packet in the FIFO.
-func (d *Dev) NextPacket(deadline time.Time) (swtch.Reader, error) {
+func (d *Dev) NextPacket(deadline time.Time) (io.Reader, error) {
 	// first we discard the current packet if not already discarded:
 	dbp("NextPacket")
 	if d.rx.cursor != d.rx.end {
@@ -65,7 +63,7 @@ func (p *packet) Discard() error {
 
 // Read reads packet data into buffer returning the amound
 // of data read. io.EOF is returned when done with the packet.
-func (p *packet) Read(buff []byte) (n uint16, err error) {
+func (p *packet) Read(buff []byte) (n int, err error) {
 	dbp("ReadPacket")
 	// total remaining packet length
 	plen := p.end - p.cursor
@@ -89,7 +87,7 @@ func (p *packet) Read(buff []byte) (n uint16, err error) {
 		p.ic.writeOp(BIT_FIELD_SET, ECON2, ECON2_PKTDEC)
 		err = io.EOF
 	}
-	return plen, err
+	return int(plen), err
 }
 
 // Write writes data into ENC28J60's TX buffer. Data must not exceed the buffer bounds or

--- a/enc28j60/conn.go
+++ b/enc28j60/conn.go
@@ -1,0 +1,121 @@
+package enc28j60
+
+import (
+	"io"
+	"time"
+
+	swtch "github.com/soypat/ether-swtch"
+)
+
+type Packet struct {
+	ic     *Dev
+	cursor uint16
+	end    uint16
+}
+
+// NextPacket returns a Packet which reads data from the
+// next packet in the FIFO queue. When one is done reading packet data, call
+// Discard on said packet and NextPacket will return the next packet in the FIFO.
+func (d *Dev) NextPacket() (swtch.Reader, error) {
+	dbp("NextPacket")
+	var err error
+	for d.read(EPKTCNT) == 0 { // loop until a packet is received.
+		time.Sleep(time.Millisecond)
+	}
+	p := &Packet{ic: d} // Weird bug when creating Packet before read loop. LLVM on AVR is buggy and ic will be nil afterwards.
+	// Set the read pointer to the start of the next packet
+	d.write16(ERDPTL, d.nextPacketPtr)
+	p.cursor = d.nextPacketPtr // Packet reader
+
+	d.readBuffer(d.buf[:])
+	d.nextPacketPtr = uint16(d.buf[0]) + uint16(d.buf[1])<<8
+	// read the packet length (see datasheet page 43)
+	plen := uint16(d.buf[2]) + uint16(d.buf[3])<<8 - 4 //remove the CRC count (minus 4)
+	p.end = p.cursor + plen
+	// read the receive status (see datasheet page 43)
+	rxstat := uint16(d.buf[4]) + uint16(d.buf[5])<<8
+	// check CRC and symbol errors (see datasheet page 44, table 7-3):
+	// The ERXFCON.CRCEN is set by default. Normally we should not
+	// need to check this.
+	if (rxstat & 0x80) == 0 {
+		err = ErrCRC
+	}
+	return p, err
+}
+
+// Discard drops the remaining packet data to be read. Any subsequent call
+// to Read will return io.EOF error. This implements ether-swtch's Reader interface.
+func (p *Packet) Discard() error {
+	dbp("DiscardPacket")
+	if p.cursor != p.end {
+		p.cursor = p.end
+		p.ic.writeOp(BIT_FIELD_SET, ECON2, ECON2_PKTDEC)
+	}
+	return nil
+}
+
+// Read reads packet data into buffer returning the amound
+// of data read. io.EOF is returned when done with the packet.
+func (p *Packet) Read(buff []byte) (n uint16, err error) {
+	dbp("ReadPacket")
+	// total remaining packet length
+	plen := p.end - p.cursor
+	if plen == 0 {
+		return 0, io.EOF
+	}
+	if len(buff) == 0 {
+		return 0, nil
+	}
+	// Limit retreive length if Total packet length is greater than buffer length
+	if plen > uint16(len(buff)) {
+		plen = uint16(len(buff))
+	}
+	// copy the packet from the receive buffer
+	p.ic.readBuffer(buff[:plen])
+	p.cursor += plen
+	// Move the RX read pointer to where we ended reading
+	p.ic.write16(ERXRDPTL, p.cursor)
+	if p.cursor == p.end { // minus CRC length
+		// decrement packet counter to indicate we are done with it.
+		p.ic.writeOp(BIT_FIELD_SET, ECON2, ECON2_PKTDEC)
+		err = io.EOF
+	}
+	return plen, err
+}
+
+// Write writes data into ENC28J60's TX buffer. Data must not exceed the buffer bounds or
+// ErrBufferSize will be returned. Use Flush method to send data over network once
+// finished writing.
+func (d *Dev) Write(buff []byte) (uint16, error) {
+	plen := uint16(len(buff))
+	if plen+d.tcursor > MAX_FRAMELEN {
+		d.tcursor = 0
+		return 0, ErrBufferSize
+	}
+
+	d.write16(EWRPTL, TXSTART_INIT+d.tcursor)
+	if d.tcursor == 0 {
+		// write per-packet control byte (0x00 means use macon3 settings)
+		d.writeOp(WRITE_BUF_MEM, 0, 0x00)
+		d.tcursor++ // WBM spurious increment
+	}
+	// copy the packet into the transmit buffer
+	d.writeBuffer(buff)
+	d.tcursor += plen
+	return plen, nil
+}
+
+// Flush sends the data written to the TX buffer with Write over the network
+// as a packet. Aftyer flush ENC28J60 is ready to start writing a new packet.
+func (d *Dev) Flush() error {
+	dbp("send response")
+	d.write16(ETXNDL, TXSTART_INIT+d.tcursor-1) // subtract WBM spurious increment
+	// send the contents of the transmit buffer onto the network
+	d.writeOp(BIT_FIELD_SET, ECON1, ECON1_TXRTS)
+	// Reset the transmit logic problem. See Rev. B4 Silicon Errata point 12.
+	if d.read(EIR)&EIR_TXERIF != 0 {
+		d.writeOp(BIT_FIELD_CLR, ECON1, ECON1_TXRTS)
+	}
+	d.tcursor = 0
+	return nil
+}

--- a/enc28j60/conn.go
+++ b/enc28j60/conn.go
@@ -7,7 +7,8 @@ import (
 	swtch "github.com/soypat/ether-swtch"
 )
 
-type Packet struct {
+// packet implements the Reader interface from ether-swtch library for datagram parsing.
+type packet struct {
 	ic     *Dev
 	cursor uint16
 	end    uint16
@@ -53,7 +54,7 @@ func (d *Dev) NextPacket(deadline time.Time) (swtch.Reader, error) {
 
 // Discard drops the remaining packet data to be read. Any subsequent call
 // to Read will return io.EOF error. This implements ether-swtch's Reader interface.
-func (p *Packet) Discard() error {
+func (p *packet) Discard() error {
 	dbp("DiscardPacket")
 	if p.cursor != p.end {
 		p.cursor = p.end
@@ -64,7 +65,7 @@ func (p *Packet) Discard() error {
 
 // Read reads packet data into buffer returning the amound
 // of data read. io.EOF is returned when done with the packet.
-func (p *Packet) Read(buff []byte) (n uint16, err error) {
+func (p *packet) Read(buff []byte) (n uint16, err error) {
 	dbp("ReadPacket")
 	// total remaining packet length
 	plen := p.end - p.cursor

--- a/enc28j60/conn.go
+++ b/enc28j60/conn.go
@@ -25,7 +25,8 @@ func (d *Dev) NextPacket(deadline time.Time) (swtch.Reader, error) {
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	p := &Packet{ic: d} // Weird bug when creating Packet before read loop. LLVM on AVR is buggy and ic will be nil afterwards.
+	// p := &Packet{ic: d} // Weird bug when creating Packet before read loop. LLVM on AVR is buggy and ic will be nil afterwards.
+	p := &d.rx
 	// Set the read pointer to the start of the next packet
 	d.write16(ERDPTL, d.nextPacketPtr)
 	p.cursor = d.nextPacketPtr // Packet reader

--- a/enc28j60/conn.go
+++ b/enc28j60/conn.go
@@ -17,7 +17,11 @@ type Packet struct {
 // next packet in the FIFO queue. When one is done reading packet data, call
 // Discard on said packet and NextPacket will return the next packet in the FIFO.
 func (d *Dev) NextPacket(deadline time.Time) (swtch.Reader, error) {
+	// first we discard the current packet if not already discarded:
 	dbp("NextPacket")
+	if d.rx.cursor != d.rx.end {
+		d.rx.Discard()
+	}
 	var err error
 	for d.read(EPKTCNT) == 0 { // loop until a packet is received.
 		if time.Since(deadline) > 0 {

--- a/enc28j60/doc.go
+++ b/enc28j60/doc.go
@@ -1,0 +1,76 @@
+/*
+Package enc28j60 Based on the enc28j60.c file by Guido Socher.
+Original file can be found at https://github.com/muanis/arduino-projects under
+libraries/etherShield/*
+
+Device information
+
+This device communicates with its host through SPI
+by means of a CS (active low) with a clock speed of up to
+20 MHz. The IC takes care of several things, mainly at
+the Data Link layer (layer 2) such as the first 8 bytes of
+the ethernet packet containing the preamble and start-of-frame,
+these are generated for outgoing buffer and removed from the
+incoming buffer (section 5.1.1).
+It also implements CRC sum and can verify incoming packets
+and reject faulty ones. It can also generate them for outgoing
+packets.
+
+Layer 2 Overview
+
+The Host (microcontroller) is responsible for writing the desired
+destination address into the transmit buffer (5.1.2). Users of the ENC
+must generate a MAC address to populate the source address field. The
+first three bytes are the OUI and are distributed by IEEE. The Host
+is responsible for writing the source address too (5.1.3).
+
+The type field specifies the protocol (ARP | IP) or may be treated
+as an application specific field for proprietary networks (5.1.4).
+
+The data field is variable length (0 to 1500 bytes). Larger packets may be dropped by nodes (5.1.5).
+
+The padding field is used for small payloads to meet IEEE requirements. An Ethernet packet
+must be no smaller than 60 bytes (64 counting the CRC sum). The host must
+generate padding as the IC will not add padding to the packet before transmitting. (5.1.6)
+
+The IC will check CRC of incoming packets. Packets with invalid CRC will automatically be
+discarded if ERXFCON.CRCEN is set. Host can also determine if recieved packets are valid
+by reading the recieve status vector (see section 7.2). CRC sum field generation by IC
+is set by default and so should not have to be filled in by Host (5.1.7)
+
+Network frame diagrams
+
+The following sections will detail Layer 2 and layer 3 protocol frames
+which are implmented in this code.
+
+Ethernet frame
+
+Diagram:
+	0        6        7         13         19        21
+	| 7 bytes  | 1 byte |  6 bytes |  6 bytes | 2 bytes | 46-1500 bytes /.../ | 4 bytes   |
+	| Preamble | SFD    | Dst Addr | Src Addr | Type    | PAYLOAD       /.../ | FCS (CRC) |
+
+the enc28j60 takes care of the preamble and the SFD. It is by default configured to take care
+of the FCS too.
+
+ARP Payload Frame
+
+Address resolution protocol. See https://www.youtube.com/watch?v=aamG4-tH_m8
+
+Legend:
+	HW:    Hardware
+	AT:    Address type
+	AL:    Address Length
+	AoS:   Address of sender
+	AoT:   Address of Target
+	Proto: Protocol
+
+Diagram:
+	0      2          4       5          6         8       14          18       24          28
+	| HW AT | Proto AT | HW AL | Proto AL | OP Code | HW AoS | Proto AoS | HW AoT | Proto AoT |
+	|  2B   |  2B      |  1B   |  1B      | 2B      |   6B   |    4B     |  6B    |   4B      |
+	| ethern| IP       |macaddr|          |ask|reply|        |           |for op=1|           |
+	| = 1   |=0x0800   |=6     |=4        | 1 | 2   |       known        |=0      |    known  |
+
+*/
+package enc28j60

--- a/enc28j60/enc28j60.go
+++ b/enc28j60/enc28j60.go
@@ -22,6 +22,7 @@ type Dev struct {
 	is interrupt.State
 	// Bank saves last memory bank accessed by read/write ops.
 	Bank uint8
+	rx   Packet
 	// Houses ERDPTL register data pointing to next packet position in buffer.
 	nextPacketPtr uint16
 	// tcursor points to the current octet in the TX buffer.
@@ -49,6 +50,7 @@ func (d *Dev) Init(macaddr []byte) error {
 	if len(macaddr) != 6 {
 		return ErrBadMac
 	}
+	d.rx.ic = d
 	d.macaddr = macaddr
 	dbp("cfg call w/mac:", macaddr)
 	d.configure(macaddr)

--- a/enc28j60/enc28j60.go
+++ b/enc28j60/enc28j60.go
@@ -1,0 +1,238 @@
+package enc28j60
+
+import (
+	"machine"
+	"runtime/interrupt"
+
+	"github.com/soypat/net"
+
+	"time"
+
+	"tinygo.org/x/drivers"
+)
+
+// Dev provides data and logic to interact witrh an ENC28J60
+// integrated circuit. After creating this device with New, use
+// Init method to initialize registers. After Init is called this
+// device is ready to read and write to the network.
+type Dev struct {
+	// Chip select pin
+	CSB machine.Pin
+	// interrupt state
+	is interrupt.State
+	// Bank saves last memory bank accessed by read/write ops.
+	Bank uint8
+	// Houses ERDPTL register data pointing to next packet position in buffer.
+	nextPacketPtr uint16
+	// tcursor points to the current octet in the TX buffer.
+	tcursor uint16
+	// buf is a small buffer for small SPI packets like read/write command bytes and reading the Receive status vector.
+	// Helps save space and speeds up IO.
+	buf [6]byte
+	// MAC address is the physical address of this device.
+	macaddr net.HardwareAddr
+	// SPI bus (requires chip select to be usable).
+	bus drivers.SPI
+}
+
+// NewSPI returns a new device driver. The SPI is configured in this call
+func New(csb machine.Pin, spi drivers.SPI) *Dev {
+	return &Dev{
+		CSB:  csb, // chip select
+		bus:  spi,
+		Bank: 255, // bad bank so as to force bank set on first read
+	}
+}
+
+// Init initializes device for use and configures the enc28j60's registries.
+func (d *Dev) Init(macaddr []byte) error {
+	if len(macaddr) != 6 {
+		return ErrBadMac
+	}
+	d.macaddr = macaddr
+	dbp("cfg call w/mac:", macaddr)
+	d.configure(macaddr)
+	if d.GetRev() == 0 {
+		return ErrBadRev
+	}
+	return nil
+}
+
+// ResetChip performs a soft reset of the ENC28J60 device
+// restoring most registers to default values.
+func (d *Dev) ResetChip() {
+	d.enableCS()
+	d.Bank = 255
+	d.bus.Tx([]byte{SOFT_RESET}, nil)
+	d.disableCS()
+}
+
+func (d *Dev) clkOut(clk uint8) {
+	//setup clkout: 2 is 12.5MHz:
+	d.write(ECOCON, clk&0x7)
+}
+
+// configure mac address and RX/TX/other buffer registers.
+func (d *Dev) configure(macaddr []byte) {
+	d.ResetChip()
+	time.Sleep(50 * time.Millisecond)
+
+	// check CLKRDY bit to see if reset is complete
+	// The CLKRDY does not work. See Rev. B4 Silicon Errata point. Just wait.
+	// for d.readOp(READ_CTL_REG, ESTAT)&ESTAT_CLKRDY == 0 {
+	// }
+
+	// bank 0 stuff
+	// initialize receive buffer
+	// 16-bit transfers, must write low byte first
+	// set receive buffer start address
+	// NextPacketPtr = RXSTART_INIT
+	// Rx start at 0
+	d.write(ERXSTL, RXSTART_INIT&0xFF)
+	d.write(ERXSTH, RXSTART_INIT>>8)
+	// set receive pointer address (should be programmed with same value, see 6.1)
+	// Thus, these lines prevent the read buffer from filling up before
+	// PacketRecieve is called
+	d.write(ERXRDPTL, RXSTART_INIT&0xFF)
+	d.write(ERXRDPTH, RXSTART_INIT>>8)
+	// RX end at 6654
+	d.write(ERXNDL, RXSTOP_INIT&0xFF)
+	d.write(ERXNDH, RXSTOP_INIT>>8)
+	// TX start at 6655
+	d.write(ETXSTL, TXSTART_INIT&0xFF)
+	d.write(ETXSTH, TXSTART_INIT>>8)
+	// TX end at 8191 (must leave space for [tsv] Status vector of length 48 which is appended to TX packet)
+	d.write(ETXNDL, TXSTOP_INIT&0xFF)
+	d.write(ETXNDH, TXSTOP_INIT>>8)
+	// do bank 1 stuff, packet filter:
+	// For broadcast packets we allow only ARP packtets
+	// All other packets should be unicast only for our mac (MAADR)
+	//
+	// The pattern to match on is therefore
+	// Type     ETH.DST
+	// ARP      BROADCAST
+	// 06 08 -- ff ff ff ff ff ff -> ip checksum for theses bytes=f7f9
+	// in binary these poitions are:11 0000 0011 1111
+	// This is hex 303F->EPMM0=0x3f,EPMM1=0x30
+	d.write(ERXFCON, ERXFCON_UCEN|ERXFCON_CRCEN|ERXFCON_PMEN)
+	d.write(EPMM0, 0x3f)
+	d.write(EPMM1, 0x30)
+	d.write(EPMCSL, 0xf9)
+	d.write(EPMCSH, 0xf7)
+
+	// do bank 2 stuff
+	// enable MAC receive frame (see 6.5 bullet 1)
+	d.write(MACON1, MACON1_MARXEN|MACON1_TXPAUS|MACON1_RXPAUS)
+	// bring MAC out of reset
+	d.write(MACON2, 0x00)
+	// enable automatic padding to 60bytes and CRC operations
+	d.writeOp(BIT_FIELD_SET, MACON3, MACON3_PADCFG0|MACON3_TXCRCEN|MACON3_FRMLNEN)
+	// set inter-frame gap (non-back-to-back)
+	d.write(MAIPGL, 0x12)
+	d.write(MAIPGH, 0x0C)
+	// set inter-frame gap (back-to-back)
+	d.write(MABBIPG, 0x12)
+	// Set the maximum packet size which the controller will accept
+	// Do not send packets longer than MAX_FRAMELEN:
+	d.write(MAMXFLH, MAX_FRAMELEN>>8)
+	// do bank 3 stuff
+	// write MAC address
+	// NOTE: MAC address in ENC28J60 is byte-backward
+	d.write(MAADR5, macaddr[0])
+	d.write(MAADR4, macaddr[1])
+	d.write(MAADR3, macaddr[2])
+	d.write(MAADR2, macaddr[3])
+	d.write(MAADR1, macaddr[4])
+	d.write(MAADR0, macaddr[5])
+	// no loopback of transmitted frames
+	d.phyWrite(PHCON2, PHCON2_HDLDIS)
+	// switch to bank 0
+	d.setBank(ECON1)
+	// enable interrutps
+	d.writeOp(BIT_FIELD_SET, EIE, EIE_INTIE|EIE_PKTIE)
+	// enable packet reception
+	d.writeOp(BIT_FIELD_SET, ECON1, ECON1_RXEN)
+}
+
+// Gets the revision of the connected ENC28J60 chip.
+// Will be a number greater than 0 if successful.
+func (d *Dev) GetRev() uint8 {
+	return d.read(EREVID)
+}
+
+// PacketSend sends a binary packet over the network.
+//
+// Deprecated: This function was ported from arduino
+// and is not ideal for AVR boards due to the high memory usage.
+// Please use Write and Flush methods.
+func (d *Dev) PacketSend(packet []byte) {
+	plen := len(packet)
+	// After a packet is transmitted, however, the hardware
+	// will write a seven-byte status vector into memory after
+	// the last byte in the packet. Therefore, the host control-
+	// ler should leave at least seven bytes between each
+	// packet and the beginning of the receive buffer. No
+	// explicit action is required to initialize the transmission
+	// buffer.
+	d.write(EWRPTL, TXSTART_INIT&0xFF)
+	d.write(EWRPTH, TXSTART_INIT>>8)
+	// Set the TXND pointer to correspond to the packet size given
+	d.write(ETXNDL, uint8(TXSTART_INIT+plen&0xFF))
+	d.write(ETXNDH, uint8((TXSTART_INIT+plen)>>8))
+	// write per-packet control byte (0x00 means use macon3 settings)
+	d.writeOp(WRITE_BUF_MEM, 0, 0x00)
+	// copy the packet into the transmit buffer
+	d.writeBuffer(packet)
+	// send the contents of the transmit buffer onto the network
+	d.writeOp(BIT_FIELD_SET, ECON1, ECON1_TXRTS)
+	// Reset the transmit logic problem. See Rev. B4 Silicon Errata point 12.
+	if d.read(EIR)&EIR_TXERIF != 0 {
+		d.writeOp(BIT_FIELD_CLR, ECON1, ECON1_TXRTS)
+	}
+}
+
+// PacketRecieve sends binary data over network and returns length of
+// data sent.
+//
+// Deprecated: This function was ported from arduino
+// and is not ideal for AVR boards due to the high memory usage.
+// Please use NextPacket() to obtain an io.Reader-like interface
+// for the packet.
+func (d *Dev) PacketRecieve(packet []byte) (plen uint16) {
+	var rxstat uint16
+	if d.read(EPKTCNT) == 0 {
+		return 0
+	}
+
+	// Set the read pointer to the start of the received packet
+	d.write16(ERDPTL, d.nextPacketPtr)
+
+	d.readBuffer(d.buf[:])
+	d.nextPacketPtr = uint16(d.buf[0]) + uint16(d.buf[1])<<8
+	// read the packet length (see datasheet page 43)
+	plen = uint16(d.buf[2]) + uint16(d.buf[3])<<8 - 4 //remove the CRC count (minus 4)
+	// read the receive status (see datasheet page 43)
+	rxstat = uint16(d.buf[4]) + uint16(d.buf[5])<<8
+
+	// limit retrieve length
+	if plen > uint16(len(packet)) {
+		plen = uint16(len(packet))
+	}
+	// check CRC and symbol errors (see datasheet page 44, table 7-3):
+	// The ERXFCON.CRCEN is set by default. Normally we should not
+	// need to check this.
+	if (rxstat & 0x80) == 0 {
+		// invalid
+		plen = 0
+	} else {
+		// copy the packet from the receive buffer
+		d.readBuffer(packet[:plen])
+	}
+	// Move the RX read pointer to the start of the next received packet
+	// This frees the memory we just read out
+	d.write16(ERXRDPTL, d.nextPacketPtr)
+
+	// decrement the packet counter indicate we are done with this packet
+	d.writeOp(BIT_FIELD_SET, ECON2, ECON2_PKTDEC)
+	return plen
+}

--- a/enc28j60/enc28j60.go
+++ b/enc28j60/enc28j60.go
@@ -20,7 +20,8 @@ type Dev struct {
 	is interrupt.State
 	// Bank saves last memory bank accessed by read/write ops.
 	Bank uint8
-	rx   Packet
+	// rx contains information of the current packet being read. Read returns EOF if finished with packet.
+	rx packet
 	// Houses ERDPTL register data pointing to next packet position in buffer.
 	nextPacketPtr uint16
 	// tcursor points to the current octet in the TX buffer.

--- a/enc28j60/enc28j60_test.go
+++ b/enc28j60/enc28j60_test.go
@@ -1,0 +1,68 @@
+package enc28j60_test
+
+import (
+	"bytes"
+	"machine"
+	"time"
+
+	"github.com/soypat/net"
+
+	swtch "github.com/soypat/ether-swtch"
+	"tinygo.org/x/drivers/enc28j60"
+)
+
+func ExampleHTTPResponse() {
+	// CS pin can be any digital ouput pin.
+	var spiCS = machine.D53
+
+	var (
+		MAC  = net.HardwareAddr{0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xFF}
+		MyIP = net.IP{192, 168, 1, 5} //static setup is the only one available
+	)
+
+	// 8MHz SPI clk for older than Rev 6 boards (See Rev. B4 Silicon Errata)
+	machine.SPI0.Configure(machine.SPIConfig{Frequency: 8e6})
+
+	e := enc28j60.New(spiCS, machine.SPI0)
+	err := e.Init(MAC)
+	if err != nil {
+		println(err.Error())
+	}
+	const okHeader = "HTTP/1.0 200 OK\r\nContent-Type: text/html\r\nPragma: no-cache\r\n\r\n"
+
+	timeout := time.Second * 1 // timeouts don't work well on AVR boards yet
+	swtch.HTTPListenAndServe(e, MAC, MyIP, timeout, func(URL []byte) (response []byte) {
+		return []byte(okHeader + "Hello world!")
+	}, func(e error) {}) // Will ignore errors.
+}
+
+func ExampleBlinky() {
+	// CS pin can be any digital ouput pin.
+	var spiCS = machine.D53
+
+	var (
+		MAC  = net.HardwareAddr{0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xFF}
+		MyIP = net.IP{192, 168, 1, 5} //static setup is the only one available
+	)
+
+	// 8MHz SPI clk for older than Rev 6 boards (See Rev. B4 Silicon Errata)
+	machine.SPI0.Configure(machine.SPIConfig{Frequency: 8e6})
+	machine.LED.Configure(machine.PinConfig{Mode: machine.PinOutput})
+
+	e := enc28j60.New(spiCS, machine.SPI0)
+	err := e.Init(MAC)
+	if err != nil {
+		println(err.Error())
+	}
+	const okHeader = "HTTP/1.0 200 OK\r\nContent-Type: text/html\r\nPragma: no-cache\r\n\r\n"
+
+	timeout := time.Second * 1
+	swtch.HTTPListenAndServe(e, MAC, MyIP, timeout, func(URL []byte) (response []byte) {
+		// Warning: This will leave you at URL "/led". Refreshing the page will trigger the toggle!
+		// Use HTTP redirects to fix this.
+		if bytes.Equal(URL, []byte("/led")) {
+			machine.LED.Set(!machine.LED.Get())
+		}
+		return []byte(okHeader + `<h1>TinyGo Ethernet</h1><a href="led">Toggle LED</a>`)
+	}, func(e error) {}) // Will ignore errors.
+}

--- a/enc28j60/errors.go
+++ b/enc28j60/errors.go
@@ -1,0 +1,43 @@
+package enc28j60
+
+type ErrorCode uint8
+
+const (
+	errUndefined ErrorCode = iota
+	// written packet exceeds size 64..1500
+	ErrBufferSize
+	// got rev=0. is dev connected?
+	ErrBadRev
+	// mac addr len not 6
+	ErrBadMac
+	// read deadline exceeded
+	ErrRXDeadlineExceeded
+	// CRC checksum fail
+	ErrCRC
+)
+
+// Implements error interface.
+func (err ErrorCode) Error() string {
+	switch err {
+	case ErrBufferSize:
+		return "written packet exceeds size 64..1500"
+	case ErrBadRev:
+		return "got rev=0. is dev connected?"
+	case ErrBadMac:
+		return "mac addr len not 6"
+	case ErrRXDeadlineExceeded:
+		return "rx deadline exceeded"
+	case ErrCRC:
+		return "CRC error"
+	}
+	return "undefined"
+}
+
+// Gets the numeric representation of an ENC28J60
+// error. Avoids usage of strings if memory consumption is an object.
+func GetErrorCode(c error) uint8 {
+	if u, ok := c.(ErrorCode); ok {
+		return uint8(u)
+	}
+	return 0
+}

--- a/enc28j60/errors.go
+++ b/enc28j60/errors.go
@@ -14,6 +14,8 @@ const (
 	ErrRXDeadlineExceeded
 	// CRC checksum fail
 	ErrCRC
+	// IO error
+	ErrIO
 )
 
 // Implements error interface.
@@ -29,6 +31,8 @@ func (err ErrorCode) Error() string {
 		return "rx deadline exceeded"
 	case ErrCRC:
 		return "CRC error"
+	case ErrIO:
+		return "IO error"
 	}
 	return "undefined"
 }

--- a/enc28j60/io.go
+++ b/enc28j60/io.go
@@ -8,8 +8,7 @@ import (
 // read len(data) bytes from buffer
 func (d *Dev) readBuffer(data []byte) {
 	d.enableCS()
-	d.buf[0] = READ_BUF_MEM
-	d.bus.Tx(d.buf[:1], nil)
+	d.bus.Transfer(READ_BUF_MEM)
 	d.bus.Tx(nil, data)
 	d.disableCS()
 	dbp("read from ebuff", data)
@@ -18,8 +17,8 @@ func (d *Dev) readBuffer(data []byte) {
 // write data to TX buffer
 func (d *Dev) writeBuffer(data []byte) {
 	d.enableCS()
-	d.buf[0] = WRITE_BUF_MEM
-	d.bus.Tx(append(d.buf[:1], data...), nil)
+	d.bus.Transfer(WRITE_BUF_MEM)
+	d.bus.Tx(data, nil)
 	d.disableCS()
 	dbp("write to ebuff", data)
 }
@@ -58,7 +57,7 @@ func (d *Dev) writeOp(op, address, data uint8) {
 	d.buf[1] = data
 	err := d.bus.Tx(d.buf[:2], nil)
 	if err != nil {
-		dbp(err.Error(), []byte{op})
+		dbp("writeOp", d.buf[:1])
 	}
 	d.disableCS()
 }

--- a/enc28j60/io.go
+++ b/enc28j60/io.go
@@ -1,0 +1,126 @@
+package enc28j60
+
+import (
+	"runtime/interrupt"
+	"time"
+)
+
+// read len(data) bytes from buffer
+func (d *Dev) readBuffer(data []byte) {
+	d.enableCS()
+	d.buf[0] = READ_BUF_MEM
+	d.bus.Tx(d.buf[:1], nil)
+	d.bus.Tx(nil, data)
+	d.disableCS()
+	dbp("read from ebuff", data)
+}
+
+// write data to TX buffer
+func (d *Dev) writeBuffer(data []byte) {
+	d.enableCS()
+	d.buf[0] = WRITE_BUF_MEM
+	d.bus.Tx(append(d.buf[:1], data...), nil)
+	d.disableCS()
+	dbp("write to ebuff", data)
+}
+
+// the ENC28J60 has 4 banks (0 through 3). It can only read/write to
+// one at a time, and much switch between them by writing to ECON1 register.
+func (d *Dev) setBank(address uint8) {
+	bank := address & BANK_MASK
+	if bank != d.Bank {
+		d.writeOp(BIT_FIELD_CLR, ECON1, ECON1_BSEL1|ECON1_BSEL0)
+		d.writeOp(BIT_FIELD_SET, ECON1, bank>>5)
+		d.Bank = bank
+	}
+}
+
+// readOp reads from a register defined in registers.go. It requires
+// the ENC28J60 Bank be set beforehand.
+func (d *Dev) readOp(op, address uint8) uint8 {
+	d.enableCS()
+	d.bus.Tx([]byte{op | (address & ADDR_MASK), 0}, d.buf[:2])
+	// do dummy read if needed (for mac and mii, see datasheet page 29)
+	if address&SPRD_MASK != 0 {
+		d.bus.Tx(d.buf[2:3], nil)
+	}
+	d.disableCS()
+	return d.buf[1]
+}
+
+// readOp writes to a register defined in registers.go. It requires
+// the ENC28J60 Bank be set beforehand.
+func (d *Dev) writeOp(op, address, data uint8) {
+	d.enableCS()
+	err := d.bus.Tx([]byte{op | (address & ADDR_MASK), data}, nil)
+	if err != nil {
+		dbp(err.Error(), []byte{op})
+	}
+	d.disableCS()
+}
+
+func (d *Dev) read(address uint8) uint8 {
+	d.setBank(address)
+	return d.readOp(READ_CTL_REG, address)
+}
+
+func (d *Dev) write(address, data uint8) {
+	d.setBank(address)
+	d.writeOp(WRITE_CTL_REG, address, data)
+}
+
+// write16 writes to two contiguous 8 bit addresses (LSB first).
+func (d *Dev) write16(addressL uint8, data uint16) {
+	d.setBank(addressL)
+	d.writeOp(WRITE_CTL_REG, addressL, uint8(data))
+	d.writeOp(WRITE_CTL_REG, addressL+1, uint8(data>>8))
+}
+
+// write16 reads two contiguous 8 bit addresses and returns
+// 16bit value LSB first.
+func (d *Dev) read16(addressL uint8) uint16 {
+	d.setBank(addressL)
+	return uint16(d.readOp(READ_CTL_REG, addressL)) + uint16(d.readOp(READ_CTL_REG, addressL+1))<<8
+}
+
+func (d *Dev) phyWrite(address uint8, data uint16) {
+	// set the PHY register address. this begins the transaction
+	d.write(MIREGADR, address)
+	// write the PHY data
+	d.write16(MIWRL, data)
+	// wait until the PHY write completes
+	for d.read(MISTAT)&MISTAT_BUSY != 0 {
+		time.Sleep(time.Microsecond * 15)
+	}
+}
+
+func (d *Dev) phyRead(address uint8) uint16 {
+	// set the PHY register address
+	d.write(MIREGADR, address)
+	d.writeOp(BIT_FIELD_SET, MICMD, MICMD_MIIRD)
+	// Poll the MISTAT.BUSY bit to be
+	// certain that the operation is complete.
+	for d.read(MISTAT)&MISTAT_BUSY != 0 {
+		time.Sleep(time.Microsecond * 15)
+	}
+	// set bank 2 again
+	d.setBank(MICMD)
+	d.writeOp(BIT_FIELD_CLR, MICMD, MICMD_MIIRD)
+	// write the PHY data
+	return d.read16(MIRDL)
+}
+
+// enableCS enables SPI communication on bus. Disables Interrupts.
+// do not call enableCS twice before calling disable
+func (d *Dev) enableCS() {
+	d.is = interrupt.Disable()
+	d.CSB.Low()
+}
+
+// disableCS ends SPI communication on bus
+// always call disableCS after calling enable once
+// critical part done
+func (d *Dev) disableCS() {
+	d.CSB.High()
+	interrupt.Restore(d.is)
+}

--- a/enc28j60/log.go
+++ b/enc28j60/log.go
@@ -2,8 +2,6 @@
 
 package enc28j60
 
-import "github.com/soypat/ether-swtch/hex"
-
 // SDB enables serial print debugging of enc28j60 library
 var SDB bool
 
@@ -14,8 +12,45 @@ func dbp(msg string, datas ...[]byte) {
 		print(msg)
 		for d := range datas {
 			print(" 0x")
-			print(string(hex.Bytes(datas[d])))
+			print(string(Bytes(datas[d])))
 		}
 		println()
 	}
+}
+
+// Byte converts a single byte to an ASCII
+// byte slice representation.
+//
+// Example:
+//  string(hex.Byte(0xff))
+//  Output: "ff"
+func Byte(b byte) []byte {
+	var res [2]byte
+	if (b >> 4) > 9 {
+		res[0] = (b >> 4) + 'A' - 10
+	} else {
+		res[0] = (b >> 4) + '0'
+	}
+	if (b & 0b0000_1111) > 9 {
+		res[1] = (b & 0b0000_1111) + 'A' - 10
+	} else {
+		res[1] = (b & 0b0000_1111) + '0'
+	}
+	return res[:]
+}
+
+// Bytes converts a binary slice of bytes to an ASCII
+// hex representation.
+//
+// Example:
+//  string(hex.Bytes([]byte{0xff,0xaa}))
+//  Output: "ffaa"
+func Bytes(b []byte) []byte {
+	o := make([]byte, len(b)*2)
+	for i := 0; i < len(b); i++ {
+		aux := Byte(b[i])
+		o[i*2] = aux[0]
+		o[i*2+1] = aux[1]
+	}
+	return o
 }

--- a/enc28j60/log.go
+++ b/enc28j60/log.go
@@ -1,0 +1,21 @@
+package enc28j60
+
+import "github.com/soypat/ether-swtch/hex"
+
+// SDB enables serial print debugging of enc28j60 library
+var SDB bool
+
+// debug serial print. If SDB is set to false then it is not compiled unless compiler cannot determine
+// SDB does not change
+func dbp(msg string, datas ...[]byte) {
+	if SDB {
+		print(msg)
+		for d := range datas {
+			print(" 0x" + string(hex.Bytes(datas[d])))
+			// for i := 0; i < len(datas[d]); i++ {
+			// 	print(string(hex.Byte(datas[d][i])))
+			// }
+		}
+		println()
+	}
+}

--- a/enc28j60/log.go
+++ b/enc28j60/log.go
@@ -1,3 +1,5 @@
+// +build !noheap
+
 package enc28j60
 
 import "github.com/soypat/ether-swtch/hex"
@@ -11,10 +13,8 @@ func dbp(msg string, datas ...[]byte) {
 	if SDB {
 		print(msg)
 		for d := range datas {
-			print(" 0x" + string(hex.Bytes(datas[d])))
-			// for i := 0; i < len(datas[d]); i++ {
-			// 	print(string(hex.Byte(datas[d][i])))
-			// }
+			print(" 0x")
+			print(string(hex.Bytes(datas[d])))
 		}
 		println()
 	}

--- a/enc28j60/log_noheap.go
+++ b/enc28j60/log_noheap.go
@@ -1,0 +1,10 @@
+// +build noheap
+
+package enc28j60
+
+// SDB enables serial print debugging of enc28j60 library
+var SDB bool
+
+// debug serial print. If SDB is set to false then it is not compiled unless compiler cannot determine
+// SDB does not change
+func dbp(msg string, datas ...[]byte) {}

--- a/enc28j60/registers.go
+++ b/enc28j60/registers.go
@@ -1,0 +1,335 @@
+package enc28j60
+
+// ENC28J60 Control Registers
+// Control register definitions are a combination of address,
+// bank number, and Ethernet/MAC/PHY indicator bits.
+
+// - Register address        (bits 0-4)
+// - Bank number        (bits 5-6)
+// - MAC/PHY indicator        (bit 7)
+const (
+	ADDR_MASK = 0x1F
+	BANK_MASK = 0x60
+	SPRD_MASK = 0x80
+)
+
+// Bank masks
+const (
+	bank0 = 0 << 5
+	bank1 = 1 << 5
+	bank2 = 2 << 5
+	bank3 = 3 << 5
+)
+
+// All-bank registers
+const (
+	EIE   = 0x1B
+	EIR   = 0x1C
+	ESTAT = 0x1D
+	ECON2 = 0x1E
+	ECON1 = 0x1F
+)
+
+// Bank 0 registers. ADDR = (uint8 addr | bank mask)
+const (
+	ERDPTL = (0x00 | bank0)
+	ERDPTH = (0x01 | bank0)
+	EWRPTL = (0x02 | bank0)
+	EWRPTH = (0x03 | bank0)
+	ETXSTL = (0x04 | bank0)
+	ETXSTH = (0x05 | bank0)
+	ETXNDL = (0x06 | bank0)
+	ETXNDH = (0x07 | bank0)
+	ERXSTL = (0x08 | bank0)
+	ERXSTH = (0x09 | bank0)
+	ERXNDL = (0x0A | bank0)
+	ERXNDH = (0x0B | bank0)
+	// Bank0. The ERXRDPT registers define a location within the
+	// FIFO where the receive hardware is forbidden to write
+	// to. In normal operation, the receive hardware will write
+	// data up to, but not including, the memory pointed to by
+	// ERXRDPT.
+	ERXRDPTL, ERXRDPTH = (0x0C | bank0), (0x0D | bank0)
+	ERXWRPTL           = (0x0E | bank0)
+	ERXWRPTH           = (0x0F | bank0)
+	EDMASTL            = (0x10 | bank0)
+	EDMASTH            = (0x11 | bank0)
+	EDMANDL            = (0x12 | bank0)
+	EDMANDH            = (0x13 | bank0)
+	EDMADSTL           = (0x14 | bank0)
+	EDMADSTH           = (0x15 | bank0)
+	EDMACSL            = (0x16 | bank0)
+	EDMACSH            = (0x17 | bank0)
+)
+
+// Bank 1 registers ADDR = (uint8 addr | bank mask)
+const (
+	EHT0    = (0x00 | bank1)
+	EHT1    = (0x01 | bank1)
+	EHT2    = (0x02 | bank1)
+	EHT3    = (0x03 | bank1)
+	EHT4    = (0x04 | bank1)
+	EHT5    = (0x05 | bank1)
+	EHT6    = (0x06 | bank1)
+	EHT7    = (0x07 | bank1)
+	EPMM0   = (0x08 | bank1)
+	EPMM1   = (0x09 | bank1)
+	EPMM2   = (0x0A | bank1)
+	EPMM3   = (0x0B | bank1)
+	EPMM4   = (0x0C | bank1)
+	EPMM5   = (0x0D | bank1)
+	EPMM6   = (0x0E | bank1)
+	EPMM7   = (0x0F | bank1)
+	EPMCSL  = (0x10 | bank1)
+	EPMCSH  = (0x11 | bank1)
+	EPMOL   = (0x14 | bank1)
+	EPMOH   = (0x15 | bank1)
+	EWOLIE  = (0x16 | bank1)
+	EWOLIR  = (0x17 | bank1)
+	ERXFCON = (0x18 | bank1)
+	EPKTCNT = (0x19 | bank1)
+)
+
+// Bank 2 registers ADDR = (uint8 addr | bank mask | SPRD mask)
+const (
+	MACON1 = (0x00 | bank2 | 0x80)
+	MACON2 = (0x01 | bank2 | 0x80)
+	MACON3 = (0x02 | bank2 | 0x80)
+	MACON4 = (0x03 | bank2 | 0x80)
+	// When FULDPX (MACON3<0>) = 0 : Nibble  time  offset  delay  between  the  end  of  one  transmission  and  the  beginning  of  the  next  in  aback-to-back sequence. The register value should be programmed to the desired period in nibble timesminus 6. The recommended setting is 12h which represents the minimum IEEE specified Inter-PacketGap (IPG) of 9.6us
+	MABBIPG  = (0x04 | bank2 | 0x80)
+	MAIPGL   = (0x06 | bank2 | 0x80)
+	MAIPGH   = (0x07 | bank2 | 0x80)
+	MACLCON1 = (0x08 | bank2 | 0x80)
+	MACLCON2 = (0x09 | bank2 | 0x80)
+	MAMXFLL  = (0x0A | bank2 | 0x80)
+	MAMXFLH  = (0x0B | bank2 | 0x80)
+	MAPHSUP  = (0x0D | bank2 | 0x80)
+	MICON    = (0x11 | bank2 | 0x80)
+	MICMD    = (0x12 | bank2 | 0x80)
+	MIREGADR = (0x14 | bank2 | 0x80)
+	MIWRL    = (0x16 | bank2 | 0x80)
+	MIWRH    = (0x17 | bank2 | 0x80)
+	MIRDL    = (0x18 | bank2 | 0x80)
+	MIRDH    = (0x19 | bank2 | 0x80)
+)
+
+// Bank 3 registers
+const (
+	MAADR1  = (0x00 | bank3 | 0x80)
+	MAADR0  = (0x01 | bank3 | 0x80)
+	MAADR3  = (0x02 | bank3 | 0x80)
+	MAADR2  = (0x03 | bank3 | 0x80)
+	MAADR5  = (0x04 | bank3 | 0x80)
+	MAADR4  = (0x05 | bank3 | 0x80)
+	EBSTSD  = (0x06 | bank3)
+	EBSTCON = (0x07 | bank3)
+	EBSTCSL = (0x08 | bank3)
+	EBSTCSH = (0x09 | bank3)
+	MISTAT  = (0x0A | bank3 | 0x80)
+	EREVID  = (0x12 | bank3)
+	ECOCON  = (0x15 | bank3)
+	EFLOCON = (0x17 | bank3)
+	EPAUSL  = (0x18 | bank3)
+	EPAUSH  = (0x19 | bank3)
+)
+
+// PHY registers
+const (
+	PHCON1  = 0x00
+	PHSTAT1 = 0x01
+	PHHID1  = 0x02
+	PHHID2  = 0x03
+	PHCON2  = 0x10
+	PHSTAT2 = 0x11
+	PHIE    = 0x12
+	PHIR    = 0x13
+	PHLCON  = 0x14
+)
+
+// ENC28J60 ERXFCON Register Bit Definitions
+const (
+	ERXFCON_UCEN  = 0x80
+	ERXFCON_ANDOR = 0x40
+	ERXFCON_CRCEN = 0x20
+	ERXFCON_PMEN  = 0x10
+	ERXFCON_MPEN  = 0x08
+	ERXFCON_HTEN  = 0x04
+	ERXFCON_MCEN  = 0x02
+	ERXFCON_BCEN  = 0x01
+)
+
+// ENC28J60 EIE Register Bit Definitions
+const (
+	EIE_INTIE  = 0x80
+	EIE_PKTIE  = 0x40
+	EIE_DMAIE  = 0x20
+	EIE_LINKIE = 0x10
+	EIE_TXIE   = 0x08
+	EIE_WOLIE  = 0x04
+	EIE_TXERIE = 0x02
+	EIE_RXERIE = 0x01
+)
+
+// ENC28J60 EIR Register Bit Definitions
+const (
+	EIR_PKTIF  = 0x40
+	EIR_DMAIF  = 0x20
+	EIR_LINKIF = 0x10
+	EIR_TXIF   = 0x08
+	EIR_WOLIF  = 0x04
+	EIR_TXERIF = 0x02
+	EIR_RXERIF = 0x01
+)
+
+// ENC28J60 ESTAT Register Bit Definitions
+const (
+	ESTAT_INT     = 0x80
+	ESTAT_LATECOL = 0x10
+	ESTAT_RXBUSY  = 0x04
+	ESTAT_TXABRT  = 0x02
+	ESTAT_CLKRDY  = 0x01
+)
+
+// ENC28J60 ECON2 Register Bit Definitions
+const (
+	ECON2_AUTOINC = 0x80
+	ECON2_PKTDEC  = 0x40
+	ECON2_PWRSV   = 0x20
+	ECON2_VRPS    = 0x08
+)
+
+// ENC28J60 ECON1 Register Bit Definitions
+const (
+	ECON1_TXRST  = 0x80
+	ECON1_RXRST  = 0x40
+	ECON1_DMAST  = 0x20
+	ECON1_CSUMEN = 0x10
+	ECON1_TXRTS  = 0x08
+	ECON1_RXEN   = 0x04
+	ECON1_BSEL1  = 0x02
+	ECON1_BSEL0  = 0x01
+)
+
+// ENC28J60 MACON1 Register Bit Definitions
+const (
+	MACON1_LOOPBK  = 0x10
+	MACON1_TXPAUS  = 0x08
+	MACON1_RXPAUS  = 0x04
+	MACON1_PASSALL = 0x02
+	MACON1_MARXEN  = 0x01
+)
+
+// ENC28J60 MACON2 Register Bit Definitions
+const (
+	MACON2_MARST   = 0x80
+	MACON2_RNDRST  = 0x40
+	MACON2_MARXRST = 0x08
+	MACON2_RFUNRST = 0x04
+	MACON2_MATXRST = 0x02
+	MACON2_TFUNRST = 0x01
+)
+
+// ENC28J60 MACON3 Register Bit Definitions
+const (
+	// All short frames will be zero-padded to 64 bytes and a valid CRC will then be appended
+	MACON3_ZPADCRC = 0b111 << 5
+	MACON3_PADCFG2 = 0x80
+	MACON3_PADCFG1 = 0x40
+	MACON3_PADCFG0 = 0x20
+	// MAC will append a  valid CRC to all frames transmitted regardless of  PADCFG bits. TXCRCEN must be set if the PADCFG bits specify that a valid CRC will be appended.
+	MACON3_TXCRCEN = 0x10
+	MACON3_PHDRLEN = 0x08
+	MACON3_HFRMLEN = 0x04
+	//The type/length field of transmitted and received frames will be checked. If it represents a length, the frame size will be compared and mismatches will be reported in the transmit/receive status vector.
+	MACON3_FRMLNEN = 0x02
+	// MAC will operate in Full-Duplex mode. PDPXMD bit must also be set.
+	MACON3_FULDPX = 0x01
+)
+
+// ENC28J60 MACON4 Register Bit Definitions
+const (
+	//When the medium is occupied, the MAC will wait indefinitely for it to become free when attempting to transmit (use this setting for IEEE 802.3™ compliance)
+	MACON4_DEFER = 1 << 6
+	//  After  incidentally  causing  a  collision  during  backpressure,  the  MAC  will  immediately  begin retransmitting
+	MACON4_BPEN = 1 << 5
+	//After any collision, the MAC will immediately begin retransmitting
+	MACON4_NOBKOFF = 1 << 4
+)
+
+// ENC28J60 MICMD Register Bit Definitions
+const (
+	MICMD_MIISCAN = 0x02
+	MICMD_MIIRD   = 0x01
+)
+
+// ENC28J60 MISTAT Register Bit Definitions
+const (
+	MISTAT_NVALID = 0x04
+	MISTAT_SCAN   = 0x02
+	MISTAT_BUSY   = 0x01
+)
+
+// ENC28J60 PHY PHCON1 Register Bit Definitions
+const (
+	PHCON1_PRST    = 0x8000
+	PHCON1_PLOOPBK = 0x4000
+	PHCON1_PPWRSV  = 0x0800
+	PHCON1_PDPXMD  = 0x0100
+)
+
+// ENC28J60 PHY PHSTAT1 Register Bit Definitions
+const (
+	PHSTAT1_PFDPX  = 0x1000
+	PHSTAT1_PHDPX  = 0x0800
+	PHSTAT1_LLSTAT = 0x0004
+	PHSTAT1_JBSTAT = 0x0002
+)
+
+// ENC28J60 PHY PHCON2 Register Bit Definitions
+const (
+	PHCON2_FRCLINK = 0x4000
+	PHCON2_TXDIS   = 0x2000
+	PHCON2_JABBER  = 0x0400
+	PHCON2_HDLDIS  = 0x0100
+)
+
+// ENC28J60 Packet Control Byte Bit Definitions
+const (
+	PKTCTRL_PHUGEEN   = 0x08
+	PKTCTRL_PPADEN    = 0x04
+	PKTCTRL_PCRCEN    = 0x02
+	PKTCTRL_POVERRIDE = 0x01
+)
+
+// SPI operation codes
+const (
+	READ_CTL_REG  = 0x00
+	READ_BUF_MEM  = 0x3A
+	WRITE_CTL_REG = 0x40
+	WRITE_BUF_MEM = 0x7A
+	BIT_FIELD_SET = 0x80
+	BIT_FIELD_CLR = 0xA0
+	SOFT_RESET    = 0xFF
+)
+
+// The RXSTART_INIT should be zero. See Rev. B4 Silicon Errata
+// buffer boundaries applied to internal 8K ram
+// the entire available packet buffer space is allocated
+//
+// start with recbuf at 0/
+const RXSTART_INIT = 0x0
+
+// receive buffer end
+const RXSTOP_INIT = (0x1FFF - 0x0600 - 1)
+
+// start TX buffer at 0x1FFF-0x0600, pace for one full ethernet frame (1536 bytes)
+const TXSTART_INIT = (0x1FFF - 0x0600)
+
+// stp TX buffer at end of mem leaving space for status vector
+const TXSTOP_INIT = 0x1FFF
+
+//
+// max frame length which the conroller will accept:
+const MAX_FRAMELEN = 1500 // (note: maximum ethernet frame length would be 1518)
+// MAX_FRAMELEN     600

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,6 @@ go 1.15
 require (
 	github.com/eclipse/paho.mqtt.golang v1.2.0
 	github.com/frankban/quicktest v1.10.2
+	github.com/soypat/ether-swtch v0.9.0
+	github.com/soypat/net v0.2.2
 )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.15
 require (
 	github.com/eclipse/paho.mqtt.golang v1.2.0
 	github.com/frankban/quicktest v1.10.2
-	github.com/soypat/ether-swtch v0.9.1
+	github.com/soypat/ether-swtch v0.10.0
 	github.com/soypat/net v0.2.2
 )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,5 @@ go 1.15
 require (
 	github.com/eclipse/paho.mqtt.golang v1.2.0
 	github.com/frankban/quicktest v1.10.2
-	github.com/soypat/ether-swtch v0.10.0
 	github.com/soypat/net v0.2.2
 )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.15
 require (
 	github.com/eclipse/paho.mqtt.golang v1.2.0
 	github.com/frankban/quicktest v1.10.2
-	github.com/soypat/ether-swtch v0.9.0
+	github.com/soypat/ether-swtch v0.9.1
 	github.com/soypat/net v0.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/soypat/ether-swtch v0.9.1 h1:h7A6wwy8CF2w4WozwbAH+oE7U4Ik5sFvy5ncIHX6qJk=
-github.com/soypat/ether-swtch v0.9.1/go.mod h1:GV76EJ0ud2JLMX9PO3OEwWi+FmDqWtR+rVDy8Udy5ok=
+github.com/soypat/ether-swtch v0.10.0 h1:oYDJ2MaamQgPevhYFq1w2dZD8hIIF0VEZ8FFr42x+kM=
+github.com/soypat/ether-swtch v0.10.0/go.mod h1:GV76EJ0ud2JLMX9PO3OEwWi+FmDqWtR+rVDy8Udy5ok=
 github.com/soypat/net v0.2.0/go.mod h1:hd58cJl8uqwu3q+9Q6/fG0WKW+YEdx3E9puO/GLk6e0=
 github.com/soypat/net v0.2.2 h1:i9AfaFeHoKjL5bPvYs5wYIU/2aU+MSs+3YJ6LWn1ZLs=
 github.com/soypat/net v0.2.2/go.mod h1:cxcMlZM5FCxUfb5k1vMWwLN1/Woxq3cdux3rT2/PCpY=

--- a/go.sum
+++ b/go.sum
@@ -9,5 +9,10 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/soypat/ether-swtch v0.9.0 h1:aNu2vFsIDsK7Ii9Rc8wz3HSIU+YxgUJyJ9dLyuf0Slw=
+github.com/soypat/ether-swtch v0.9.0/go.mod h1:GV76EJ0ud2JLMX9PO3OEwWi+FmDqWtR+rVDy8Udy5ok=
+github.com/soypat/net v0.2.0/go.mod h1:hd58cJl8uqwu3q+9Q6/fG0WKW+YEdx3E9puO/GLk6e0=
+github.com/soypat/net v0.2.2 h1:i9AfaFeHoKjL5bPvYs5wYIU/2aU+MSs+3YJ6LWn1ZLs=
+github.com/soypat/net v0.2.2/go.mod h1:cxcMlZM5FCxUfb5k1vMWwLN1/Woxq3cdux3rT2/PCpY=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/soypat/ether-swtch v0.9.0 h1:aNu2vFsIDsK7Ii9Rc8wz3HSIU+YxgUJyJ9dLyuf0Slw=
-github.com/soypat/ether-swtch v0.9.0/go.mod h1:GV76EJ0ud2JLMX9PO3OEwWi+FmDqWtR+rVDy8Udy5ok=
+github.com/soypat/ether-swtch v0.9.1 h1:h7A6wwy8CF2w4WozwbAH+oE7U4Ik5sFvy5ncIHX6qJk=
+github.com/soypat/ether-swtch v0.9.1/go.mod h1:GV76EJ0ud2JLMX9PO3OEwWi+FmDqWtR+rVDy8Udy5ok=
 github.com/soypat/net v0.2.0/go.mod h1:hd58cJl8uqwu3q+9Q6/fG0WKW+YEdx3E9puO/GLk6e0=
 github.com/soypat/net v0.2.2 h1:i9AfaFeHoKjL5bPvYs5wYIU/2aU+MSs+3YJ6LWn1ZLs=
 github.com/soypat/net v0.2.2/go.mod h1:cxcMlZM5FCxUfb5k1vMWwLN1/Woxq3cdux3rT2/PCpY=


### PR DESCRIPTION
Rewrote ENC28J60 driver with more go-like approach to packet reading. I left the arduino-inspired functions PacketSend and PacketRead in case someone was looking to directly port some arduino program to Go.