### PR TITLE
net/http: improve header parsing

### DIFF
--- a/net/http/tinygo.go
+++ b/net/http/tinygo.go
@@ -186,12 +186,17 @@ func (c *Client) doResp(conn net.Conn, req *Request) (*Response, error) {
 			if err != nil {
 				println("Read error: " + err.Error())
 			} else {
-				idx := bytes.Index(buf[ofs:ofs+n], []byte("\r\n\r\n"))
+				// Take care of the case where "\r\n\r\n" is on the boundary of a buffer
+				start := ofs
+				if start > 3 {
+					start -= 3
+				}
+				idx := bytes.Index(buf[start:ofs+n], []byte("\r\n\r\n"))
 				if idx == -1 {
 					ofs += n
 					continue
 				}
-				idx += ofs + 4
+				idx += start + 4
 
 				scanner = bufio.NewScanner(bytes.NewReader(buf[0 : ofs+n]))
 				if resp.Status == "" && scanner.Scan() {
@@ -269,6 +274,9 @@ func (c *Client) doResp(conn net.Conn, req *Request) (*Response, error) {
 				return nil, fmt.Errorf("slice out of range : use http.SetBuf() to change the allocation to %d bytes or more", end)
 			}
 			n, err := conn.Read(buf[ofs : ofs+0x400])
+			if err != nil {
+				return nil, err
+			}
 			if n == 0 {
 				continue
 			}


### PR DESCRIPTION
This PR improves header parsing.

```
# before : Can't find "\r\n\r\n"
buf[ofs:ofs+n] = []byte{..., '\r', '\a', '\r'}
buf[ofs:ofs+n] = []byte{'\a', ...}
```

```
# after : Can find "\r\n\r\n"
buf[ofs:ofs+n] = []byte{..., '\r', '\a', '\r'}
buf[ofs-3:ofs+n] = []byte{'\r', '\a', '\r', '\a', ...} // 
```

I was aware of this problem when I tried to access the following

* https://httpbin.org/get
    * https://httpbin.org/   is very useful!