### PR TITLE
rtl8720dn: add Rpc_tcpip_adapter_init_with_timeout()

### DIFF
--- a/examples/rtl8720dn/wioterminal.go
+++ b/examples/rtl8720dn/wioterminal.go
@@ -47,7 +47,7 @@ func Setup() (*rtl8720dn.RTL8720DN, error) {
 	rtl := rtl8720dn.New(uart)
 	rtl.Debug(debug)
 
-	_, err := rtl.Rpc_tcpip_adapter_init()
+	_, err := rtl.Rpc_tcpip_adapter_init_with_timeout(10 * time.Second)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
For example, if the firmware of the RTL8720 is out of date, no response will be returned.
This PR defines functions that can time out in such cases.

The reason for not updating Rpc_tcpip_adapter_init directly is that Rpc_tcpip_adapter_init is automatically generated.