### PR TITLE
vl53l1x: Add functions for setting the device address

### DIFF
--- a/vl53l1x/registers.go
+++ b/vl53l1x/registers.go
@@ -7,6 +7,7 @@ const Address = 0x29 //0x52
 const (
 	CHIP_ID                                                 = 0xEACC
 	SOFT_RESET                                              = 0x0000
+	I2C_SLAVE_DEVICE_ADDRESS                                = 0x0001
 	OSC_MEASURED_FAST_OSC_FREQUENCY                         = 0x0006
 	VHV_CONFIG_TIMEOUT_MACROP_LOOP_BOUND                    = 0x0008
 	VHV_CONFIG_INIT                                         = 0x000B

--- a/vl53l1x/vl53l1x.go
+++ b/vl53l1x/vl53l1x.go
@@ -133,6 +133,17 @@ func (d *Device) Configure(use2v8Mode bool) bool {
 	return true
 }
 
+// SetAddress sets the I2C address which this device listens to.
+func (d *Device) SetAddress(address uint8) {
+	d.writeReg(I2C_SLAVE_DEVICE_ADDRESS, address)
+	d.Address = uint16(address)
+}
+
+// GetAddress returns the I2C address which this device listens to.
+func (d *Device) GetAddress() uint8 {
+	return uint8(d.Address)
+}
+
 // SetTimeout configures the timeout
 func (d *Device) SetTimeout(timeout uint32) {
 	d.timeout = timeout


### PR DESCRIPTION
This PR implements functions to get and set the device address similar to its
reference implementation in C:
https://github.com/pololu/vl53l1x-arduino/blob/master/VL53L1X.cpp#L28

The field `Address` of type `Device` could be changed to a private now; but I kept it because it would be a breaking change.