### PR TITLE
Add support for '8-step mode' to easystepper (#393)

### DIFF
--- a/examples/easystepper/main.go
+++ b/examples/easystepper/main.go
@@ -8,7 +8,11 @@ import (
 )
 
 func main() {
-	motor := easystepper.New(machine.P13, machine.P15, machine.P14, machine.P16, 200, 75)
+	config := easystepper.DeviceConfig{
+		Pin1: machine.P13, Pin2: machine.P15, Pin3: machine.P14, Pin4: machine.P16,
+		StepCount: 200, RPM: 75, Mode: easystepper.ModeFour,
+	}
+	motor, _ := easystepper.New(config)
 	motor.Configure()
 
 	for {


### PR DESCRIPTION
Currently, easystepper driver supports only '4-step mode' (12-23-34-41) when energizing the coils
This does not work with all motors & drivers (e.g. 28BJY-48 & ULN2003)

This commit adds support for 8-step mode (1-12-2-23-3-34-4-41)

Note: this commit breaks backward source compatibility for the factory/constructor functions.

Fixes #393