### PR TITLE
net/mqtt: add support for retained messsages

### DIFF
--- a/net/mqtt/mqtt.go
+++ b/net/mqtt/mqtt.go
@@ -146,6 +146,7 @@ func (c *mqttclient) Publish(topic string, qos byte, retained bool, payload inte
 	pub := packets.NewControlPacket(packets.Publish).(*packets.PublishPacket)
 	pub.Qos = qos
 	pub.TopicName = topic
+	pub.Retain = retained
 	switch payload.(type) {
 	case string:
 		pub.Payload = []byte(payload.(string))


### PR DESCRIPTION
This PR adds support for retained MQTT messages, since apparently it was missing.