### PR TITLE
wifinina: correct sendParamStr to handle empty strings

### DIFF
--- a/wifinina/wifinina.go
+++ b/wifinina/wifinina.go
@@ -969,7 +969,9 @@ func (d *Device) sendParamBuf(p []byte, isLastParam bool) (l int) {
 func (d *Device) sendParamStr(p string, isLastParam bool) (l int) {
 	l = len(p)
 	d.SPI.Transfer(uint8(l))
-	d.SPI.Tx([]byte(p), nil)
+	if l > 0 {
+		d.SPI.Tx([]byte(p), nil)
+	}
 	if isLastParam {
 		d.SPI.Transfer(CmdEnd)
 		l += 1


### PR DESCRIPTION
This PR fixes #364 by modifing the WiFiNINA driver function `sendParamStr()` to correctly handle empty strings, such as when connecting to an unsecured access point.