### PR TITLE
Add support for '8-step mode' to easystepper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,8 @@ endif
 	@md5sum ./build/test.hex
 	tinygo build -size short -o ./build/test.uf2 -target=pico ./examples/ssd1289/main.go
 	@md5sum ./build/test.uf2
+	tinygo build -size short -o ./build/test.hex -target=pico ./examples/irremote/main.go
+	@md5sum ./build/test.hex
 
 DRIVERS = $(wildcard */)
 NOTESTS = build examples flash semihosting pcd8544 shiftregister st7789 microphone mcp3008 gps microbitmatrix \

--- a/easystepper/easystepper.go
+++ b/easystepper/easystepper.go
@@ -6,28 +6,65 @@ import (
 	"time"
 )
 
+// StepMode determines the number of coil configurations for a single step
+type StepMode uint8
+
+// Valid values for StepMode
+const (
+	FourStepMode  = 4 // 12-23-34-41
+	EightStepMode = 8 // 1-12-2-23-3-34-4-41
+)
+
+// Device defines the interface for a single easystepper driver
+type Device interface {
+	// Configure configures the pins of the Device
+	Configure()
+	// Move rotates the motor the given number of steps (negative steps rotates in opposite direction)
+	// This method uses the '4-Step' model 12-23-34-41 and is retained for backwards compatibility
+	Move(steps int32)
+	// MoveStepsMode rotates the motor the given number of steps using the given step mode
+	// Negative steps rotates in opposite direction)
+	MoveStepsMode(steps int32, mode StepMode)
+	// Off turns off all motor pins
+	Off()
+}
+
+// DualDevice defines the interface for a dual easystepper driver
+type DualDevice interface {
+	// Configure configures the pins of the DualDevice
+	Configure()
+	// Move rotates the motor the given number of steps (negative steps rotates in opposite direction)
+	// This method uses the '4-Step' model 12-23-34-41 and is retained for backwards compatibility
+	Move(stepsA, stepsB int32)
+	// MoveStepsMode rotates the motors the given number of steps using the given step mode
+	// Negative steps rotates in opposite direction)
+	MoveStepsMode(stepsA, stepsB int32, mode StepMode)
+	// Off turns off all motor pins
+	Off()
+}
+
 // Device holds the pins and the delay between steps
