### PR TITLE
add Sensor interface and Measurement type

### DIFF
--- a/sensor.go
+++ b/sensor.go
@@ -1,0 +1,36 @@
+package drivers
+
+// Measurement specifies a type of measurement,
+// for example: temperature, acceleration, pressure.
+type Measurement uint32
+
+// Sensor measurements
+const (
+	Voltage Measurement = 1 << iota
+	Temperature
+	Humidity
+	Pressure
+	Distance
+	Acceleration
+	AngularVelocity
+	MagneticField
+	Luminosity
+	Time
+	// Add Measurements above AllMeasurements.
+
+	// AllMeasurements is the OR of all Measurement values. It ensures all measurements are done.
+	AllMeasurements Measurement = (1 << 32) - 1
+)
+
+// Sensor represents an object capable of making one
+// or more measurements. A sensor will then have methods
+// which read the last updated measurements.
+//
+// Many Sensors may be collected into
+// one Sensor interface to synchronize measurements.
+type Sensor interface {
+	// Update performs IO to update the measurements of a sensor.
+	// It shall return error only when the sensor encounters an error that prevents it from
+	// storing all or part of the measurements it was called to do.
+	Update(which Measurement) error
+}


### PR DESCRIPTION
Re-PRing because I broke my local branch while trying to rebase https://github.com/tinygo-org/drivers/pull/321 to latest dev. I'll copy and paste the contents:

## Some Background
Hey there peeps, here's part of the `Update` method proposal. This comes with a `Sensor` interface which implements said method. This interface then could be embedded in all subsequent sensor interface types, i.e:
```go
type Sensor interface {
	Update(which Measurement) error
}

type IMU interface {
    Sensor
    Acceleration() (ax, ay, az int32)
    AngularVelocity() (gx, gy, gz int32)
}

type Barometer interface {
    Sensor
    Pressure() int32
}
```

### Benefits
These changes were first discussed in [`add AHRS interfaces for vehicle attitude control`](https://github.com/tinygo-org/drivers/pull/299) and then added as a formal proposal in [`Proposal: Update method call to read sensor data from a bus`](https://github.com/tinygo-org/drivers/issues/310). There has been little to no discussion on the matter. I will restate some of the benefits of the `Update` proposal:

1. Probably most importantly, error management: Where before errors were discarded now they are formally dealt with.
2. Less bus pressure
3. Idiomatic development of sensor frameworks. Provides us with high level interfaces useful for testing.

To be clear, I think we should still have the `ReadMeasurement` methods which perform an update followed by measurement read which are usually much simpler to understand and work with for people who are new to embedded systems.

## Demonstrations and Proof of Concept
* Proof of concept using BMP180 and MCP3008: https://github.com/tinygo-org/drivers/pull/335
* #298 implements interface for MPU6050 acceleration/angular velocity sensor

## Comments on current methodology
The way it is currently done there are methods for drivers that look like so:
```go
// No apparent error handling
func (d Dev) ReadMeasurement() (x, y int16) 

// Explicit error handling
func (d Dev) ReadMeasurementWithErr() (x, y int16, err error) 
```
There are some benefits to having these
* Provides a "cleaner" APIs by not having a returned error method as is the case for most drivers today in this repo. i.e `ReadPressure() (microbar int32)` (but discards error)
* It's easier to understand if you are a newcomer to embedded systems
* Less importantly, if one prefers a memory optimized implementation, `ReadMeasurement` method requires no data to be stored before passing it to user.  Nowadays I think storing a couple uint32's should not be a problem on modern controllers.


## Community Comments
Yurii Soldak on adding a `Measurement()` method on top of the `ReadMeasurement()` method:
> So, for say, Barometer, we gonna have 3 methods in a typical driver implementation: Will it not be confusing?
Or we willing to drop ReadPressure()? Shall we standardise on error emitted then incompatible Measurement type requested?

Ayke unsure about an `Audio` Measurement: 
> because audio is a bit different from the others. Unlike things like temperature, humidity, or time, audio requires a large amount of data to move around and is very time sensitive (a delay of 1ms may be far too long).


Patricio on how `Update()` chooses to update measurements
>That said I believe it is worth discussing the side effects of `Update` with an example: on the MPU6050 the registers are ordered as such `AccelXH_int8, AccelXL_int8, ... TempH_int8, TempL_int8, RotHX_int8, RotLX_int8, ... RotLZ_int8`. Say you want Acceleration and rotation, as is common, you would certainly perform a streamed read from `AccelXH` to `RotLZ` as a single i2c transaction, but now you've also read the temperature into buffer. Now, if I've counted the possibilities correctly, you have two options which decide how you document `Update`:
1. `// Update reads sensor data requested. Does not guarantee only the sensors requested are read`. When calling `Measurement`, data is read straight from the buffer
2. `// Update reads only sensor data requested.`. This probably means you have to create struct field for each sensor data and only save to it the values requested. This takes up more space if also storing the buffer inside the struct. Goes from 24 bytes to 48 or so. A small benefit of this is that there need not be byte shifting and ORing on `Measurement` call since `Update` already does that for us.
