### PR TITLE
add last-will-and-testament to MQTT

### DIFF
--- a/net/mqtt/mqtt.go
+++ b/net/mqtt/mqtt.go
@@ -100,6 +100,12 @@ func (c *mqttclient) Connect() Token {
 	connectPkt.ProtocolName = "MQTT"
 	connectPkt.Keepalive = 60
 
+	connectPkt.WillFlag = c.opts.WillEnabled
+	connectPkt.WillTopic = c.opts.WillTopic
+	connectPkt.WillMessage = c.opts.WillPayload
+	connectPkt.WillQos = c.opts.WillQos
+	connectPkt.WillRetain = c.opts.WillRetained
+
 	err = connectPkt.Write(c.conn)
 	if err != nil {
 		return &mqtttoken{err: err}


### PR DESCRIPTION
For some reason, the LWT settings in the MQTT options were not being included in the connect method, so I've added them. If you set a last will message, it will now be passed along when connecting to a broker.