### PR TITLE
makeybutton: some fixes and refactoring

### DIFF
--- a/examples/makeybutton/main.go
+++ b/examples/makeybutton/main.go
@@ -15,8 +15,8 @@ var (
 
 func main() {
 	led.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	button.Configure(machine.PinConfig{Mode: machine.PinInputPullup})
 	key = makeybutton.NewButton(button)
+	key.Configure()
 
 	for {
 		switch key.Get() {
@@ -25,6 +25,6 @@ func main() {
 		case makeybutton.Released:
 			led.Low()
 		}
-		time.Sleep(30 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 	}
 }

--- a/makeybutton/buffer.go
+++ b/makeybutton/buffer.go
@@ -1,6 +1,6 @@
 package makeybutton
 
-const bufferSize = 10
+const bufferSize = 6
 
 // Buffer is a buffer to keep track of the most recent readings for a button.
 type Buffer struct {

--- a/makeybutton/button.go
+++ b/makeybutton/button.go
@@ -61,7 +61,7 @@ func (b *Button) Get() ButtonEvent {
 	b.readings.Put(pressed)
 
 	switch {
-	case pressed && avg > 0:
+	case pressed && avg > -1 * bufferSize - 2:
 		if b.state == Press {
 			return NotChanged
 		}


### PR DESCRIPTION
This PR fixes the makeybutton by reducing the size of the buffer for better responsiveness. It also add a `Configure()` method to bring it in line with the typical device patterns.