### PR TITLE
image: fix interface

### DIFF
--- a/examples/ili9341/slideshow/main.go
+++ b/examples/ili9341/slideshow/main.go
@@ -72,7 +72,8 @@ func drawPng(display *ili9341.Device) error {
 		}
 	})
 
-	return png.Decode(p)
+	_, err := png.Decode(p)
+	return err
 }
 
 func drawJpeg(display *ili9341.Device) error {
@@ -84,7 +85,8 @@ func drawJpeg(display *ili9341.Device) error {
 		}
 	})
 
-	return jpeg.Decode(p)
+	_, err := jpeg.Decode(p)
+	return err
 }
 
 func errorMessage(err error) {

--- a/image/jpeg/reader.go
+++ b/image/jpeg/reader.go
@@ -773,10 +773,10 @@ func (d *decoder) convertToRGB() (image.Image, error) {
 
 // Decode reads a JPEG image from r. Different from the standard package, the
 // decoded result will be received by the callback set by SetCallback().
-func Decode(r io.Reader) error {
+func Decode(r io.Reader) (image.Image, error) {
 	var d decoder
 	_, err := d.decode(r, false)
-	return err
+	return nil, err
 }
 
 // DecodeConfig returns the color model and dimensions of a JPEG image without

--- a/image/png/reader.go
+++ b/image/png/reader.go
@@ -965,7 +965,7 @@ func (d *decoder) checkHeader() error {
 
 // Decode reads a PNG image from r. Different from the standard package, the
 // decoded result will be received by the callback set by SetCallback().
-func Decode(r io.Reader) error {
+func Decode(r io.Reader) (image.Image, error) {
 	d := &decoder{
 		r:   r,
 		crc: crc32.NewIEEE(),
@@ -974,17 +974,17 @@ func Decode(r io.Reader) error {
 		if err == io.EOF {
 			err = io.ErrUnexpectedEOF
 		}
-		return err
+		return nil, err
 	}
 	for d.stage != dsSeenIEND {
 		if err := d.parseChunk(); err != nil {
 			if err == io.EOF {
 				err = io.ErrUnexpectedEOF
 			}
-			return err
+			return nil, err
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 // DecodeConfig returns the color model and dimensions of a PNG image without


### PR DESCRIPTION
This PR fixes the interface that was discussed in #363.

The test is not OK yet, but it is the same as the Go standard test result, so we won't deal with it here.

```
sago3@B450GT3 MINGW64 ~/dev/src/tinygo.org/x/drivers (fix-interface)
$ cd image/png/ && tinygo test
FAIL    tinygo.org/x/drivers/image/png  0.156s
FAIL

sago3@B450GT3 MINGW64 ~/dev/src/tinygo.org/x/drivers/image/png (fix-interface)
$ cd ../jpeg/ && tinygo test
ld.lld: error: undefined symbol: time.startTimer
>>> referenced by C:\Go\src\time\sleep.go:96
>>>               C:\Users\sago3\AppData\Local\Temp\tinygo2750643149\main.o:(tinygo.org/x/drivers/image/jpeg.TestLargeImageWithShortData)
failed to run tool: ld.lld
error: failed to link C:\Users\sago3\AppData\Local\Temp\tinygo2750643149\main.exe: exit status 1
FAIL
```