### PR TITLE
WIP: ws2812: add support for 125MHz for RP2040

### DIFF
--- a/ws2812/ws2812-asm_cortexm.go
+++ b/ws2812/ws2812-asm_cortexm.go
@@ -652,6 +652,305 @@ func (d Device) writeByte120(c byte) {
 	interrupt.Restore(mask)
 }
 
+func (d Device) writeByte125(c byte) {
+	portSet, maskSet := d.Pin.PortMaskSet()
+	portClear, maskClear := d.Pin.PortMaskClear()
+
+	// Timings:
+	// T0H: 44 - 46 cycles or 352.0ns - 368.0ns
+	// T1H: 132 - 134 cycles or 1056.0ns - 1072.0ns
+	// TLD: 144 -    cycles or 1152.0ns -
+	mask := interrupt.Disable()
+	value := uint32(c) << 24
+	device.AsmFull(`
+	1: @ send_bit
+	  str   {maskSet}, {portSet}     @ [2]   T0H and T0L start here
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  lsls  {value}, #1              @ [1]
+	  bcs.n 2f                       @ [1/3] skip_store
+	  str   {maskClear}, {portClear} @ [2]   T0H -> T0L transition
+	2: @ skip_store
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  str   {maskClear}, {portClear} @ [2]   T1H -> T1L transition
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  nop
+	  subs  {i}, #1                  @ [1]
+	  bne.n 1b                       @ [1/3] send_bit
+	`, map[string]interface{}{
+		"value":     value,
+		"i":         8,
+		"maskSet":   maskSet,
+		"portSet":   portSet,
+		"maskClear": maskClear,
+		"portClear": portClear,
+	})
+	interrupt.Restore(mask)
+}
+
 func (d Device) writeByte168(c byte) {
 	portSet, maskSet := d.Pin.PortMaskSet()
 	portClear, maskClear := d.Pin.PortMaskClear()

--- a/ws2812/ws2812.go
+++ b/ws2812/ws2812.go
@@ -1,7 +1,7 @@
 // Package ws2812 implements a driver for WS2812 and SK6812 RGB LED strips.
 package ws2812 // import "tinygo.org/x/drivers/ws2812"
 
-//go:generate go run gen-ws2812.go -arch=cortexm 16 48 64 120 168
+//go:generate go run gen-ws2812.go -arch=cortexm 16 48 64 120 125 168
 //go:generate go run gen-ws2812.go -arch=tinygoriscv 160 320
 
 import (

--- a/ws2812/ws2812_cortexm.go
+++ b/ws2812/ws2812_cortexm.go
@@ -29,6 +29,9 @@ func (d Device) WriteByte(c byte) error {
 	case 120_000_000: // 120MHz
 		d.writeByte120(c)
 		return nil
+	case 125_000_000: // 125MHz
+		d.writeByte125(c)
+		return nil
 	case 168_000_000: // 168MHz, e.g. stm32f405
 		d.writeByte168(c)
 		return nil


### PR DESCRIPTION
This adds support for 125Mhz CPU frequency to WS2812

FYI I accidentally pushed and then reverted this change to dev; was sure of the best way to clean that up, hope I did it correctly.

accidental push: https://github.com/tinygo-org/drivers/commit/b4eb406a43ba15b53b0a466e76cfdaa7e29b4137
revert: https://github.com/tinygo-org/drivers/commit/0ced12683cc455aef1fc621fefde562cfbe2414b