### PR TITLE
sdcard: support thingplus-rp2040

### DIFF
--- a/examples/sdcard/console/feather-m4.go
+++ b/examples/sdcard/console/feather-m4.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	spi = machine.SPI0
+	spi = &machine.SPI0
 	sckPin = machine.SPI0_SCK_PIN
 	sdoPin = machine.SPI0_SDO_PIN
 	sdiPin = machine.SPI0_SDI_PIN

--- a/examples/sdcard/console/grandcentral-m4.go
+++ b/examples/sdcard/console/grandcentral-m4.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	spi = machine.SPI1
+	spi = &machine.SPI1
 	sckPin = machine.SDCARD_SCK_PIN
 	sdoPin = machine.SDCARD_SDO_PIN
 	sdiPin = machine.SDCARD_SDI_PIN

--- a/examples/sdcard/console/m0.go
+++ b/examples/sdcard/console/m0.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	spi = machine.SPI0
+	spi = &machine.SPI0
 	sckPin = machine.SPI0_SCK_PIN
 	sdoPin = machine.SPI0_SDO_PIN
 	sdiPin = machine.SPI0_SDI_PIN

--- a/examples/sdcard/console/main.go
+++ b/examples/sdcard/console/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	spi    machine.SPI
+	spi    *machine.SPI
 	sckPin machine.Pin
 	sdoPin machine.Pin
 	sdiPin machine.Pin
@@ -18,7 +18,6 @@ var (
 )
 
 func main() {
-	waitSerial()
 	fmt.Printf("sdcard console\r\n")
 
 	led := ledPin
@@ -40,12 +39,5 @@ func main() {
 		time.Sleep(200 * time.Millisecond)
 		led.Low()
 		time.Sleep(200 * time.Millisecond)
-	}
-}
-
-// Wait for user to open serial console
-func waitSerial() {
-	for !machine.Serial.DTR() {
-		time.Sleep(100 * time.Millisecond)
 	}
 }

--- a/examples/sdcard/console/p1am-100.go
+++ b/examples/sdcard/console/p1am-100.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	spi = machine.SDCARD_SPI
+	spi = &machine.SDCARD_SPI
 	sckPin = machine.SDCARD_SCK_PIN
 	sdoPin = machine.SDCARD_SDO_PIN
 	sdiPin = machine.SDCARD_SDI_PIN

--- a/examples/sdcard/console/pygamer.go
+++ b/examples/sdcard/console/pygamer.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	spi = machine.SPI0
+	spi = &machine.SPI0
 	sckPin = machine.SPI0_SCK_PIN
 	sdoPin = machine.SPI0_SDO_PIN
 	sdiPin = machine.SPI0_SDI_PIN

--- a/examples/sdcard/console/pyportal.go
+++ b/examples/sdcard/console/pyportal.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	spi = machine.SPI0
+	spi = &machine.SPI0
 	sckPin = machine.SPI0_SCK_PIN
 	sdoPin = machine.SPI0_SDO_PIN
 	sdiPin = machine.SPI0_SDI_PIN

--- a/examples/sdcard/console/thingplus-rp2040.go
+++ b/examples/sdcard/console/thingplus-rp2040.go
@@ -1,0 +1,18 @@
+//go:build thingplus_rp2040
+// +build thingplus_rp2040
+
+package main
+
+import (
+	"machine"
+)
+
+func init() {
+	spi = machine.SPI1
+	sckPin = machine.SPI1_SCK_PIN
+	sdoPin = machine.SPI1_SDO_PIN
+	sdiPin = machine.SPI1_SDI_PIN
+	csPin = machine.GPIO9
+
+	ledPin = machine.LED
+}

--- a/examples/sdcard/console/wioterminal.go
+++ b/examples/sdcard/console/wioterminal.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	spi = machine.SPI2
+	spi = &machine.SPI2
 	sckPin = machine.SCK2
 	sdoPin = machine.SDO2
 	sdiPin = machine.SDI2

--- a/examples/sdcard/tinyfs/feather-m4.go
+++ b/examples/sdcard/tinyfs/feather-m4.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	spi = machine.SPI0
+	spi = &machine.SPI0
 	sckPin = machine.SPI0_SCK_PIN
 	sdoPin = machine.SPI0_SDO_PIN
 	sdiPin = machine.SPI0_SDI_PIN

--- a/examples/sdcard/tinyfs/grandcentral-m4.go
+++ b/examples/sdcard/tinyfs/grandcentral-m4.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	spi = machine.SPI1
+	spi = &machine.SPI1
 	sckPin = machine.SDCARD_SCK_PIN
 	sdoPin = machine.SDCARD_SDO_PIN
 	sdiPin = machine.SDCARD_SDI_PIN

