### PR TITLE
Wifinina: transparently maintain wifi connection

### DIFF
--- a/wifinina/wifinina.go
+++ b/wifinina/wifinina.go
@@ -17,7 +17,6 @@ import (
 	"machine"
 
 	"tinygo.org/x/drivers"
-	"tinygo.org/x/drivers/net"
 )
 
 const _debug = false
@@ -294,14 +293,11 @@ func New(bus drivers.SPI, csPin, ackPin, gpio0Pin, resetPin machine.Pin) *Device
 	}
 }
 
-func (d *Device) Configure() {
-
-	net.UseDriver(d.NewDriver())
-
-	d.CS.Configure(machine.PinConfig{machine.PinOutput})
-	d.ACK.Configure(machine.PinConfig{machine.PinInput})
-	d.RESET.Configure(machine.PinConfig{machine.PinOutput})
-	d.GPIO0.Configure(machine.PinConfig{machine.PinOutput})
+func (d *Device) Reset() {
+	d.CS.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	d.ACK.Configure(machine.PinConfig{Mode: machine.PinInput})
+	d.RESET.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	d.GPIO0.Configure(machine.PinConfig{Mode: machine.PinOutput})
 
 	d.GPIO0.High()
 	d.CS.High()
@@ -311,8 +307,7 @@ func (d *Device) Configure() {
 	time.Sleep(1 * time.Millisecond)
 
 	d.GPIO0.Low()
-	d.GPIO0.Configure(machine.PinConfig{machine.PinInput})
-
+	d.GPIO0.Configure(machine.PinConfig{Mode: machine.PinInput})
 }
 
 // ----------- client methods (should this be a separate struct?) ------------


### PR DESCRIPTION
This encapsulates the tedious task of maintaining connection with an access point.
Now you don't have to have that boilerplate in your application code.

Especially useful for devices that can be moved and/or not always have stable WiFi connection.
Supports multiple access points.

Plays nicely with `http.Get` and friends, see refactored example.

P.S. I've tried hard maintain backwards compatibility. Otherwise the API could, probably, be better.