### PR TITLE
ili9341: change to use drivers.SPI interface

### DIFF
--- a/ili9341/spi.go
+++ b/ili9341/spi.go
@@ -4,15 +4,17 @@ package ili9341
 
 import (
 	"machine"
+
+	"tinygo.org/x/drivers"
 )
 
 var buf [64]byte
 
 type spiDriver struct {
-	bus machine.SPI
+	bus drivers.SPI
 }
 
-func NewSPI(bus machine.SPI, dc, cs, rst machine.Pin) *Device {
+func NewSPI(bus drivers.SPI, dc, cs, rst machine.Pin) *Device {
 	return &Device{
 		dc:  dc,
 		cs:  cs,


### PR DESCRIPTION
SPI interface instead of machine.SPI in order to work with the rp2040.
The rp2040 is because the definition of machine.SPI0 is a pointer.

https://github.com/tinygo-org/tinygo/blob/dev/src/machine/machine_rp2040_spi.go#L10-L20

Rather than separate implementation of examples for RP2040, I think we should use drivers.SPI interface for ease of testing.