### PR TITLE
rtl8720dn: add examples/rtl8720dn/tcpclient

### DIFF
--- a/examples/rtl8720dn/tcpclient/main.go
+++ b/examples/rtl8720dn/tcpclient/main.go
@@ -1,0 +1,121 @@
+// This example opens a TCP connection using a device with RTL8720DN firmware
+// and sends some data, for the purpose of testing speed and connectivity.
+//
+// You can open a server to accept connections from this program using:
+//
+// nc -w 5 -lk 8080
+//
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	"tinygo.org/x/drivers/net"
+)
+
+// You can override the setting with the init() in another source code.
+// func init() {
+//    ssid = "sghome-gw"
+//    password = "3af25537b4524"
+//    serverIP = "192.168.1.119"
+//    debug = true
+// }
+
+var (
+	ssid     string
+	password string
+	serverIP = ""
+	debug    = false
+)
+
+var buf = &bytes.Buffer{}
+
+func main() {
+	err := run()
+	for err != nil {
+		fmt.Printf("error: %s\r\n", err.Error())
+		time.Sleep(5 * time.Second)
+	}
+}
+
+func run() error {
+	rtl, err := setupRTL8720DN()
+	if err != nil {
+		return err
+	}
+	net.UseDriver(rtl)
+
+	err = rtl.ConnectToAP(ssid, password)
+	if err != nil {
+		return err
+	}
+
+	ip, subnet, gateway, err := rtl.GetIP()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("IP Address : %s\r\n", ip)
+	fmt.Printf("Mask       : %s\r\n", subnet)
+	fmt.Printf("Gateway    : %s\r\n", gateway)
+
+	for {
+		sendBatch()
+		time.Sleep(500 * time.Millisecond)
+	}
+	println("Done.")
+
+	return nil
+}
+
+func sendBatch() {
+
+	// make TCP connection
+	ip := net.ParseIP(serverIP)
+	raddr := &net.TCPAddr{IP: ip, Port: 8080}
+	laddr := &net.TCPAddr{Port: 8080}
+
+	message("---------------\r\nDialing TCP connection")
+	conn, err := net.DialTCP("tcp", laddr, raddr)
+	for ; err != nil; conn, err = net.DialTCP("tcp", laddr, raddr) {
+		message(err.Error())
+		time.Sleep(5 * time.Second)
+	}
+
+	n := 0
+	w := 0
+	start := time.Now()
+
+	// send data
+	message("Sending data")
+
+	for i := 0; i < 1000; i++ {
+		buf.Reset()
+		fmt.Fprint(buf,
+			"\r---------------------------- i == ", i, " ----------------------------"+
+				"\r---------------------------- i == ", i, " ----------------------------")
+		if w, err = conn.Write(buf.Bytes()); err != nil {
+			println("error:", err.Error(), "\r")
+			continue
+		}
+		n += w
+	}
+
+	buf.Reset()
+	ms := time.Now().Sub(start).Milliseconds()
+	fmt.Fprint(buf, "\nWrote ", n, " bytes in ", ms, " ms\r\n")
+	message(buf.String())
+
+	if _, err := conn.Write(buf.Bytes()); err != nil {
+		println("error:", err.Error(), "\r")
+	}
+
+	// Right now this code is never reached. Need a way to trigger it...
+	println("Disconnecting TCP...")
+	conn.Close()
+}
+
+func message(msg string) {
+	println(msg, "\r")
+}

--- a/examples/rtl8720dn/tcpclient/wioterminal.go
+++ b/examples/rtl8720dn/tcpclient/wioterminal.go
@@ -1,0 +1,71 @@
+// +build wioterminal
+
+package main
+
+import (
+	"device/sam"
+	"machine"
+	"runtime/interrupt"
+	"time"
+
+	"tinygo.org/x/drivers/rtl8720dn"
+)
+
+var (
+	uart UARTx
+)
+
+func handleInterrupt(interrupt.Interrupt) {
+	// should reset IRQ
+	uart.Receive(byte((uart.Bus.DATA.Get() & 0xFF)))
+	uart.Bus.INTFLAG.SetBits(sam.SERCOM_USART_INT_INTFLAG_RXC)
+}
+
+func setupRTL8720DN() (*rtl8720dn.RTL8720DN, error) {
+	machine.RTL8720D_CHIP_PU.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.RTL8720D_CHIP_PU.Low()
+	time.Sleep(100 * time.Millisecond)
+	machine.RTL8720D_CHIP_PU.High()
+	time.Sleep(1000 * time.Millisecond)
+	waitSerial()
+
+	uart = UARTx{
+		UART: &machine.UART{
+			Buffer: machine.NewRingBuffer(),
+			Bus:    sam.SERCOM0_USART_INT,
+			SERCOM: 0,
+		},
+	}
+
+	uart.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, handleInterrupt)
+	uart.Configure(machine.UARTConfig{TX: machine.PB24, RX: machine.PC24, BaudRate: 614400})
+
+	rtl := rtl8720dn.New(uart)
+	rtl.Debug(debug)
+
+	_, err := rtl.Rpc_tcpip_adapter_init()
+	if err != nil {
+		return nil, err
+	}
+
+	return rtl, nil
+}
+
+// Wait for user to open serial console
+func waitSerial() {
+	for !machine.Serial.DTR() {
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+type UARTx struct {
+	*machine.UART
+}
+
+func (u UARTx) Read(p []byte) (n int, err error) {
+	if u.Buffered() == 0 {
+		time.Sleep(1 * time.Millisecond)
+		return 0, nil
+	}
+	return u.UART.Read(p)
+}

--- a/rtl8720dn/netdriver.go
+++ b/rtl8720dn/netdriver.go
@@ -32,9 +32,13 @@ func (r *RTL8720DN) ConnectTCPSocket(addr, port string) error {
 	}
 
 	ipaddr := make([]byte, 4)
-	_, err := r.Rpc_netconn_gethostbyname(addr, &ipaddr)
-	if err != nil {
-		return err
+	if len(addr) == 4 {
+		copy(ipaddr, addr)
+	} else {
+		_, err := r.Rpc_netconn_gethostbyname(addr, &ipaddr)
+		if err != nil {
+			return err
+		}
 	}
 
 	portNum, err := strconv.ParseUint(port, 0, 0)


### PR DESCRIPTION
This PR adds examples/rtl8720dn/tcpclient.
ConnectTCPSocket() needed to be modified slightly.

The main changes in this PR are as follows
This PR can be merged after #288 has been merged.

```
$ git diff --name-status rtl8720dn_udp
A       examples/rtl8720dn/tcpclient/main.go
A       examples/rtl8720dn/tcpclient/wioterminal.go
M       rtl8720dn/netdriver.go
```