### PR TITLE
all: Go 1.17 fmt corrections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 clean:
 	@rm -rf build
 
-FMT_PATHS = ./*.go ./examples/**/*.go
+FMT_PATHS = ./
 
 fmt-check:
 	@unformatted=$$(gofmt -l $(FMT_PATHS)); [ -z "$$unformatted" ] && exit 0; echo "Unformatted:"; for fn in $$unformatted; do echo "  $$fn"; done; exit 1

--- a/dht/highfreq.go
+++ b/dht/highfreq.go
@@ -1,4 +1,5 @@
-// +build mimxrt1062  stm32f405  atsamd51  stm32f103xx  k210  stm32f407
+//go:build mimxrt1062 || stm32f405 || atsamd51 || stm32f103xx || k210 || stm32f407
+// +build mimxrt1062 stm32f405 atsamd51 stm32f103xx k210 stm32f407
 
 package dht // import "tinygo.org/x/drivers/dht"
 

--- a/dht/lowfreq.go
+++ b/dht/lowfreq.go
@@ -1,3 +1,4 @@
+//go:build !mimxrt1062 && !stm32f405 && !atsamd51 && !stm32f103xx && !k210 && !stm32f407
 // +build !mimxrt1062,!stm32f405,!atsamd51,!stm32f103xx,!k210,!stm32f407
 
 package dht // import "tinygo.org/x/drivers/dht"

--- a/examples/ili9341/basic/atsamd21.go
+++ b/examples/ili9341/basic/atsamd21.go
@@ -1,3 +1,4 @@
+//go:build atsamd21
 // +build atsamd21
 
 package main

--- a/examples/ili9341/basic/pyportal.go
+++ b/examples/ili9341/basic/pyportal.go
@@ -1,3 +1,4 @@
+//go:build pyportal
 // +build pyportal
 
 package main

--- a/examples/ili9341/basic/wioterminal.go
+++ b/examples/ili9341/basic/wioterminal.go
@@ -1,3 +1,4 @@
+//go:build wioterminal
 // +build wioterminal
 
 package main

--- a/examples/ili9341/pyportal_boing/pyportal.go
+++ b/examples/ili9341/pyportal_boing/pyportal.go
@@ -1,3 +1,4 @@
+//go:build pyportal
 // +build pyportal
 
 package main

--- a/examples/ili9341/pyportal_boing/wioterminal.go
+++ b/examples/ili9341/pyportal_boing/wioterminal.go
@@ -1,3 +1,4 @@
+//go:build wioterminal
 // +build wioterminal
 
 package main

--- a/examples/ili9341/scroll/atsamd21.go
+++ b/examples/ili9341/scroll/atsamd21.go
@@ -1,3 +1,4 @@
+//go:build atsamd21
 // +build atsamd21
 
 package main

--- a/examples/ili9341/scroll/pyportal.go
+++ b/examples/ili9341/scroll/pyportal.go
@@ -1,3 +1,4 @@
+//go:build pyportal
 // +build pyportal
 
 package main

--- a/examples/ili9341/scroll/wioterminal.go
+++ b/examples/ili9341/scroll/wioterminal.go
@@ -1,3 +1,4 @@
+//go:build wioterminal
 // +build wioterminal
 
 package main

--- a/examples/rtl8720dn/mqttclient/wioterminal.go
+++ b/examples/rtl8720dn/mqttclient/wioterminal.go
@@ -1,3 +1,4 @@
+//go:build wioterminal
 // +build wioterminal
 
 package main

--- a/examples/rtl8720dn/mqttsub/wioterminal.go
+++ b/examples/rtl8720dn/mqttsub/wioterminal.go
@@ -1,3 +1,4 @@
+//go:build wioterminal
 // +build wioterminal
 
 package main

--- a/examples/rtl8720dn/ntpclient/wioterminal.go
+++ b/examples/rtl8720dn/ntpclient/wioterminal.go
@@ -1,3 +1,4 @@
+//go:build wioterminal
 // +build wioterminal
 
 package main

--- a/examples/rtl8720dn/tcpclient/wioterminal.go
+++ b/examples/rtl8720dn/tcpclient/wioterminal.go
@@ -1,3 +1,4 @@
+//go:build wioterminal
 // +build wioterminal
 
 package main

--- a/examples/rtl8720dn/tlsclient/wioterminal.go
+++ b/examples/rtl8720dn/tlsclient/wioterminal.go
@@ -1,3 +1,4 @@
+//go:build wioterminal
 // +build wioterminal
 
 package main

