### PR TITLE
DHTXX: Use runtime interrupt instead of UART

### DIFF
--- a/dht/thermometer.go
+++ b/dht/thermometer.go
@@ -8,6 +8,7 @@ package dht // import "tinygo.org/x/drivers/dht"
 
 import (
 	"machine"
+	"runtime/interrupt"
 	"time"
 )
 
@@ -156,9 +157,10 @@ func (t *device) read() error {
 // receiveSignals counts number of low and high cycles. The execution is time critical, so the function disables
 // interrupts
 func receiveSignals(pin machine.Pin, result []counter) {
+	mask := interrupt.Disable()
+	defer interrupt.Restore(mask)
+
 	i := uint8(0)
-	machine.UART1.Interrupt.Disable()
-	defer machine.UART1.Interrupt.Enable()
 	for ; i < 40; i++ {
 		result[i*2] = expectChange(pin, false)
 		result[i*2+1] = expectChange(pin, true)

--- a/examples/dht/main.go
+++ b/examples/dht/main.go
@@ -12,7 +12,7 @@ func main() {
 	dhtSensor := dht.New(pin, dht.DHT11)
 	for {
 		temp, hum, err := dhtSensor.Measurements()
-		if err != nil {
+		if err == nil {
 			fmt.Printf("Temperature: %02d.%d°C, Humidity: %02d.%d%%\n", temp/10, temp%10, hum/10, hum%10)
 		} else {
 			fmt.Printf("Could not take measurements from the sensor: %s\n", err.Error())


### PR DESCRIPTION
Implementing what was being suggested in https://github.com/tinygo-org/drivers/issues/255#issuecomment-852140542.

i quickly tested this on a `itsybitsy-nrf52840` and seems to work fine.

(Should) fix #255

shall I also add a smoke test for this? something like:

```
tinygo build -size short -o ./build/test.hex -target=itsybitsy-nrf52840 ./examples/dht/main.go
```
