### PR TITLE
rtl8720dn: add support for udpstation and ntpclient

### DIFF
--- a/examples/rtl8720dn/ntpclient/main.go
+++ b/examples/rtl8720dn/ntpclient/main.go
@@ -1,0 +1,144 @@
+// This is an example of using the rtl8720dn driver to implement a NTP client.
+// It creates a UDP connection to request the current time and parse the
+// response from a NTP server.
+package main
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"time"
+
+	"tinygo.org/x/drivers/net"
+)
+
+// IP address of the server aka "hub". Replace with your own info.
+// You can override the setting with the init() in another source code.
+// func init() {
+//    ssid = "your-ssid"
+//    password = "your-password"
+//    ntpHost = "129.6.15.29"
+//    debug = true
+// }
+
+var (
+	ssid     string
+	password string
+	ntpHost  = "129.6.15.29"
+	debug    = false
+)
+
+const NTP_PACKET_SIZE = 48
+
+var b = make([]byte, NTP_PACKET_SIZE)
+
+func main() {
+	err := run()
+	for err != nil {
+		fmt.Printf("error: %s\r\n", err.Error())
+		time.Sleep(5 * time.Second)
+	}
+}
+
+func run() error {
+	rtl, err := setupRTL8720DN()
+	if err != nil {
+		return err
+	}
+	net.UseDriver(rtl)
+
+	err = rtl.ConnectToAP(ssid, password)
+	if err != nil {
+		return err
+	}
+
+	ip, subnet, gateway, err := rtl.GetIP()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("IP Address : %s\r\n", ip)
+	fmt.Printf("Mask       : %s\r\n", subnet)
+	fmt.Printf("Gateway    : %s\r\n", gateway)
+
+	// now make UDP connection
+	hip := net.ParseIP(ntpHost)
+	raddr := &net.UDPAddr{IP: hip, Port: 123}
+	laddr := &net.UDPAddr{Port: 2390}
+	conn, err := net.DialUDP("udp", laddr, raddr)
+	if err != nil {
+		return err
+	}
+
+	for {
+		// send data
+		println("Requesting NTP time...")
+		t, err := getCurrentTime(conn)
+		if err != nil {
+			message("Error getting current time: %v", err)
+		} else {
+			message("NTP time: %v", t)
+		}
+		runtime.AdjustTimeOffset(-1 * int64(time.Since(t)))
+		for i := 0; i < 10; i++ {
+			message("Current time: %v", time.Now())
+			time.Sleep(1 * time.Second)
+		}
+	}
+
+}
+
+func getCurrentTime(conn *net.UDPSerialConn) (time.Time, error) {
+	if err := sendNTPpacket(conn); err != nil {
+		return time.Time{}, err
+	}
+	clearBuffer()
+	for now := time.Now(); time.Since(now) < time.Second; {
+		time.Sleep(5 * time.Millisecond)
+		if n, err := conn.Read(b); err != nil {
+			return time.Time{}, fmt.Errorf("error reading UDP packet: %w", err)
+		} else if n == 0 {
+			continue // no packet received yet
+		} else if n != NTP_PACKET_SIZE {
+			if n != NTP_PACKET_SIZE {
+				return time.Time{}, fmt.Errorf("expected NTP packet size of %d: %d", NTP_PACKET_SIZE, n)
+			}
+		}
+		return parseNTPpacket(), nil
+	}
+	return time.Time{}, errors.New("no packet received after 1 second")
+}
+
+func sendNTPpacket(conn *net.UDPSerialConn) error {
+	clearBuffer()
+	b[0] = 0b11100011 // LI, Version, Mode
+	b[1] = 0          // Stratum, or type of clock
+	b[2] = 6          // Polling Interval
+	b[3] = 0xEC       // Peer Clock Precision
+	// 8 bytes of zero for Root Delay & Root Dispersion
+	b[12] = 49
+	b[13] = 0x4E
+	b[14] = 49
+	b[15] = 52
+	if _, err := conn.Write(b); err != nil {
+		return err
+	}
+	return nil
+}
+
+func parseNTPpacket() time.Time {
+	// the timestamp starts at byte 40 of the received packet and is four bytes,
+	// this is NTP time (seconds since Jan 1 1900):
+	t := uint32(b[40])<<24 | uint32(b[41])<<16 | uint32(b[42])<<8 | uint32(b[43])
+	const seventyYears = 2208988800
+	return time.Unix(int64(t-seventyYears), 0)
+}
+
+func clearBuffer() {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+func message(format string, args ...interface{}) {
+	println(fmt.Sprintf(format, args...), "\r")
+}

--- a/examples/rtl8720dn/ntpclient/wioterminal.go
+++ b/examples/rtl8720dn/ntpclient/wioterminal.go
@@ -1,0 +1,71 @@
+// +build wioterminal
+
+package main
+
+import (
+	"device/sam"
+	"machine"
+	"runtime/interrupt"
+	"time"
+
+	"tinygo.org/x/drivers/rtl8720dn"
+)
+
+var (
+	uart UARTx
+)
+
+func handleInterrupt(interrupt.Interrupt) {
+	// should reset IRQ
+	uart.Receive(byte((uart.Bus.DATA.Get() & 0xFF)))
+	uart.Bus.INTFLAG.SetBits(sam.SERCOM_USART_INT_INTFLAG_RXC)
+}
+
+func setupRTL8720DN() (*rtl8720dn.RTL8720DN, error) {
+	machine.RTL8720D_CHIP_PU.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.RTL8720D_CHIP_PU.Low()
+	time.Sleep(100 * time.Millisecond)
+	machine.RTL8720D_CHIP_PU.High()
+	time.Sleep(1000 * time.Millisecond)
+	waitSerial()
+
+	uart = UARTx{
+		UART: &machine.UART{
+			Buffer: machine.NewRingBuffer(),
+			Bus:    sam.SERCOM0_USART_INT,
+			SERCOM: 0,
+		},
+	}
+
+	uart.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, handleInterrupt)
+	uart.Configure(machine.UARTConfig{TX: machine.PB24, RX: machine.PC24, BaudRate: 614400})
+
+	rtl := rtl8720dn.New(uart)
+	rtl.Debug(debug)
+
+	_, err := rtl.Rpc_tcpip_adapter_init()
+	if err != nil {
+		return nil, err
+	}
+
+	return rtl, nil
+}
+
+// Wait for user to open serial console
+func waitSerial() {
+	for !machine.Serial.DTR() {
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+type UARTx struct {
+	*machine.UART
+}
+
+func (u UARTx) Read(p []byte) (n int, err error) {
+	if u.Buffered() == 0 {
+		time.Sleep(1 * time.Millisecond)
+		return 0, nil
+	}
+	return u.UART.Read(p)
+}

--- a/examples/rtl8720dn/udpstation/main.go
+++ b/examples/rtl8720dn/udpstation/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"tinygo.org/x/drivers/net"
+	"tinygo.org/x/drivers/net/http"
+)
+
+// IP address of the server aka "hub". Replace with your own info.
+// You can override the setting with the init() in another source code.
+// func init() {
+//    ssid = "your-ssid"
+//    password = "your-password"
+//    hubIP = "192.168.1.118"
+//    debug = true
+// }
+
+var (
+	ssid     string
+	password string
+	hubIP    = ""
+	debug    = false
+)
+
+var buf [0x400]byte
+
+func main() {
+	err := run()
+	for err != nil {
+		fmt.Printf("error: %s\r\n", err.Error())
+		time.Sleep(5 * time.Second)
+	}
+}
+
+func run() error {
+	rtl, err := setupRTL8720DN()
+	if err != nil {
+		return err
+	}
+	net.UseDriver(rtl)
+	http.SetBuf(buf[:])
+
+	err = rtl.ConnectToAP(ssid, password)
+	if err != nil {
+		return err
+	}
+
+	ip, subnet, gateway, err := rtl.GetIP()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("IP Address : %s\r\n", ip)
+	fmt.Printf("Mask       : %s\r\n", subnet)
+	fmt.Printf("Gateway    : %s\r\n", gateway)
+
+	// now make UDP connection
+	hip := net.ParseIP(hubIP)
+	raddr := &net.UDPAddr{IP: hip, Port: 2222}
+	laddr := &net.UDPAddr{Port: 2222}
+
+	println("Dialing UDP connection...")
+	conn, err := net.DialUDP("udp", laddr, raddr)
+	if err != nil {
+		return err
+	}
+
+	for {
+		// send data
+		println("Sending data...")
+		for i := 0; i < 25; i++ {
+			conn.Write([]byte("hello " + strconv.Itoa(i) + "\r\n"))
+		}
+		time.Sleep(1000 * time.Millisecond)
+	}
+
+	// Right now this code is never reached. Need a way to trigger it...
+	println("Disconnecting UDP...")
+	conn.Close()
+	println("Done.")
+
+	return nil
+}
+
+func message(msg string) {
+	println(msg, "\r")
+}

--- a/examples/rtl8720dn/udpstation/wioterminal.go
+++ b/examples/rtl8720dn/udpstation/wioterminal.go
@@ -1,0 +1,71 @@
+// +build wioterminal
+
+package main
+
+import (
+	"device/sam"
+	"machine"
+	"runtime/interrupt"
+	"time"
+
+	"tinygo.org/x/drivers/rtl8720dn"
+)
+
+var (
+	uart UARTx
+)
+
+func handleInterrupt(interrupt.Interrupt) {
+	// should reset IRQ
+	uart.Receive(byte((uart.Bus.DATA.Get() & 0xFF)))
+	uart.Bus.INTFLAG.SetBits(sam.SERCOM_USART_INT_INTFLAG_RXC)
+}
+
+func setupRTL8720DN() (*rtl8720dn.RTL8720DN, error) {
+	machine.RTL8720D_CHIP_PU.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.RTL8720D_CHIP_PU.Low()
+	time.Sleep(100 * time.Millisecond)
+	machine.RTL8720D_CHIP_PU.High()
+	time.Sleep(1000 * time.Millisecond)
+	waitSerial()
+
+	uart = UARTx{
+		UART: &machine.UART{
+			Buffer: machine.NewRingBuffer(),
+			Bus:    sam.SERCOM0_USART_INT,
+			SERCOM: 0,
+		},
+	}
+
+	uart.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, handleInterrupt)
+	uart.Configure(machine.UARTConfig{TX: machine.PB24, RX: machine.PC24, BaudRate: 614400})
+
+	rtl := rtl8720dn.New(uart)
+	rtl.Debug(debug)
+
+	_, err := rtl.Rpc_tcpip_adapter_init()
+	if err != nil {
+		return nil, err
+	}
+
+	return rtl, nil
+}
+
+// Wait for user to open serial console
+func waitSerial() {
+	for !machine.Serial.DTR() {
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+type UARTx struct {
+	*machine.UART
+}
+
+func (u UARTx) Read(p []byte) (n int, err error) {
+	if u.Buffered() == 0 {
+		time.Sleep(1 * time.Millisecond)
+		return 0, nil
+	}
+	return u.UART.Read(p)
+}

--- a/net/net.go
+++ b/net/net.go
@@ -342,6 +342,18 @@ func (a *TCPAddr) opAddr() Addr {
 
 // ParseIP parses s as an IP address, returning the result.
 func ParseIP(s string) IP {
+	b := strings.Split(s, ".")
+	if len(b) == 4 {
+		ip := make([]byte, 4)
+
+		for i := range ip {
+			x, _ := strconv.ParseUint(b[i], 10, 8)
+			ip[i] = byte(x)
+		}
+
+		return IP(ip)
+	}
+
 	return IP([]byte(s))
 }
 

--- a/rtl8720dn/rtl8720dn.go
+++ b/rtl8720dn/rtl8720dn.go
@@ -15,6 +15,7 @@ type RTL8720DN struct {
 	client         uint32
 	length         int
 	root_ca        *string
+	udpInfo        [6]byte // Port: [2]byte + IP: [4]byte
 }
 
 type ConnectionType int


### PR DESCRIPTION
This PR adds support for UDP.
The following examples are newly supported

* examples/rtl8720dn/ntpclient
* examples/rtl8720dn/udpstation

The main changes in this PR are as follows
This PR can be merged after #287 has been merged.

```
$ git diff --name-status rtl8720dn_http
A       examples/rtl8720dn/ntpclient/main.go
A       examples/rtl8720dn/ntpclient/wioterminal.go
A       examples/rtl8720dn/udpstation/main.go
A       examples/rtl8720dn/udpstation/wioterminal.go
M       net/net.go
M       rtl8720dn/netdriver.go
M       rtl8720dn/rtl8720dn.go
```