### PR TITLE
ili9341, ili9342: add support for m5stack

### DIFF
--- a/examples/ili9341/initdisplay/m5stack.go
+++ b/examples/ili9341/initdisplay/m5stack.go
@@ -1,0 +1,43 @@
+//go:build m5stack
+// +build m5stack
+
+package initdisplay
+
+import (
+	"machine"
+
+	"tinygo.org/x/drivers/ili9341"
+)
+
+func InitDisplay() *ili9341.Device {
+	machine.SPI2.Configure(machine.SPIConfig{
+		SCK:       machine.SPI0_SCK_PIN,
+		SDO:       machine.SPI0_SDO_PIN,
+		SDI:       machine.SPI0_SDI_PIN,
+		Frequency: 40e6,
+	})
+
+	// configure backlight
+	backlight := machine.LCD_BL_PIN
+	backlight.Configure(machine.PinConfig{machine.PinOutput})
+
+	display := ili9341.NewSPI(
+		machine.SPI2,
+		machine.LCD_DC_PIN,
+		machine.LCD_SS_PIN,
+		machine.LCD_RST_PIN,
+	)
+
+	// configure display
+	display.Configure(ili9341.Config{
+		Width:            320,
+		Height:           240,
+		DisplayInversion: true,
+	})
+
+	backlight.High()
+
+	display.SetRotation(ili9341.Rotation0Mirror)
+
+	return display
+}


### PR DESCRIPTION
This PR adds the ability to run LCD on M5Stack (Basic / Gray).
The LCD in M5Stack is ili9342.