### PR TITLE
net/http: support for cookies when https

### DIFF
--- a/net/http/tinygo.go
+++ b/net/http/tinygo.go
@@ -20,6 +20,11 @@ func SetBuf(b []byte) {
 }
 
 func (c *Client) Do(req *Request) (*Response, error) {
+	if c.Jar != nil {
+		for _, cookie := range c.Jar.Cookies(req.URL) {
+			req.AddCookie(cookie)
+		}
+	}
 	switch req.URL.Scheme {
 	case "http":
 		return c.doHTTP(req)
@@ -31,12 +36,6 @@ func (c *Client) Do(req *Request) (*Response, error) {
 }
 
 func (c *Client) doHTTP(req *Request) (*Response, error) {
-	if c.Jar != nil {
-		for _, cookie := range c.Jar.Cookies(req.URL) {
-			req.AddCookie(cookie)
-		}
-	}
-
 	// make TCP connection
 	ip := net.ParseIP(req.URL.Hostname())
 	port := 80


### PR DESCRIPTION
Until now, cookies were enabled only for HTTP.
Fix implemented and verified to work correctly.

https://httpbin.org/#/Cookies/get_cookies

```go
	// cookie
	jar, err := cookiejar.New(nil)
	if err != nil {
		log.Fatal(err)
	}
	client := &http.Client{Jar: jar}
	http.DefaultClient = client

	url = "https://httpbin.org/cookies/set/name/there"
	res, err := http.Get(url)
	if err != nil {
		log.Fatal(err)
	}
```

and

```go
		url = "https://httpbin.org/cookies"
		res, err := http.Get(url)
		if err != nil {
			log.Fatal(err)
		}
```