### PR TITLE
Fix Nano 33 BLE drivers

### DIFF
--- a/apds9960/apds9960.go
+++ b/apds9960/apds9960.go
@@ -57,58 +57,20 @@ type enableConfig struct {
 	PON  bool
 }
 
+// New creates a new APDS-9960 connection. The I2C bus must already be
+// configured.
+//
+// This function only creates the Device object, it does not touch the device.
+func New(bus drivers.I2C) Device {
+	return Device{bus: bus, Address: ADPS9960_ADDRESS, mode: MODE_NONE}
+}
+
 // Connected returns whether APDS-9960 has been found.
 // It does a "who am I" request and checks the response.
 func (d *Device) Connected() bool {
 	data := []byte{0}
 	d.bus.ReadRegister(d.Address, APDS9960_ID_REG, data)
 	return data[0] == 0xAB
-}
-
-// Configure sets up the APDS-9960 device.
-func (d *Device) Configure(cfg Configuration) {
-	d.DisableAll() // turn off everything
-
-	// "default" settings
-	if cfg.ProximityPulseLength == 0 {
-		cfg.ProximityPulseLength = 16
-	}
-	if cfg.ProximityPulseCount == 0 {
-		cfg.ProximityPulseCount = 64
-	}
-	if cfg.GesturePulseLength == 0 {
-		cfg.GesturePulseLength = 16
-	}
-	if cfg.GesturePulseCount == 0 {
-		cfg.GesturePulseCount = 64
-	}
-	if cfg.ProximityGain == 0 {
-		cfg.ProximityGain = 1
-	}
-	if cfg.GestureGain == 0 {
-		cfg.GestureGain = 1
-	}
-	if cfg.ColorGain == 0 {
-		cfg.ColorGain = 4
-	}
-	if cfg.ADCIntegrationCycles == 0 {
-		cfg.ADCIntegrationCycles = 4
-	}
-	if cfg.threshold == 0 {
-		d.gesture.threshold = 30
-	}
-	if cfg.sensitivity == 0 {
-		d.gesture.sensitivity = 20
-	}
-
-	d.SetProximityPulse(cfg.ProximityPulseLength, cfg.ProximityPulseCount)
-	d.SetGesturePulse(cfg.GesturePulseLength, cfg.GesturePulseCount)
-	d.SetGains(cfg.ProximityGain, cfg.GestureGain, cfg.ColorGain)
-	d.SetADCIntegrationCycles(cfg.ADCIntegrationCycles)
-
-	if cfg.LEDBoost > 0 {
-		d.LEDBoost(cfg.LEDBoost)
-	}
 }
 
 // GetMode returns current engine mode
@@ -352,6 +314,51 @@ func (d *Device) ReadGesture() (gesture int32) {
 }
 
 // private functions
