### PR TITLE
add Sensor interface

### DIFF
--- a/sensor.go
+++ b/sensor.go
@@ -1,0 +1,31 @@
+package drivers
+
+// Measurement specifies a type of measurement,
+// for example: temperature, acceleration, pressure.
+type Measurement uint32
+
+// Sensor measurements
+const (
+	Voltage Measurement = 1 << iota
+	Temperature
+	Humidity
+	Pressure
+	Distance
+	Acceleration
+	AngularVelocity
+	MagneticField
+	Luminosity
+	Time
+
+	AllMeasurements Measurement = 0xffffffff
+)
+
+// Sensor represents an object capable of making one
+// or more measurements. A sensor will then have methods
+// which read the last updated measurements.
+//
+// Many Sensors may be collected into
+// one Sensor interface to synchronize measurements.
+type Sensor interface {
+	Update(which Measurement) error
+}


### PR DESCRIPTION
Hey there peeps, here's part of the `Update` method proposal. This comes with a `Sensor` interface which implements said method. This interface then could be embedded in all subsequent sensor interface types, i.e:
```go
type Sensor interface {
	Update(which Measurement) error
}

type IMU interface {
    Sensor
    Acceleration() (ax, ay, az int32)
    AngularVelocity() (gx, gy, gz int32)
}

type Barometer interface {
    Sensor
    Pressure() int32
}
```

These changes were first discussed in [`add AHRS interfaces for vehicle attitude control`](https://github.com/tinygo-org/drivers/pull/299) and then added as a formal proposal in [`Proposal: Update method call to read sensor data from a bus`](https://github.com/tinygo-org/drivers/issues/310). There has been little to no discussion on the matter. I will restate some of the benefits of the `Update` proposal:

1. Probably most importantly, error management: Where before errors were discarded now they are formally dealt with.
2. Less bus pressure
3. Idiomatic development of sensor frameworks. Provides us with high level interfaces useful for testing.

To be clear, I think we should still have the `ReadMeasurement` methods which perform an update followed by measurement read which are usually much simpler to understand and work with for people who are new to embedded systems.