-type Device struct {
+type device struct {
 	pins       [4]machine.Pin
 	stepDelay  int32
 	stepNumber uint8
 }
 
 // DualDevice holds information for controlling 2 motors
-type DualDevice struct {
-	devices [2]Device
+type dualDevice struct {
+	devices [2]device
 }
 
 // New returns a new easystepper driver given 4 pins, number of steps and rpm
 func New(pin1, pin2, pin3, pin4 machine.Pin, steps int32, rpm int32) Device {
-	return Device{
+	return &device{
 		pins:      [4]machine.Pin{pin1, pin2, pin3, pin4},
 		stepDelay: 60000000 / (steps * rpm),
 	}
 }
 
 // Configure configures the pins of the Device
-func (d *Device) Configure() {
+func (d *device) Configure() {
 	for _, pin := range d.pins {
 		pin.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	}
@@ -35,50 +72,62 @@ func (d *Device) Configure() {
 
 // NewDual returns a new dual easystepper driver given 8 pins, number of steps and rpm
 func NewDual(pin1, pin2, pin3, pin4, pin5, pin6, pin7, pin8 machine.Pin, steps int32, rpm int32) DualDevice {
-	var dual DualDevice
-	dual.devices[0] = Device{
+	var dual dualDevice
+	dual.devices[0] = device{
 		pins:      [4]machine.Pin{pin1, pin2, pin3, pin4},
 		stepDelay: 60000000 / (steps * rpm),
 	}
-	dual.devices[1] = Device{
+	dual.devices[1] = device{
 		pins:      [4]machine.Pin{pin5, pin6, pin7, pin8},
 		stepDelay: 60000000 / (steps * rpm),
 	}
-	return dual
+	return &dual
 }
 
 // Configure configures the pins of the DualDevice
-func (d *DualDevice) Configure() {
+func (d *dualDevice) Configure() {
 	d.devices[0].Configure()
 	d.devices[1].Configure()
 }
 
-// Move rotates the motor the number of given steps
+// Move rotates the motor the number of given steps using 4-step mode
 // (negative steps will rotate it the opposite direction)
-func (d *Device) Move(steps int32) {
+func (d *device) Move(steps int32) {
+	d.MoveStepsMode(steps, FourStepMode)
+}
+
+// MoveStepsMode rotates the motor the number of given steps using the given step mode
+// (negative steps will rotate it the opposite direction)
+func (d *device) MoveStepsMode(steps int32, mode StepMode) {
 	direction := steps > 0
 	if steps < 0 {
 		steps = -steps
 	}
 	steps += int32(d.stepNumber)
 	var s int32
-	d.stepMotor(d.stepNumber)
+	d.stepMotor(d.stepNumber, mode)
 	for s = int32(d.stepNumber); s < steps; s++ {
 		time.Sleep(time.Duration(d.stepDelay) * time.Microsecond)
-		d.moveDirectionSteps(direction, s)
+		d.moveDirectionSteps(direction, s, mode)
 	}
 }
 
 // Off turns off all motor pins
-func (d *Device) Off() {
+func (d *device) Off() {
 	for _, pin := range d.pins {
 		pin.Low()
 	}
 }
 
-// Move rotates the motors the number of given steps
+// Move rotates the motor the number of given steps using 4-step mode
 // (negative steps will rotate it the opposite direction)
-func (d *DualDevice) Move(stepsA, stepsB int32) {
+func (d *dualDevice) Move(stepsA, stepsB int32) {
+	d.MoveStepsMode(stepsA, stepsB, FourStepMode)
+}
+
+// MoveStepsMode rotates the motor the number of given steps using the given step mode
+// (negative steps will rotate it the opposite direction)
+func (d *dualDevice) MoveStepsMode(stepsA, stepsB int32, mode StepMode) {
 	min := uint8(1)
 	max := uint8(0)
 	var directions [2]bool
@@ -96,29 +145,38 @@ func (d *DualDevice) Move(stepsA, stepsB int32) {
 		stepsA, stepsB = stepsB, stepsA
 		max, min = min, max
 	}
-	d.devices[0].stepMotor(d.devices[0].stepNumber)
-	d.devices[1].stepMotor(d.devices[1].stepNumber)
+	d.devices[0].stepMotor(d.devices[0].stepNumber, mode)
+	d.devices[1].stepMotor(d.devices[1].stepNumber, mode)
 	stepsA += int32(d.devices[max].stepNumber)
 	minStep = int32(d.devices[min].stepNumber)
 	for s := int32(d.devices[max].stepNumber); s < stepsA; s++ {
 		time.Sleep(time.Duration(d.devices[0].stepDelay) * time.Microsecond)
-		d.devices[max].moveDirectionSteps(directions[max], s)
+		d.devices[max].moveDirectionSteps(directions[max], s, mode)
 
 		if ((s * stepsB) / stepsA) > minStep {
 			minStep++
-			d.devices[min].moveDirectionSteps(directions[min], minStep)
+			d.devices[min].moveDirectionSteps(directions[min], minStep, mode)
 		}
 	}
 }
 
 // Off turns off all motor pins
-func (d *DualDevice) Off() {
+func (d *dualDevice) Off() {
 	d.devices[0].Off()
 	d.devices[1].Off()
 }
 
-// stepMotor changes the pins' state to the correct step
-func (d *Device) stepMotor(step uint8) {
+// stepMotor changes the pins' state to the correct step for the given mode
+func (d *device) stepMotor(step uint8, mode StepMode) {
+	if mode == FourStepMode {
+		d.stepMotor4(step)
+	} else if mode == EightStepMode {
+		d.stepMotor8(step)
+	}
+}
+
+// stepMotor4 changes the pins' state to the correct step in 4-step mode
+func (d *device) stepMotor4(step uint8) {
 	switch step {
 	case 0:
 		d.pins[0].High()
@@ -148,13 +206,63 @@ func (d *Device) stepMotor(step uint8) {
 	d.stepNumber = step
 }
 
+// stepMotor8 changes the pins' state to the correct step in 8-step mode
+func (d *device) stepMotor8(step uint8) {
+	switch step {
+	case 0:
+		d.pins[0].High()
+		d.pins[2].Low()
+		d.pins[1].Low()
+		d.pins[3].Low()
+	case 1:
+		d.pins[0].High()
+		d.pins[2].High()
+		d.pins[1].Low()
+		d.pins[3].Low()
+	case 2:
+		d.pins[0].Low()
+		d.pins[2].High()
+		d.pins[1].Low()
+		d.pins[3].Low()
+	case 3:
+		d.pins[0].Low()
+		d.pins[2].High()
+		d.pins[1].High()
+		d.pins[3].Low()
+	case 4:
+		d.pins[0].Low()
+		d.pins[2].Low()
+		d.pins[1].High()
+		d.pins[3].Low()
+	case 5:
+		d.pins[0].Low()
+		d.pins[2].Low()
+		d.pins[1].High()
+		d.pins[3].High()
+	case 6:
+		d.pins[0].Low()
+		d.pins[2].Low()
+		d.pins[1].Low()
+		d.pins[3].High()
+	case 7:
+		d.pins[0].High()
+		d.pins[2].Low()
+		d.pins[1].Low()
+		d.pins[3].High()
+	}
+	d.stepNumber = step
+}
+
 // moveDirectionSteps uses the direction to calculate the correct step and change the motor to it.
-// Direction true: 0, 1, 2, 3, 0, 1, 2, ...
-// Direction false: 0, 3, 2, 1, 0, 3, 2, ...
-func (d *Device) moveDirectionSteps(direction bool, step int32) {
+// Direction true:  (4-step mode) 0, 1, 2, 3, 0, 1, 2, ...
+// Direction false: (4-step mode) 0, 3, 2, 1, 0, 3, 2, ...
+// Direction true:  (8-step mode) 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, ...
+// Direction false: (8-step mode) 0, 7, 6, 5, 4, 3, 2, 1, 0, 7, 6, ...
+func (d *device) moveDirectionSteps(direction bool, step int32, mode StepMode) {
+	modulus := int32(mode)
 	if direction {
-		d.stepMotor(uint8(step % 4))
+		d.stepMotor(uint8(step%modulus), mode)
 	} else {
-		d.stepMotor(uint8((step + 2*(step%2)) % 4))
+		d.stepMotor(uint8(((-step%modulus)+modulus)%modulus), mode)
 	}
 }

--- a/examples/easystepper/main.go
+++ b/examples/easystepper/main.go
@@ -13,11 +13,11 @@ func main() {
 
 	for {
 		println("CLOCKWISE")
-		motor.Move(2050)
+		motor.Move(2050) // Legacy API - uses easystepper.FourStepMode
 		time.Sleep(time.Millisecond * 1000)
 
 		println("COUNTERCLOCKWISE")
-		motor.Move(-2050)
+		motor.MoveStepsMode(-2050, easystepper.FourStepMode)
 		time.Sleep(time.Millisecond * 1000)
 	}
 }

--- a/examples/irremote/main.go
+++ b/examples/irremote/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"machine"
+	"time"
+
+	"tinygo.org/x/drivers/irremote"
+)
+
+var irCmdButtons = map[uint8]string{
+	0xA2: "POWER",
+	0xE2: "FUNC/STOP",
+	0x62: "VOL+",
+	0x22: "FAST BACK",
+	0x02: "PAUSE",
+	0xC2: "FAST FORWARD",
+	0xE0: "DOWN",
+	0xA8: "VOL-",
+	0x90: "UP",
+	0x98: "EQ",
+	0xB0: "ST/REPT",
+	0x68: "0",
+	0x30: "1",
+	0x18: "2",
+	0x7A: "3",
+	0x10: "4",
+	0x38: "5",
+	0x5A: "6",
+	0x42: "7",
+	0x4A: "8",
+	0x52: "9",
+}
+
+var (
+	pinIROut = machine.GP26
+	ir       irremote.IRReceiverDevice
+)
+
+func setupPins() {
+	ir = irremote.New(pinIROut)
+	ir.Configure()
+}
+
+func irCallback(code uint32, addr uint16, cmd uint8, repeat bool) {
+	println("Button: " + irCmdButtons[cmd])
+}
+
+func main() {
+	setupPins()
+	ir.Callback(irCallback)
+	for {
+		time.Sleep(time.Millisecond * 10)
+	}
+}

--- a/examples/max72xx/main.go
+++ b/examples/max72xx/main.go
@@ -29,6 +29,7 @@ func main() {
 	driver.StopDisplayTest()
 	driver.SetDecodeMode(4)
 	driver.SetScanLimit(4)
+	driver.SetIntensity(8)
 	driver.StopShutdownMode()
 
 	for i := 1; i < int(digitNumber); i++ {

--- a/irremote/irremote.go
+++ b/irremote/irremote.go
@@ -1,0 +1,173 @@
+package irremote // import "tinygo.org/x/drivers/irremote"
+
+import (
+	"machine"
+	"time"
+)
+
+// NEC protocol references
+// https://www.sbprojects.net/knowledge/ir/nec.php
+// https://techdocs.altium.com/display/FPGA/NEC+Infrared+Transmission+Protocol
+// https://simple-circuit.com/arduino-nec-remote-control-decoder/
+
+// Client callback function for IR commands
+// 'code' is the raw NEC format code. 'addr' & 'cmd' are the NEC decoded address and command codes respectively
+// See the NEC protocol reference links above for more information
+type IRCallback func(code uint32, addr uint16, cmd uint8, repeat bool)
+
+// Public API for an IR receiver device
+type IRReceiverDevice interface {
+	// Configure pins for the IR receiver module
+	Configure()
+	// Start/Stop receiving IR callbacks (pass nil to stop)
+	Callback(cb IRCallback)
+}
+
+// Return a new IR receiver device
+func New(pin machine.Pin) IRReceiverDevice {
+	return &irReceiver{pin: pin}
+}
+
+// Internal NEC IR protocol states
+const (
+	lead_pulse_start = iota // Start receiving IR data, beginning of 9ms lead pulse
+	lead_space_start        // End of 9ms lead pulse, start of 4.5ms space
+	lead_space_end          // End of 4.5ms space, start of 562µs pulse
+	bit_read_start          // End of 562µs pulse, start of 562µs or 1687µs space
+	bit_read_end            // End of 562µs or 1687µs space
+)
+
+// Internal IR device struct
+type irReceiver struct {
+	pin      machine.Pin // IR output pin.
+	cb       IRCallback  // client callback
+	necState int         // state machine
+	necCode  uint32      // data read
+	lastTime time.Time   // used to track states
+	bitIndex int         // tracks which bit of necCode is being read
+}
+
+func (ir *irReceiver) Configure() {
+	// The IR receiver sends logic HIGH when NOT receiving IR, and logic LOW when receiving IR
+	ir.pin.Configure(machine.PinConfig{Mode: machine.PinInputPullup})
+}
+
+func (ir *irReceiver) Callback(cb IRCallback) {
+	ir.cb = cb
+	ir.necState = lead_pulse_start
+	if cb != nil {
+		// Start monitoring IR output pin for changes
+		ir.pin.SetInterrupt(machine.PinFalling|machine.PinRising, ir.pinChange)
+	} else {
+		// Stop monitoring IR output pin for changes
+		ir.pin.SetInterrupt(0, nil)
+	}
+}
+
+// Internal pin rising/falling edge interrupt handler
+func (ir *irReceiver) pinChange(pin machine.Pin) {
+	/* Currently TinyGo is sending machine.NoPin (0xff) for all pins, at least on RP2040
+	if pin != ir.pin {
+		return // This is not the pin you're looking for
+	}
+	*/
+	now := time.Now()
+	duration := now.Sub(ir.lastTime)
+	ir.lastTime = now
+	switch ir.necState {
+	case lead_pulse_start:
+		ir.necCode = 0
+		ir.bitIndex = 0
+		if !ir.pin.Get() {
+			// IR is 'on' (pin is pulled high and sent low when IR is received)
+			ir.necState = lead_space_start // move to next state
+		}
+	case lead_space_start:
+		if duration > time.Microsecond*9500 || duration < time.Microsecond*8500 {
+			// Invalid interval for lead 9ms pulse. Reset
+			ir.necState = lead_pulse_start
+		} else {
+			// Lead pulse detected, move to next state
+			ir.necState = lead_space_end
+		}
+	case lead_space_end:
+		if duration > time.Microsecond*5000 || duration < time.Microsecond*4000 {
+			// Invalid interval for 4.5ms lead space. Reset
+			ir.necState = lead_pulse_start
+		} else {
+			// Lead space detected, move to next state
+			ir.necState = bit_read_start
+		}
+	case bit_read_start:
+		if duration > time.Microsecond*700 || duration < time.Microsecond*400 {
+			// Invalid interval for 562.5µs pulse. Reset
+			ir.necState = lead_pulse_start
+		} else {
+			// 562.5µs pulse detected, move to next state
+			ir.necState = bit_read_end
+		}
+	case bit_read_end:
+		if duration > time.Microsecond*1800 || duration < time.Microsecond*400 {
+			// Invalid interval for 562.5µs OR 1687.5µs space. Reset
+			ir.necState = lead_pulse_start
+		} else {
+			// 562.5µs OR 1687.5µs space detected
+			mask := uint32((1 << (31 - ir.bitIndex)))
+			if duration > time.Microsecond*1000 {
+				// 562.5µs space detected (logic 1) - Set bit
+				ir.necCode |= mask
+			} else {
+				// 1687.5µs space detected (logic 0) - Clear bit
+				ir.necCode &^= mask
+			}
+
+			ir.bitIndex++
+			if ir.bitIndex > 31 {
+				// We've read all bits for this code. around we go again
+				ir.necState = lead_pulse_start
+				// Decode (address, command) & validate
+				addr, cmd, err := ir.decode()
+				if irDecodeErrorNone == err {
+					// valid addr & cmd. Inovke client callback function
+					// TODO: repeat codes. Always send 'false' for now
+					ir.cb(ir.necCode, addr, cmd, false)
+				}
+			} else {
+				// Read next bit
+				ir.necState = bit_read_start
+			}
+		}
+	}
+}
+
+// Error type for NEC format decoding
+type irDecodeError int
+
+const (
+	irDecodeErrorNone             = iota // no error occurred
+	irDecodeErrorInverseCheckFail        // validation of inverse cmd does not match cmd
+)
+
+func (ir *irReceiver) decode() (addr uint16, cmd uint8, err irDecodeError) {
+	addr, cmd, err = 0, 0, irDecodeErrorNone
+	// Decode cmd and inverse cmd and perform validation check
+	cmd = uint8((ir.necCode & 0xff00) >> 8)
+	invCmd := uint8(ir.necCode & 0xff)
+	if cmd != ^invCmd {
+		// Validation failure. cmd and inverse cmd do not match
+		err = irDecodeErrorInverseCheckFail
+		return
+	}
+	// cmd validation pass, decode address
+	addrLow := uint8((ir.necCode & 0xff000000) >> 24)
+	addrHigh := uint8((ir.necCode & 0x00ff0000) >> 16)
+	if addrHigh == ^addrLow {
+		// addrHigh is inverse of addrLow. This is not a valid 16-bit address in extended NEC coding
+		// since it is indistinguishable from 8-bit address with inverse validation. Use the 8-bit address
+		addr = uint16(addrLow)
+	} else {
+		// 16-bit extended NEC address
+		addr = (uint16(addrHigh) << 8) | uint16(addrLow)
+	}
+	return
+}

--- a/max72xx/max72xx.go
+++ b/max72xx/max72xx.go
@@ -31,7 +31,16 @@ func (driver *Device) Configure() {
 // SetScanLimit sets the scan limit. Maximum is 8.
 // Example: a 4 digit 7SegmentDisplay has a scan limit of 4
 func (driver *Device) SetScanLimit(digitNumber uint8) {
-	driver.WriteCommand(byte(REG_SCANLIMIT), byte(digitNumber-1))
+	driver.WriteCommand(REG_SCANLIMIT, digitNumber-1)
+}
+
+// SetIntensity sets the intensity of the diplays.
+// There are 16 possible intensity levels. The valid range is 0x00-0x0F
+func (driver *Device) SetIntensity(intensity uint8) {
+	if intensity > 0x0F {
+		intensity = 0x0F
+	}
+	driver.WriteCommand(REG_INTENSITY, intensity)
 }
 
 // SetDecodeMode sets the decode mode for 7 segment displays.


### PR DESCRIPTION
Currently, easystepper driver supports only '4-step mode' (12-23-34-41) when energizing the coils
This does not work with all motors & drivers (e.g. 28BJY-48 & ULN2003)

This PR adds support for 8-step mode (1-12-2-23-3-34-4-41)

Source compatibility has been maintained at the expense of a (now) redundant public API
(Move() func's are retained but call the new MoveStepsMode() APIs using 4-step mode param)
since Go does not support default values for parameters.

This PR also encapsulates the API using interfaces instead of exposing the internal
Device structs to the caller.

The example has also been updated to make use of both 'Move' APIs