### PR TITLE
vl53l1x: Fix switch-case semantics

### DIFF
--- a/vl53l1x/vl53l1x.go
+++ b/vl53l1x/vl53l1x.go
@@ -157,7 +157,6 @@ func (d *Device) SetDistanceMode(mode DistanceMode) bool {
 		d.writeReg(SD_CONFIG_WOI_SD1, 0x05)
 		d.writeReg(SD_CONFIG_INITIAL_PHASE_SD0, 6)
 		d.writeReg(SD_CONFIG_INITIAL_PHASE_SD1, 6)
-		break
 	case MEDIUM:
 		// timing config
 		d.writeReg(RANGE_CONFIG_VCSEL_PERIOD_A, 0x0B)
@@ -169,7 +168,6 @@ func (d *Device) SetDistanceMode(mode DistanceMode) bool {
 		d.writeReg(SD_CONFIG_WOI_SD1, 0x09)
 		d.writeReg(SD_CONFIG_INITIAL_PHASE_SD0, 10)
 		d.writeReg(SD_CONFIG_INITIAL_PHASE_SD1, 10)
-		break
 	case LONG:
 		// timing config
 		d.writeReg(RANGE_CONFIG_VCSEL_PERIOD_A, 0x0F)
@@ -181,7 +179,6 @@ func (d *Device) SetDistanceMode(mode DistanceMode) bool {
 		d.writeReg(SD_CONFIG_WOI_SD1, 0x0D)
 		d.writeReg(SD_CONFIG_INITIAL_PHASE_SD0, 14)
 		d.writeReg(SD_CONFIG_INITIAL_PHASE_SD1, 14)
-		break
 	default:
 		return false
 	}
@@ -333,44 +330,35 @@ func (d *Device) AmbientRate() int32 {
 func (d *Device) getRangingData() {
 	d.rangingData.mm = uint16((uint32(d.results.mmCrosstalkSD0)*2011 + 0x0400) / 0x0800)
 	switch d.results.status {
-	case 17: // MULTCLIPFAIL
-	case 2: // VCSELWATCHDOGTESTFAILURE
-	case 1: // VCSELCONTINUITYTESTFAILURE
-	case 3: // NOVHVVALUEFOUND
+	case 1, // VCSELCONTINUITYTESTFAILURE
+		2,  // VCSELWATCHDOGTESTFAILURE
+		3,  // NOVHVVALUEFOUND
+		17: // MULTCLIPFAIL
 		d.rangingData.status = HardwareFail
-		break
 
 	case 13: // USERROICLIP
 		d.rangingData.status = MinRangeFail
-		break
 
 	case 18: // GPHSTREAMCOUNT0READY
 		d.rangingData.status = SynchronizationInt
-		break
 
 	case 5: // RANGEPHASECHECK
 		d.rangingData.status = OutOfBoundsFail
-		break
 
 	case 4: // MSRCNOTARGET
 		d.rangingData.status = SignalFail
-		break
 
 	case 6: // SIGMATHRESHOLDCHECK
 		d.rangingData.status = SignalFail
-		break
 
 	case 7: // PHASECONSISTENCY
 		d.rangingData.status = WrapTargetFail
-		break
 
 	case 12: // RANGEIGNORETHRESHOLD
 		d.rangingData.status = XtalkSignalFail
-		break
 
 	case 8: // MINCLIP
 		d.rangingData.status = RangeValidMinRangeClipped
-		break
 
 	case 9: // RANGECOMPLETE
 		if d.results.streamCount == 0 {
@@ -378,7 +366,6 @@ func (d *Device) getRangingData() {
 		} else {
 			d.rangingData.status = RangeValid
 		}
-		break
 
 	default:
 		d.rangingData.status = None


### PR DESCRIPTION
The source code has been ported from C. It seems, the different
semantics of switch-case in Go has not been ported properly.
To fix this, remove 'break' statements and introduce 'fallthrough' where
necessary.

Signed-off-by: Oliver Stäbler <oliver.staebler@bytesatwork.ch>