### PR TITLE
net/http: Fix http.Get() with port specification

### DIFF
--- a/net/http/tinygo.go
+++ b/net/http/tinygo.go
@@ -38,8 +38,16 @@ func (c *Client) doHTTP(req *Request) (*Response, error) {
 	}
 
 	// make TCP connection
-	ip := net.ParseIP(req.URL.Host)
-	raddr := &net.TCPAddr{IP: ip, Port: 80}
+	ip := net.ParseIP(req.URL.Hostname())
+	port := 80
+	if req.URL.Port() != "" {
+		p, err := strconv.ParseUint(req.URL.Port(), 0, 64)
+		if err != nil {
+			return nil, err
+		}
+		port = int(p)
+	}
+	raddr := &net.TCPAddr{IP: ip, Port: port}
 	laddr := &net.TCPAddr{Port: 8080}
 
 	conn, err := net.DialTCP("tcp", laddr, raddr)


### PR DESCRIPTION
This PR corrects the behavior of `http.Get()`.
Only http is affected, not https.

Two items were corrected.

1. Change to pass only hostname to net.ParseIP
2. Fix Port setting was always 80