--- a/examples/sdcard/tinyfs/m0.go
+++ b/examples/sdcard/tinyfs/m0.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	spi = machine.SPI0
+	spi = &machine.SPI0
 	sckPin = machine.SPI0_SCK_PIN
 	sdoPin = machine.SPI0_SDO_PIN
 	sdiPin = machine.SPI0_SDI_PIN

--- a/examples/sdcard/tinyfs/main.go
+++ b/examples/sdcard/tinyfs/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	spi    machine.SPI
+	spi    *machine.SPI
 	sckPin machine.Pin
 	sdoPin machine.Pin
 	sdiPin machine.Pin
@@ -20,8 +20,6 @@ var (
 )
 
 func main() {
-	waitSerial()
-
 	sd := sdcard.New(spi, sckPin, sdoPin, sdiPin, csPin)
 	err := sd.Configure()
 	if err != nil {
@@ -39,11 +37,4 @@ func main() {
 	})
 
 	console.RunFor(&sd, filesystem)
-}
-
-// Wait for user to open serial console
-func waitSerial() {
-	for !machine.Serial.DTR() {
-		time.Sleep(100 * time.Millisecond)
-	}
 }

--- a/examples/sdcard/tinyfs/p1am-100.go
+++ b/examples/sdcard/tinyfs/p1am-100.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	spi = machine.SDCARD_SPI
+	spi = &machine.SDCARD_SPI
 	sckPin = machine.SDCARD_SCK_PIN
 	sdoPin = machine.SDCARD_SDO_PIN
 	sdiPin = machine.SDCARD_SDI_PIN

--- a/examples/sdcard/tinyfs/pygamer.go
+++ b/examples/sdcard/tinyfs/pygamer.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	spi = machine.SPI0
+	spi = &machine.SPI0
 	sckPin = machine.SPI0_SCK_PIN
 	sdoPin = machine.SPI0_SDO_PIN
 	sdiPin = machine.SPI0_SDI_PIN

--- a/examples/sdcard/tinyfs/pyportal.go
+++ b/examples/sdcard/tinyfs/pyportal.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	spi = machine.SPI0
+	spi = &machine.SPI0
 	sckPin = machine.SPI0_SCK_PIN
 	sdoPin = machine.SPI0_SDO_PIN
 	sdiPin = machine.SPI0_SDI_PIN

--- a/examples/sdcard/tinyfs/thingplus-rp2040.go
+++ b/examples/sdcard/tinyfs/thingplus-rp2040.go
@@ -1,0 +1,18 @@
+//go:build thingplus_rp2040
+// +build thingplus_rp2040
+
+package main
+
+import (
+	"machine"
+)
+
+func init() {
+	spi = machine.SPI1
+	sckPin = machine.SPI1_SCK_PIN
+	sdoPin = machine.SPI1_SDO_PIN
+	sdiPin = machine.SPI1_SDI_PIN
+	csPin = machine.GPIO9
+
+	ledPin = machine.LED
+}

--- a/examples/sdcard/tinyfs/wioterminal.go
+++ b/examples/sdcard/tinyfs/wioterminal.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	spi = machine.SPI2
+	spi = &machine.SPI2
 	sckPin = machine.SCK2
 	sdoPin = machine.SDO2
 	sdiPin = machine.SDI2

--- a/sdcard/sdcard.go
+++ b/sdcard/sdcard.go
@@ -28,7 +28,7 @@ var (
 )
 
 type Device struct {
-	bus        machine.SPI
+	bus        *machine.SPI
 	sck        machine.Pin
 	sdo        machine.Pin
 	sdi        machine.Pin
@@ -41,7 +41,7 @@ type Device struct {
 	CSD        *CSD
 }
 
-func New(b machine.SPI, sck, sdo, sdi, cs machine.Pin) Device {
+func New(b *machine.SPI, sck, sdo, sdi, cs machine.Pin) Device {
 	return Device{
 		bus:        b,
 		cs:         cs,


### PR DESCRIPTION
The instances of SPI interfaces SPI0, SPI1, ... are
pointers to SPI types on rp2040 machines, rather plain
values like other machines.

This needs restructuring the sdcard API to take a pointer
to the SPI interface rather the SPI type itself.

A different issue is the Serial.DTR signal to be used in the example code.
The current UART code does not implement the modem control signals. Here is a
workaround for not having this functionality. Maybe it would be simpler to
simply remove waiting for serial line to come alive ?