### PR TITLE
ili9341, ili9342: add support for m5stack-core2

### DIFF
--- a/examples/ili9341/initdisplay/m5stack_core2.go
+++ b/examples/ili9341/initdisplay/m5stack_core2.go
@@ -1,0 +1,49 @@
+//go:build m5stack_core2
+// +build m5stack_core2
+
+package initdisplay
+
+import (
+	"image/color"
+	"machine"
+
+	axp192 "tinygo.org/x/drivers/axp192/m5stack-core2-axp192"
+	"tinygo.org/x/drivers/i2csoft"
+	"tinygo.org/x/drivers/ili9341"
+)
+
+// InitDisplay initializes the display of each board.
+func InitDisplay() *ili9341.Device {
+	machine.SPI2.Configure(machine.SPIConfig{
+		SCK:       machine.LCD_SCK_PIN,
+		SDO:       machine.LCD_SDO_PIN,
+		SDI:       machine.LCD_SDI_PIN,
+		Frequency: 40e6,
+	})
+
+	i2c := i2csoft.New(machine.SCL0_PIN, machine.SDA0_PIN)
+	i2c.Configure(i2csoft.I2CConfig{Frequency: 100e3})
+
+	axp := axp192.New(i2c)
+	led := axp.LED
+	led.Low()
+
+	display := ili9341.NewSPI(
+		machine.SPI2,
+		machine.LCD_DC_PIN,
+		machine.LCD_SS_PIN,
+		machine.NoPin,
+	)
+
+	// configure display
+	display.Configure(ili9341.Config{
+		Width:            320,
+		Height:           240,
+		DisplayInversion: true,
+	})
+	display.FillScreen(color.RGBA{255, 255, 255, 255})
+
+	display.SetRotation(ili9341.Rotation0Mirror)
+
+	return display
+}

--- a/ili9341/registers.go
+++ b/ili9341/registers.go
@@ -81,4 +81,9 @@ const (
 	Rotation90  Rotation = 1 // 90 degrees clock-wise rotation
 	Rotation180 Rotation = 2
 	Rotation270 Rotation = 3
+
+	Rotation0Mirror   Rotation = 4
+	Rotation90Mirror  Rotation = 5
+	Rotation180Mirror Rotation = 6
+	Rotation270Mirror Rotation = 7
 )


### PR DESCRIPTION
This PR adds the ability to run LCD on M5Stack Core2.
The correct driver is ILI9342, but I created it as ILI9341 first to avoid duplicating the examples code.

ILI9342 DataSheet : https://m5stack.oss-cn-shenzhen.aliyuncs.com/resource/docs/datasheet/core/ILI9342C-ILITEK.pdf

ILI9341 and ILI9342 are almost identical.
The only differences are INVON and MADCTL.

This PR needs to be merged after axp192.
TinyGo 0.21.0 will be released soon and will add M5Stack Core2.
I'd like to get M5Stack Core2's LCD working with TinyGo 0.21.0.