### PR TITLE
wifinina: change examples/wifinina to use http.Get()

### DIFF
--- a/examples/wifinina/http-get/main.go
+++ b/examples/wifinina/http-get/main.go
@@ -4,6 +4,12 @@
 //
 // https://github.com/arduino-libraries/WiFiNINA/blob/master/examples/WiFiWebClientRepeating/
 //
+// This example will not work with samd21 or other systems with less than 32KB
+// of RAM.  Use the following if you want to run wifinina on samd21, etc.
+//
+// examples/wifinina/webclient
+// examples/wifinina/tlsclient
+//
 package main
 
 import (
@@ -23,6 +29,7 @@ const ssid = ""
 const pass = ""
 
 // IP address of the server aka "hub". Replace with your own info.
+// Can specify a URL starting with http or https
 const url = "http://tinygo.org/"
 
 // these are the default pins for the Arduino Nano33 IoT.

--- a/examples/wifinina/http-get/main.go
+++ b/examples/wifinina/http-get/main.go
@@ -1,0 +1,154 @@
+// This example opens a TCP connection using a device with WiFiNINA firmware
+// and sends a HTTP request to retrieve a webpage, based on the following
+// Arduino example:
+//
+// https://github.com/arduino-libraries/WiFiNINA/blob/master/examples/WiFiWebClientRepeating/
+//
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"machine"
+	"strings"
+	"time"
+
+	"tinygo.org/x/drivers/net"
+	"tinygo.org/x/drivers/net/http"
+	"tinygo.org/x/drivers/wifinina"
+)
+
+// access point info
+const ssid = ""
+const pass = ""
+
+// IP address of the server aka "hub". Replace with your own info.
+const url = "http://tinygo.org/"
+
+// these are the default pins for the Arduino Nano33 IoT.
+// change these to connect to a different UART or pins for the ESP8266/ESP32
+var (
+
+	// these are the default pins for the Arduino Nano33 IoT.
+	spi = machine.NINA_SPI
+
+	// this is the ESP chip that has the WIFININA firmware flashed on it
+	adaptor *wifinina.Device
+)
+
+var buf [0x400]byte
+
+var lastRequestTime time.Time
+var conn net.Conn
+
+func setup() {
+	// Configure SPI for 8Mhz, Mode 0, MSB First
+	spi.Configure(machine.SPIConfig{
+		Frequency: 8 * 1e6,
+		SDO:       machine.NINA_SDO,
+		SDI:       machine.NINA_SDI,
+		SCK:       machine.NINA_SCK,
+	})
+
+	adaptor = wifinina.New(spi,
+		machine.NINA_CS,
+		machine.NINA_ACK,
+		machine.NINA_GPIO0,
+		machine.NINA_RESETN)
+	adaptor.Configure()
+}
+
+func main() {
+
+	setup()
+	http.SetBuf(buf[:])
+
+	waitSerial()
+
+	connectToAP()
+
+	// You can send and receive cookies in the following way
+	// 	import "tinygo.org/x/drivers/net/http/cookiejar"
+	// 	jar, err := cookiejar.New(nil)
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// 	client := &http.Client{Jar: jar}
+	// 	http.DefaultClient = client
+
+	cnt := 0
+	for {
+		// Various examples are as follows
+		//
+		// -- Get
+		// 	resp, err := http.Get(url)
+		//
+		// -- Post
+		// 	body := `cnt=12`
+		// 	resp, err = http.Post(url, "application/x-www-form-urlencoded", strings.NewReader(body))
+		//
+		// -- Post with JSON
+		// 	body := `{"msg": "hello"}`
+		// 	resp, err := http.Post(url, "application/json", strings.NewReader(body))
+
+		resp, err := http.Get(url)
+		if err != nil {
+			fmt.Printf("%s\r\n", err.Error())
+			continue
+		}
+
+		fmt.Printf("%s %s\r\n", resp.Proto, resp.Status)
+		for k, v := range resp.Header {
+			fmt.Printf("%s: %s\r\n", k, strings.Join(v, " "))
+		}
+		fmt.Printf("\r\n")
+
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			fmt.Printf("%s\r\n", scanner.Text())
+		}
+		resp.Body.Close()
+
+		cnt++
+		fmt.Printf("-------- %d --------\r\n", cnt)
+		time.Sleep(10 * time.Second)
+	}
+
+}
+
+// Wait for user to open serial console
+func waitSerial() {
+	for !machine.Serial.DTR() {
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// connect to access point
+func connectToAP() {
+	if len(ssid) == 0 || len(pass) == 0 {
+		for {
+			println("Connection failed: Either ssid or password not set")
+			time.Sleep(10 * time.Second)
+		}
+	}
+	time.Sleep(2 * time.Second)
+	message("Connecting to " + ssid)
+	adaptor.SetPassphrase(ssid, pass)
+	for st, _ := adaptor.GetConnectionStatus(); st != wifinina.StatusConnected; {
+		message("Connection status: " + st.String())
+		time.Sleep(1 * time.Second)
+		st, _ = adaptor.GetConnectionStatus()
+	}
+	message("Connected.")
+	time.Sleep(2 * time.Second)
+	ip, _, _, err := adaptor.GetIP()
+	for ; err != nil; ip, _, _, err = adaptor.GetIP() {
+		message(err.Error())
+		time.Sleep(1 * time.Second)
+	}
+	message(ip.String())
+}
+
+func message(msg string) {
+	println(msg, "\r")
+}


### PR DESCRIPTION
Changed to use tinygo.org/drivers/net/http.Get(), added in #287
With this change, webclient and tlsclient now have almost the same source code.
This means that there is no longer a difference between http and https.

```
$ diff examples/wifinina/webclient/main.go examples/wifinina/tlsclient/main.go
2,3c2
< // and sends a HTTP request to retrieve a webpage, based on the following
< // Arduino example:
---
> // and sends a HTTPS request to retrieve a webpage
5c4,6
< // https://github.com/arduino-libraries/WiFiNINA/blob/master/examples/WiFiWebClientRepeating/
---
> // You shall see "strict-transport-security" header in the response,
> // this confirms communication is indeed over HTTPS
> // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
26c27
< const url = "http://tinygo.org/"
---
> const url = "https://www.example.com/"
39c40
< var buf [0x400]byte
---
> var buf [0x1000]byte
```

The bad thing about this PR is that the memory usage has probably increased.
The current drivers/net/http are implemented in such a way that the entire response is put into memory.
This may be a problem for samd21.

If memory usage is a problem, it may be a good idea to leave the current webclient/tlsclient as is and create a new example.
