### PR TITLE
rtl8720dn: add ./examples/rtl8720dn/version

### DIFF
--- a/examples/rtl8720dn/version/main.go
+++ b/examples/rtl8720dn/version/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"tinygo.org/x/drivers/examples/rtl8720dn"
+)
+
+var (
+	debug = false
+)
+
+func main() {
+	err := run()
+	for err != nil {
+		fmt.Printf("error: %s\r\n", err.Error())
+		time.Sleep(5 * time.Second)
+	}
+}
+
+func run() error {
+	//rtl8720dn.Debug(true)
+	rtl, err := rtl8720dn.Setup()
+	if err != nil {
+		return err
+	}
+
+	ver, err := rtl.Version()
+	if err != nil {
+		return nil
+	}
+
+	for {
+		fmt.Printf("RTL8270DN Firmware Version: %s\r\n", ver)
+		time.Sleep(10 * time.Second)
+	}
+
+	return nil
+}

--- a/examples/rtl8720dn/wioterminal.go
+++ b/examples/rtl8720dn/wioterminal.go
@@ -1,0 +1,79 @@
+//go:build wioterminal
+// +build wioterminal
+
+package rtl8720dn
+
+import (
+	"device/sam"
+	"machine"
+	"runtime/interrupt"
+	"time"
+
+	"tinygo.org/x/drivers/rtl8720dn"
+)
+
+var (
+	uart  UARTx
+	debug bool
+)
+
+func handleInterrupt(interrupt.Interrupt) {
+	// should reset IRQ
+	uart.Receive(byte((uart.Bus.DATA.Get() & 0xFF)))
+	uart.Bus.INTFLAG.SetBits(sam.SERCOM_USART_INT_INTFLAG_RXC)
+}
+
+func Setup() (*rtl8720dn.RTL8720DN, error) {
+	machine.RTL8720D_CHIP_PU.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.RTL8720D_CHIP_PU.Low()
+	time.Sleep(100 * time.Millisecond)
+	machine.RTL8720D_CHIP_PU.High()
+	time.Sleep(1000 * time.Millisecond)
+	if debug {
+		waitSerial()
+	}
+
+	uart = UARTx{
+		UART: &machine.UART{
+			Buffer: machine.NewRingBuffer(),
+			Bus:    sam.SERCOM0_USART_INT,
+			SERCOM: 0,
+		},
+	}
+
+	uart.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, handleInterrupt)
+	uart.Configure(machine.UARTConfig{TX: machine.PB24, RX: machine.PC24, BaudRate: 614400})
+
+	rtl := rtl8720dn.New(uart)
+	rtl.Debug(debug)
+
+	_, err := rtl.Rpc_tcpip_adapter_init()
+	if err != nil {
+		return nil, err
+	}
+
+	return rtl, nil
+}
+
+// Wait for user to open serial console
+func waitSerial() {
+	for !machine.Serial.DTR() {
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+type UARTx struct {
+	*machine.UART
+}
+
+func (u UARTx) Read(p []byte) (n int, err error) {
+	if u.Buffered() == 0 {
+		time.Sleep(1 * time.Millisecond)
+		return 0, nil
+	}
+	return u.UART.Read(p)
+}
+
+func Debug(b bool) {
+	debug = b
+}


### PR DESCRIPTION
Created an example to read the version of rtl8720dn.

Also, wioterminal rtl8720dn initialization was created in examples/rtl8720dn/wioterminal.go.
Right now, there are many examples/rtl8720dn/*/wioterminal.go, but eventually we would like to unify them into examples/rtl8720dn/wioterminal.go.


The version readout yields the following results

```
RTL8270DN Firmware Version: 2.1.2
```