--- a/examples/rtl8720dn/udpstation/wioterminal.go
+++ b/examples/rtl8720dn/udpstation/wioterminal.go
@@ -1,3 +1,4 @@
+//go:build wioterminal
 // +build wioterminal
 
 package main

--- a/examples/rtl8720dn/webclient-tinyterm/wioterminal.go
+++ b/examples/rtl8720dn/webclient-tinyterm/wioterminal.go
@@ -1,3 +1,4 @@
+//go:build wioterminal
 // +build wioterminal
 
 package main

--- a/examples/rtl8720dn/webclient/wioterminal.go
+++ b/examples/rtl8720dn/webclient/wioterminal.go
@@ -1,3 +1,4 @@
+//go:build wioterminal
 // +build wioterminal
 
 package main

--- a/examples/rtl8720dn/webserver/wioterminal.go
+++ b/examples/rtl8720dn/webserver/wioterminal.go
@@ -1,3 +1,4 @@
+//go:build wioterminal
 // +build wioterminal
 
 package main

--- a/examples/sdcard/console/feather-m4.go
+++ b/examples/sdcard/console/feather-m4.go
@@ -1,3 +1,4 @@
+//go:build feather_m4 || feather_m4_can || feather_nrf52840
 // +build feather_m4 feather_m4_can feather_nrf52840
 
 package main

--- a/examples/sdcard/console/grandcentral-m4.go
+++ b/examples/sdcard/console/grandcentral-m4.go
@@ -1,5 +1,5 @@
-//go:build ignore
-// +build ignore
+//go:build grandcentral_m4
+// +build grandcentral_m4
 
 package main
 

--- a/examples/sdcard/console/grandcentral-m4.go
+++ b/examples/sdcard/console/grandcentral-m4.go
@@ -1,4 +1,5 @@
-// +build grandcentral-m4
+//go:build ignore
+// +build ignore
 
 package main
 

--- a/examples/sdcard/console/m0.go
+++ b/examples/sdcard/console/m0.go
@@ -1,3 +1,4 @@
+//go:build atsamd21 && !p1am_100
 // +build atsamd21,!p1am_100
 
 package main

--- a/examples/sdcard/console/p1am-100.go
+++ b/examples/sdcard/console/p1am-100.go
@@ -1,3 +1,4 @@
+//go:build p1am_100
 // +build p1am_100
 
 package main

--- a/examples/sdcard/console/pygamer.go
+++ b/examples/sdcard/console/pygamer.go
@@ -1,3 +1,4 @@
+//go:build pygamer
 // +build pygamer
 
 package main

--- a/examples/sdcard/console/pyportal.go
+++ b/examples/sdcard/console/pyportal.go
@@ -1,3 +1,4 @@
+//go:build pyportal
 // +build pyportal
 
 package main

--- a/examples/sdcard/console/wioterminal.go
+++ b/examples/sdcard/console/wioterminal.go
@@ -1,3 +1,4 @@
+//go:build wioterminal
 // +build wioterminal
 
 package main

--- a/examples/sdcard/tinyfs/console/console.go
+++ b/examples/sdcard/tinyfs/console/console.go
@@ -1,3 +1,4 @@
+//go:build tinygo
 // +build tinygo
 
 package console

--- a/examples/sdcard/tinyfs/feather-m4.go
+++ b/examples/sdcard/tinyfs/feather-m4.go
@@ -1,3 +1,4 @@
+//go:build feather_m4 || feather_m4_can || feather_nrf52840
 // +build feather_m4 feather_m4_can feather_nrf52840
 
 package main

--- a/examples/sdcard/tinyfs/grandcentral-m4.go
+++ b/examples/sdcard/tinyfs/grandcentral-m4.go
@@ -1,5 +1,5 @@
-//go:build ignore
-// +build ignore
+//go:build grandcentral_m4
+// +build grandcentral_m4
 
 package main
 

--- a/examples/sdcard/tinyfs/grandcentral-m4.go
+++ b/examples/sdcard/tinyfs/grandcentral-m4.go
@@ -1,4 +1,5 @@
-// +build grandcentral-m4
+//go:build ignore
+// +build ignore
 
 package main
 

--- a/examples/sdcard/tinyfs/m0.go
+++ b/examples/sdcard/tinyfs/m0.go
@@ -1,3 +1,4 @@
+//go:build atsamd21 && !p1am_100
 // +build atsamd21,!p1am_100
 
 package main

