### PR TITLE
ws2812: add support for m5stamp-c3

### DIFF
--- a/examples/ws2812/others_wo_led.go
+++ b/examples/ws2812/others_wo_led.go
@@ -1,5 +1,5 @@
-//go:build !digispark && !arduino && !qtpy && !m5stamp_c3
-// +build !digispark,!arduino,!qtpy,!m5stamp_c3
+//go:build qtpy || m5stamp_c3
+// +build qtpy m5stamp_c3
 
 package main
 
@@ -8,4 +8,4 @@ import "machine"
 // Replace neo and led in the code below to match the pin
 // that you are using if different.
 var neo machine.Pin = machine.WS2812
-var led = machine.LED
+var led = machine.NoPin

--- a/examples/ws2812/qtpy.go
+++ b/examples/ws2812/qtpy.go
@@ -5,11 +5,6 @@ package main
 
 import "machine"
 
-// Replace neo and led in the code below to match the pin
-// that you are using if different.
-var neo machine.Pin = machine.NEOPIXELS
-var led = machine.NoPin
-
 func init() {
 	pwr := machine.NEOPIXELS_POWER
 	pwr.Configure(machine.PinConfig{Mode: machine.PinOutput})


### PR DESCRIPTION
In this PR, add support for m5stamp-c3.
Implemented the case where machine.LED does not exist in others_wo_led.go, as in m5stamp-c3 and qtpy.

Tested with m5stamp-c3 and qtpy.