+
+func (d *Device) configureDevice(cfg Configuration) {
+	d.DisableAll() // turn off everything
+
+	// "default" settings
+	if cfg.ProximityPulseLength == 0 {
+		cfg.ProximityPulseLength = 16
+	}
+	if cfg.ProximityPulseCount == 0 {
+		cfg.ProximityPulseCount = 64
+	}
+	if cfg.GesturePulseLength == 0 {
+		cfg.GesturePulseLength = 16
+	}
+	if cfg.GesturePulseCount == 0 {
+		cfg.GesturePulseCount = 64
+	}
+	if cfg.ProximityGain == 0 {
+		cfg.ProximityGain = 1
+	}
+	if cfg.GestureGain == 0 {
+		cfg.GestureGain = 1
+	}
+	if cfg.ColorGain == 0 {
+		cfg.ColorGain = 4
+	}
+	if cfg.ADCIntegrationCycles == 0 {
+		cfg.ADCIntegrationCycles = 4
+	}
+	if cfg.threshold == 0 {
+		d.gesture.threshold = 30
+	}
+	if cfg.sensitivity == 0 {
+		d.gesture.sensitivity = 20
+	}
+
+	d.SetProximityPulse(cfg.ProximityPulseLength, cfg.ProximityPulseCount)
+	d.SetGesturePulse(cfg.GesturePulseLength, cfg.GesturePulseCount)
+	d.SetGains(cfg.ProximityGain, cfg.GestureGain, cfg.ColorGain)
+	d.SetADCIntegrationCycles(cfg.ADCIntegrationCycles)
+
+	if cfg.LEDBoost > 0 {
+		d.LEDBoost(cfg.LEDBoost)
+	}
+}
 
 func (d *Device) enable(cfg enableConfig) {
 	var gen, pien, aien, wen, pen, aen, pon uint8

--- a/apds9960/apds9960_generic.go
+++ b/apds9960/apds9960_generic.go
@@ -5,10 +5,8 @@ package apds9960
 
 import "tinygo.org/x/drivers"
 
-// New creates a new APDS-9960 connection. The I2C bus must already be
-// configured.
-//
-// This function only creates the Device object, it does not touch the device.
-func New(bus drivers.I2C) Device {
-	return Device{bus: bus, Address: ADPS9960_ADDRESS, mode: MODE_NONE}
+// Configure sets up the APDS-9960 device.
+func (d *Device) Configure(cfg Configuration) {
+	// configure device
+	d.configureDevice(cfg)
 }

--- a/apds9960/apds9960_nano_33_ble.go
+++ b/apds9960/apds9960_nano_33_ble.go
@@ -6,24 +6,19 @@ package apds9960
 import (
 	"machine"
 	"time"
-
-	"tinygo.org/x/drivers"
 )
 
-// New creates a new APDS-9960 connection. The I2C bus must already be
-// configured.
-//
-// This function only creates the Device object, it does not touch the device.
-func New(bus drivers.I2C) Device {
-	// turn on internal power pin (machine.P0_22) and I2C1 pullups power pin (machine.P1_00)
-	// and wait a moment.
-	ENV := machine.P0_22
-	ENV.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	ENV.High()
-	R := machine.P1_00
-	R.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	R.High()
-	time.Sleep(time.Millisecond * 10)
+// Configure sets up the APDS-9960 device.
+func (d *Device) Configure(cfg Configuration) {
 
-	return Device{bus: bus, Address: ADPS9960_ADDRESS, mode: MODE_NONE}
+	// Following lines are Nano 33 BLE specific, they have nothing to do with sensor per se
+	machine.LSM_PWR.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.LSM_PWR.High()
+	machine.I2C_PULLUP.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.I2C_PULLUP.High()
+	// Wait a moment
+	time.Sleep(10 * time.Millisecond)
+
+	// configure device
+	d.configureDevice(cfg)
 }

--- a/examples/apds9960/color/main.go
+++ b/examples/apds9960/color/main.go
@@ -9,20 +9,21 @@ import (
 
 func main() {
 
+	// use Nano 33 BLE Sense's internal I2C bus
 	machine.I2C1.Configure(machine.I2CConfig{
-		SCL:       machine.P0_15, // SCL1 on Nano 33 BLE Sense
-		SDA:       machine.P0_14, // SDA1 on Nano 33 BLE Sense
+		SCL:       machine.SCL1_PIN,
+		SDA:       machine.SDA1_PIN,
 		Frequency: machine.TWI_FREQ_400KHZ,
 	})
 
 	sensor := apds9960.New(machine.I2C1)
 
+	sensor.Configure(apds9960.Configuration{}) // use default settings
+
 	if !sensor.Connected() {
 		println("APDS-9960 not connected!")
 		return
 	}
-
-	sensor.Configure(apds9960.Configuration{}) // use default settings
 
 	sensor.EnableColor() // enable color engine
 

--- a/examples/apds9960/gesture/main.go
+++ b/examples/apds9960/gesture/main.go
@@ -9,20 +9,21 @@ import (
 
 func main() {
 
+	// use Nano 33 BLE Sense's internal I2C bus
 	machine.I2C1.Configure(machine.I2CConfig{
-		SCL:       machine.P0_15, // SCL1 on Nano 33 BLE Sense
-		SDA:       machine.P0_14, // SDA1 on Nano 33 BLE Sense
+		SCL:       machine.SCL1_PIN,
+		SDA:       machine.SDA1_PIN,
 		Frequency: machine.TWI_FREQ_400KHZ,
 	})
 
 	sensor := apds9960.New(machine.I2C1)
 
+	sensor.Configure(apds9960.Configuration{}) // use default settings
+
 	if !sensor.Connected() {
 		println("APDS-9960 not connected!")
 		return
 	}
-
-	sensor.Configure(apds9960.Configuration{}) // use default settings
 
 	sensor.EnableGesture() // enable gesture engine
 
@@ -34,7 +35,7 @@ func main() {
 			gesture := sensor.ReadGesture()
 			print("Detected gesture: ")
 			switch gesture {
-			case apds9960.GESTURE_UP:
+			case apds9960.GESTURE_UP: // the nRF52 chip is "up"
 				println("Up")
 			case apds9960.GESTURE_DOWN:
 				println("Down")

--- a/examples/apds9960/proximity/main.go
+++ b/examples/apds9960/proximity/main.go
@@ -9,20 +9,22 @@ import (
 
 func main() {
 
+	// use Nano 33 BLE Sense's internal I2C bus
 	machine.I2C1.Configure(machine.I2CConfig{
-		SCL:       machine.P0_15, // SCL1 on Nano 33 BLE Sense
-		SDA:       machine.P0_14, // SDA1 on Nano 33 BLE Sense
+		SCL:       machine.SCL1_PIN,
+		SDA:       machine.SDA1_PIN,
 		Frequency: machine.TWI_FREQ_400KHZ,
 	})
 
 	sensor := apds9960.New(machine.I2C1)
 
+	// use default settings
+	sensor.Configure(apds9960.Configuration{})
+
 	if !sensor.Connected() {
 		println("APDS-9960 not connected!")
 		return
 	}
-
-	sensor.Configure(apds9960.Configuration{}) // use default settings
 
 	sensor.EnableProximity() // enable proximity engine
 

--- a/examples/hts221/main.go
+++ b/examples/hts221/main.go
@@ -9,28 +9,27 @@ import (
 
 func main() {
 
+	// use Nano 33 BLE Sense's internal I2C bus
 	machine.I2C1.Configure(machine.I2CConfig{
-		SCL:       machine.P0_15, // SCL1 on Nano 33 BLE Sense
-		SDA:       machine.P0_14, // SDA1 on Nano 33 BLE Sense
+		SCL:       machine.SCL1_PIN,
+		SDA:       machine.SDA1_PIN,
 		Frequency: machine.TWI_FREQ_400KHZ,
 	})
 
 	sensor := hts221.New(machine.I2C1)
+
+	sensor.Configure() // power on and calibrate
 
 	if !sensor.Connected() {
 		println("HTS221 not connected!")
 		return
 	}
 
-	sensor.Configure() // power on and calibrate
-
 	for {
-
 		h, _ := sensor.ReadHumidity()
 		t, _ := sensor.ReadTemperature()
 		println("h =", float32(h)/100.0, "% / t =", float32(t)/1000.0, "*C")
 		time.Sleep(time.Second)
-
 	}
 
 }

--- a/examples/lps22hb/main.go
+++ b/examples/lps22hb/main.go
@@ -9,29 +9,27 @@ import (
 
 func main() {
 
+	// use Nano 33 BLE Sense's internal I2C bus
 	machine.I2C1.Configure(machine.I2CConfig{
-		SCL:       machine.P0_15, // SCL1 on Nano 33 BLE Sense
-		SDA:       machine.P0_14, // SDA1 on Nano 33 BLE Sense
+		SCL:       machine.SCL1_PIN,
+		SDA:       machine.SDA1_PIN,
 		Frequency: machine.TWI_FREQ_400KHZ,
 	})
 
 	sensor := lps22hb.New(machine.I2C1)
+	sensor.Configure()
 
 	if !sensor.Connected() {
 		println("LPS22HB not connected!")
 		return
 	}
 
-	sensor.Configure()
-
 	for {
-
 		p, _ := sensor.ReadPressure()
 		t, _ := sensor.ReadTemperature()
 		println("p =", float32(p)/1000.0, "hPa / t =", float32(t)/1000.0, "*C")
 		time.Sleep(time.Second)
 		// note: the device would power down itself after each query
-
 	}
 
 }

--- a/hts221/hts221.go
+++ b/hts221/hts221.go
@@ -21,20 +21,20 @@ type Device struct {
 	temperatureZero  float32
 }
 
+// New creates a new HTS221 connection. The I2C bus must already be
+// configured.
+//
+// This function only creates the Device object, it does not touch the device.
+func New(bus drivers.I2C) Device {
+	return Device{bus: bus, Address: HTS221_ADDRESS}
+}
+
 // Connected returns whether HTS221 has been found.
 // It does a "who am I" request and checks the response.
 func (d *Device) Connected() bool {
 	data := []byte{0}
 	d.bus.ReadRegister(d.Address, HTS221_WHO_AM_I_REG, data)
 	return data[0] == 0xBC
-}
-
-// Configure sets up the HTS221 device for communication.
-func (d *Device) Configure() {
-	// read calibration data
-	d.calibration()
-	// activate device and use block data update mode
-	d.Power(true)
 }
 
 // Power is for turn on/off the HTS221 device

--- a/hts221/hts221_generic.go
+++ b/hts221/hts221_generic.go
@@ -5,10 +5,10 @@ package hts221
 
 import "tinygo.org/x/drivers"
 
-// New creates a new HTS221 connection. The I2C bus must already be
-// configured.
-//
-// This function only creates the Device object, it does not touch the device.
-func New(bus drivers.I2C) Device {
-	return Device{bus: bus, Address: HTS221_ADDRESS}
+// Configure sets up the HTS221 device for communication.
+func (d *Device) Configure() {
+	// read calibration data
+	d.calibration()
+	// activate device and use block data update mode
+	d.Power(true)
 }

--- a/hts221/hts221_nano_33_ble.go
+++ b/hts221/hts221_nano_33_ble.go
@@ -11,8 +11,8 @@ import (
 // Configure sets up the HTS221 device for communication.
 func (d *Device) Configure() {
 	// Following lines are Nano 33 BLE specific, they have nothing to do with sensor per se
-	machine.LSM_PWR.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	machine.LSM_PWR.High()
+	machine.HTS_PWR.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.HTS_PWR.High()
 	machine.I2C_PULLUP.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	machine.I2C_PULLUP.High()
 	// Wait a moment

--- a/hts221/hts221_nano_33_ble.go
+++ b/hts221/hts221_nano_33_ble.go
@@ -6,24 +6,20 @@ package hts221
 import (
 	"machine"
 	"time"
-
-	"tinygo.org/x/drivers"
 )
 
-// New creates a new HTS221 connection. The I2C bus must already be
-// configured.
-//
-// This function only creates the Device object, it does not touch the device.
-func New(bus drivers.I2C) Device {
-	// turn on internal power pin (machine.P0_22) and I2C1 pullups power pin (machine.P1_00)
-	// and wait a moment.
-	ENV := machine.P0_22
-	ENV.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	ENV.High()
-	R := machine.P1_00
-	R.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	R.High()
-	time.Sleep(time.Millisecond * 10)
+// Configure sets up the HTS221 device for communication.
+func (d *Device) Configure() {
+	// Following lines are Nano 33 BLE specific, they have nothing to do with sensor per se
+	machine.LSM_PWR.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.LSM_PWR.High()
+	machine.I2C_PULLUP.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.I2C_PULLUP.High()
+	// Wait a moment
+	time.Sleep(10 * time.Millisecond)
 
-	return Device{bus: bus, Address: HTS221_ADDRESS}
+	// read calibration data
+	d.calibration()
+	// activate device and use block data update mode
+	d.Power(true)
 }

--- a/lps22hb/lps22hb.go
+++ b/lps22hb/lps22hb.go
@@ -14,18 +14,12 @@ type Device struct {
 	Address uint8
 }
 
-// Connected returns whether LPS22HB has been found.
-// It does a "who am I" request and checks the response.
-func (d *Device) Connected() bool {
-	data := []byte{0}
-	d.bus.ReadRegister(d.Address, LPS22HB_WHO_AM_I_REG, data)
-	return data[0] == 0xB1
-}
-
-// Configure sets up the LPS22HB device for communication.
-func (d *Device) Configure() {
-	// set to block update mode
-	d.bus.WriteRegister(d.Address, LPS22HB_CTRL1_REG, []byte{0x02})
+// New creates a new LPS22HB connection. The I2C bus must already be
+// configured.
+//
+// This function only creates the Device object, it does not touch the device.
+func New(bus drivers.I2C) Device {
+	return Device{bus: bus, Address: LPS22HB_ADDRESS}
 }
 
 // ReadPressure returns the pressure in milli pascals (mPa).
@@ -40,6 +34,14 @@ func (d *Device) ReadPressure() (pressure int32, err error) {
 	pValue := float32(uint32(data[2])<<16|uint32(data[1])<<8|uint32(data[0])) / 4096.0
 
 	return int32(pValue * 1000), nil
+}
+
+// Connected returns whether LPS22HB has been found.
+// It does a "who am I" request and checks the response.
+func (d *Device) Connected() bool {
+	data := []byte{0}
+	d.bus.ReadRegister(d.Address, LPS22HB_WHO_AM_I_REG, data)
+	return data[0] == 0xB1
 }
 
 // ReadTemperature returns the temperature in celsius milli degrees (°C/1000).

--- a/lps22hb/lps22hb_generic.go
+++ b/lps22hb/lps22hb_generic.go
@@ -5,10 +5,8 @@ package lps22hb
 
 import "tinygo.org/x/drivers"
 
-// New creates a new LPS22HB connection. The I2C bus must already be
-// configured.
-//
-// This function only creates the Device object, it does not touch the device.
-func New(bus drivers.I2C) Device {
-	return Device{bus: bus, Address: LPS22HB_ADDRESS}
+// Configure sets up the LPS22HB device for communication.
+func (d *Device) Configure() {
+	// set to block update mode
+	d.bus.WriteRegister(d.Address, LPS22HB_CTRL1_REG, []byte{0x02})
 }

--- a/lps22hb/lps22hb_nano_33_ble.go
+++ b/lps22hb/lps22hb_nano_33_ble.go
@@ -11,8 +11,8 @@ import (
 // Configure sets up the LPS22HB device for communication.
 func (d *Device) Configure() {
 	// Following lines are Nano 33 BLE specific, they have nothing to do with sensor per se
-	machine.LSM_PWR.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	machine.LSM_PWR.High()
+	machine.LSP_PWR.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.LSP_PWR.High()
 	machine.I2C_PULLUP.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	machine.I2C_PULLUP.High()
 	// Wait a moment

--- a/lps22hb/lps22hb_nano_33_ble.go
+++ b/lps22hb/lps22hb_nano_33_ble.go
@@ -6,24 +6,18 @@ package lps22hb
 import (
 	"machine"
 	"time"
-
-	"tinygo.org/x/drivers"
 )
 
-// New creates a new LPS22HB connection. The I2C bus must already be
-// configured.
-//
-// This function only creates the Device object, it does not touch the device.
-func New(bus drivers.I2C) Device {
-	// turn on internal power pin (machine.P0_22) and I2C1 pullups power pin (machine.P1_00)
-	// and wait a moment.
-	ENV := machine.P0_22
-	ENV.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	ENV.High()
-	R := machine.P1_00
-	R.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	R.High()
-	time.Sleep(time.Millisecond * 10)
+// Configure sets up the LPS22HB device for communication.
+func (d *Device) Configure() {
+	// Following lines are Nano 33 BLE specific, they have nothing to do with sensor per se
+	machine.LSM_PWR.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.LSM_PWR.High()
+	machine.I2C_PULLUP.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.I2C_PULLUP.High()
+	// Wait a moment
+	time.Sleep(10 * time.Millisecond)
 
-	return Device{bus: bus, Address: LPS22HB_ADDRESS}
+	// set to block update mode
+	d.bus.WriteRegister(d.Address, LPS22HB_CTRL1_REG, []byte{0x02})
 }


### PR DESCRIPTION
Fix HTS221, LPS22HB and APDS9960 drivers and their examples to fit code convention and use named Nano 33 BLE internal pins.