--- a/examples/sdcard/tinyfs/p1am-100.go
+++ b/examples/sdcard/tinyfs/p1am-100.go
@@ -1,3 +1,4 @@
+//go:build p1am_100
 // +build p1am_100
 
 package main

--- a/examples/sdcard/tinyfs/pygamer.go
+++ b/examples/sdcard/tinyfs/pygamer.go
@@ -1,3 +1,4 @@
+//go:build pygamer
 // +build pygamer
 
 package main

--- a/examples/sdcard/tinyfs/pyportal.go
+++ b/examples/sdcard/tinyfs/pyportal.go
@@ -1,3 +1,4 @@
+//go:build pyportal
 // +build pyportal
 
 package main

--- a/examples/sdcard/tinyfs/wioterminal.go
+++ b/examples/sdcard/tinyfs/wioterminal.go
@@ -1,3 +1,4 @@
+//go:build wioterminal
 // +build wioterminal
 
 package main

--- a/flash/transport_qspi_samd.go
+++ b/flash/transport_qspi_samd.go
@@ -1,3 +1,4 @@
+//go:build atsamd51
 // +build atsamd51
 
 package flash

--- a/ili9341/parallel_atsamd51.go
+++ b/ili9341/parallel_atsamd51.go
@@ -1,3 +1,4 @@
+//go:build atsamd51
 // +build atsamd51
 
 package ili9341

--- a/ili9341/spi.go
+++ b/ili9341/spi.go
@@ -1,3 +1,4 @@
+//go:build !atsamd51 && !atsamd21
 // +build !atsamd51,!atsamd21
 
 package ili9341

--- a/ili9341/spi_atsamd21.go
+++ b/ili9341/spi_atsamd21.go
@@ -1,3 +1,4 @@
+//go:build atsamd21
 // +build atsamd21
 
 package ili9341

--- a/ili9341/spi_atsamd51.go
+++ b/ili9341/spi_atsamd51.go
@@ -1,3 +1,4 @@
+//go:build atsamd51
 // +build atsamd51
 
 package ili9341

--- a/microbitmatrix/microbitmatrix-v1.go
+++ b/microbitmatrix/microbitmatrix-v1.go
@@ -1,3 +1,4 @@
+//go:build microbit
 // +build microbit
 
 // Package microbitmatrix implements a driver for the BBC micro:bit's LED matrix.

--- a/microbitmatrix/microbitmatrix-v2.go
+++ b/microbitmatrix/microbitmatrix-v2.go
@@ -1,3 +1,4 @@
+//go:build microbit_v2
 // +build microbit_v2
 
 // Package microbitmatrix implements a driver for the BBC micro:bit version 2 LED matrix.

--- a/shifter/pybadge.go
+++ b/shifter/pybadge.go
@@ -1,3 +1,4 @@
+//go:build pybadge
 // +build pybadge
 
 package shifter

--- a/ws2812/gen-ws2812-arm.go
+++ b/ws2812/gen-ws2812-arm.go
@@ -1,3 +1,4 @@
+//go:build none
 // +build none
 
 package main

--- a/ws2812/ws2812-asm_cortexm.go
+++ b/ws2812/ws2812-asm_cortexm.go
@@ -1,3 +1,4 @@
+//go:build cortexm
 // +build cortexm
 
 package ws2812

--- a/ws2812/ws2812_avr.go
+++ b/ws2812/ws2812_avr.go
@@ -1,3 +1,4 @@
+//go:build avr
 // +build avr
 
 package ws2812

--- a/ws2812/ws2812_cortexm.go
+++ b/ws2812/ws2812_cortexm.go
@@ -1,3 +1,4 @@
+//go:build cortexm
 // +build cortexm
 
 package ws2812

--- a/ws2812/ws2812_generic.go
+++ b/ws2812/ws2812_generic.go
@@ -1,3 +1,4 @@
+//go:build !baremetal
 // +build !baremetal
 
 package ws2812

--- a/ws2812/ws2812_xtensa.go
+++ b/ws2812/ws2812_xtensa.go
@@ -1,3 +1,4 @@
+//go:build xtensa
 // +build xtensa
 
 package ws2812


### PR DESCRIPTION
This PR changes all build tags to match the format `go:build` that is now required by Go 1.17

It also adds a commit to modify the `make fmt-check` to actually check all of the files in each of the driver subdirectories. Oops!