### PR TITLE
ws2812: fix generated build tags

### DIFF
--- a/ws2812/gen-ws2812-arm.go
+++ b/ws2812/gen-ws2812-arm.go
@@ -164,7 +164,8 @@ func main() {
 		os.Exit(1)
 	}
 	defer f.Close()
-	f.WriteString(`// +build cortexm
+	f.WriteString(`//go:build cortexm
+// +build cortexm
 
 package ws2812
 


### PR DESCRIPTION
See https://github.com/tinygo-org/drivers/pull/309 and https://github.com/tinygo-org/drivers/pull/292.

Before this change, the `//go:build` line would be removed. After this change, it is left in place.