### PR TITLE
dht: fix humidity and temperature extraction for DHT22 (#358)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,12 +231,12 @@ endif
 DRIVERS = $(wildcard */)
 NOTESTS = build examples flash semihosting pcd8544 shiftregister st7789 microphone mcp3008 gps microbitmatrix \
 		hcsr04 ssd1331 ws2812 thermistor apa102 easystepper ssd1351 ili9341 wifinina shifter hub75 \
-		hd44780 buzzer ssd1306 espat l9110x st7735 bmi160 l293x dht keypad4x4 max72xx p1am tone tm1637 \
+		hd44780 buzzer ssd1306 espat l9110x st7735 bmi160 l293x keypad4x4 max72xx p1am tone tm1637 \
 		pcf8563 mcp2515 servo sdcard rtl8720dn image cmd i2csoft hts221 lps22hb apds9960 axp192 xpt2046 \
 		ft6336 sx126x ssd1289
 TESTS = $(filter-out $(addsuffix /%,$(NOTESTS)),$(DRIVERS))
 
 unit-test:
-	@go test -v $(addprefix ./,$(TESTS)) 
+	@go test -v $(addprefix ./,$(TESTS))
 
 test: clean fmt-check unit-test smoke-test

--- a/dht/constants.go
+++ b/dht/constants.go
@@ -1,3 +1,6 @@
+//go:build tinygo
+// +build tinygo
+
 // Package dht provides a driver for DHTXX family temperature and humidity sensors.
 //
 // [1] Datasheet DHT11: https://www.mouser.com/datasheet/2/758/DHT11-Technical-Data-Sheet-Translated-Version-1143054.pdf
@@ -7,33 +10,9 @@
 package dht // import "tinygo.org/x/drivers/dht"
 
 import (
-	"encoding/binary"
 	"machine"
 	"time"
 )
-
-// enum type for device type
-type DeviceType uint8
-
-// DeviceType specific parsing of information received from the sensor
-func (d DeviceType) extractData(buf []byte) (temp int16, hum uint16) {
-	if d == DHT11 {
-		temp = int16(buf[2])
-		if buf[3]&0x80 > 0 {
-			temp = -1 - temp
-		}
-		temp *= 10
-		temp += int16(buf[3] & 0x0f)
-		hum = 10*uint16(buf[0]) + uint16(buf[1])
-	} else {
-		hum = binary.LittleEndian.Uint16(buf[0:2])
-		temp = int16(buf[3])<<8 + int16(buf[2]&0x7f)
-		if buf[2]&0x80 > 0 {
-			temp = -temp
-		}
-	}
-	return
-}
 
 // Celsius and Fahrenheit temperature scales
 type TemperatureScale uint8
@@ -53,9 +32,6 @@ type ErrorCode uint8
 const (
 	startTimeout = time.Millisecond * 200
 	startingLow  = time.Millisecond * 20
-
-	DHT11 DeviceType = iota
-	DHT22
 
 	C TemperatureScale = iota
 	F

--- a/dht/device.go
+++ b/dht/device.go
@@ -1,0 +1,44 @@
+package dht
+
+import (
+	"encoding/binary"
+)
+
+// DeviceType is the enum type for device type
+type DeviceType uint8
+
+const (
+	DHT11 DeviceType = iota
+	DHT22
+)
+
+// extractData parses information received from the sensor.
+// The 2 first buffers are for the humidity and
+// the 2 following corresponds to the temperature.
+func (d DeviceType) extractData(buf []byte) (temp int16, hum uint16) {
+	switch d {
+	case DHT11:
+		hum = 10*uint16(buf[0]) + uint16(buf[1])
+		temp = int16(buf[2])
+		if buf[3]&0x80 > 0 {
+			temp = -1 - temp
+		}
+		temp *= 10
+		temp += int16(buf[3] & 0x0f)
+	case DHT22:
+		hum = binary.BigEndian.Uint16(buf[0:2])
+		temp = int16(buf[2]&0x7f)<<8 + int16(buf[3])
+		// the first bit corresponds to the sign bit
+		if buf[2]&0x80 > 0 {
+			temp = -temp
+		}
+	default:
+		// keeping this for retro-compatibility but not tested
+		hum = binary.LittleEndian.Uint16(buf[0:2])
+		temp = int16(buf[3])<<8 + int16(buf[2]&0x7f)
+		if buf[2]&0x80 > 0 {
+			temp = -temp
+		}
+	}
+	return
+}

--- a/dht/device_internal_test.go
+++ b/dht/device_internal_test.go
@@ -1,0 +1,46 @@
+package dht
+
+import (
+	"testing"
+)
+
+func TestDeviceType_extractData(t *testing.T) {
+	bitStr := "0000001010001100000000010101111111101110"
+	buf := bitStringToBytes(bitStr)
+
+	tt := []struct {
+		name     string
+		d        DeviceType
+		buf      []byte
+		wantTemp int16
+		wantHum  uint16
+	}{
+		{
+			// temp = 35.1C hum = 65.2%
+			name: "DHT22", d: DHT22, buf: buf, wantTemp: 351, wantHum: 652,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			gotTemp, gotHum := tc.d.extractData(tc.buf)
+			if gotTemp != tc.wantTemp {
+				t.Errorf("extractData() gotTemp = %v, want %v", gotTemp, tc.wantTemp)
+			}
+			if gotHum != tc.wantHum {
+				t.Errorf("extractData() gotHum = %v, want %v", gotHum, tc.wantHum)
+			}
+		})
+	}
+}
+
+func bitStringToBytes(s string) []byte {
+	b := make([]byte, (len(s)+(8-1))/8)
+	for i, r := range s {
+		if r < '0' || r > '1' {
+			panic("not in range")
+		}
+		b[i>>3] |= byte(r-'0') << uint(7-i&7)
+	}
+	return b
+}

--- a/dht/thermometer.go
+++ b/dht/thermometer.go
@@ -1,3 +1,6 @@
+//go:build tinygo
+// +build tinygo
+
 // Package dht provides a driver for DHTXX family temperature and humidity sensors.
 //
 // [1] Datasheet DHT11: https://www.mouser.com/datasheet/2/758/DHT11-Technical-Data-Sheet-Translated-Version-1143054.pdf

--- a/dht/timesafethermometer.go
+++ b/dht/timesafethermometer.go
@@ -1,3 +1,6 @@
+//go:build tinygo
+// +build tinygo
+
 // Package dht provides a driver for DHTXX family temperature and humidity sensors.
 //
 // [1] Datasheet DHT11: https://www.mouser.com/datasheet/2/758/DHT11-Technical-Data-Sheet-Translated-Version-1143054.pdf

--- a/dht/util.go
+++ b/dht/util.go
@@ -1,3 +1,6 @@
+//go:build tinygo
+// +build tinygo
+
 package dht // import "tinygo.org/x/drivers/dht"
 
 import (


### PR DESCRIPTION
## Context
When reading values from the DHT22 sensor with an ArduinoNano IoT33, the obtained values are not realistic.
e.g.:
```bash
Temperature:  537.6°C, Humidity: 4992.1%
```

## Resolution

Closes issue #358 

The buffer of the temperature value was padded using `LittleEndian` instead of `BigEndian`.
The 2 bytes buffers of the humidity value were just reverted.

Output
```
Temperature: 22.9°C, Humidity: 49.2%
```

NB: To make it works I had to disable the interruption in `receiveSignals`.
```go
state := interrupt.Disable()
defer interrupt.Restore(state)
```

## Tests

I wrote a simple unit test on the `extractData` method using the expected values from the [datasheet of the DHT22]( 
https://cdn-shop.adafruit.com/datasheets/Digital+humidity+and+temperature+sensor+AM2302.pdf).
I am not sure about the UT convention, any feedback is welcome.