### PR TITLE
fix(ssd1351): Fix mirrored text on OLED display

### DIFF
--- a/ssd1351/ssd1351.go
+++ b/ssd1351/ssd1351.go
@@ -103,7 +103,7 @@ func (d *Device) Configure(cfg Config) {
 	d.Command(SET_MUX_RATIO)
 	d.Data(0x7F)
 	d.Command(SET_REMAP_COLORDEPTH)
-	d.Data(0x72)
+	d.Data(0x62)
 	d.Command(SET_COLUMN_ADDRESS)
 	d.Data(0x00)
 	d.Data(0x7F)


### PR DESCRIPTION
Having issue with mirrored text on my OLED display.  Setup summary:

* Using this [OLED display from waveshare](https://www.waveshare.com/1.5inch-rgb-oled-module.htm)
* Using the [ssd1351 Driver](https://github.com/tinygo-org/drivers/tree/release/ssd1351)
* Using the [TinyFont examples](https://github.com/tinygo-org/tinyfont/tree/release/examples)
* Using board: `esp32-coreboard-v2`

The issue is in the ssd1351 configure method, the `SET_REMAP_COLORDEPH` is set to `0x72`([see](https://github.com/tinygo-org/drivers/blob/release/ssd1351/ssd1351.go#L106)), but it should be `0x62`

### The problem

The issue is with the fourth bit which controls the scan direction.  Each bit of the `SET_REMAP_COLORDEPH` does something different according to page 32 of this [ssd1351 data sheet](https://newhavendisplay.com/content/app_notes/SSD1351.pdf).  For the current setting `0x72` we can see that bit-4 is `1` which tells the device to scan backwards. 

```text
0x72 = 0b01110010
            |   |
            |   └── bit 0
            └──---- bit 4 - set to 1, scan backwards 

# from ssd1351 data sheet
0 - Scan from COM0 to COM[N –1] [reset]
1 - Scan from COM[N-1] to COM0. Where N is the Multiplex ratio.
```

### The Fix

The fix was to set bit 4 to zero, i.e. set `0x62` as the correct value. 

```text
0x62 = 0b01100010
            |   |
            |   └── bit 0
            └──---- bit 4 - set to 0, scan forward
```

To test this on my display I added the following two lines after calling configure and it works.

```go
display.Command(ssd1351.SET_REMAP_COLORDEPTH)
display.Data(0x62)
```



