### PR TITLE
MQTT: keepalive, clean disconnect, and more!

### DIFF
--- a/net/mqtt/paho.go
+++ b/net/mqtt/paho.go
@@ -210,7 +210,7 @@ type ClientOptions struct {
 
 // NewClientOptions returns a new ClientOptions struct.
 func NewClientOptions() *ClientOptions {
-	return &ClientOptions{Adaptor: net.ActiveDevice, ProtocolVersion: 4}
+	return &ClientOptions{Adaptor: net.ActiveDevice, ProtocolVersion: 4, KeepAlive: 60, PingTimeout: time.Second * 10}
 }
 
 // AddBroker adds a broker URI to the list of brokers to be used. The format should be
@@ -254,6 +254,23 @@ func (o *ClientOptions) SetUsername(u string) *ClientOptions {
 // be sent in plaintext accross the wire.
 func (o *ClientOptions) SetPassword(p string) *ClientOptions {
 	o.Password = p
+	return o
+}
+
+// SetKeepAlive will set the amount of time (in seconds) that the client
+// should wait before sending a PING request to the broker. This will
+// allow the client to know that a connection has not been lost with the
+// server.
+func (o *ClientOptions) SetKeepAlive(k time.Duration) *ClientOptions {
+	o.KeepAlive = int64(k / time.Second)
+	return o
+}
+
+// SetPingTimeout will set the amount of time (in seconds) that the client
+// will wait after sending a PING request to the broker, before deciding
+// that the connection has been lost. Default is 10 seconds.
+func (o *ClientOptions) SetPingTimeout(k time.Duration) *ClientOptions {
+	o.PingTimeout = k
 	return o
 }
 


### PR DESCRIPTION
This update adds in various functionality to allow MQTT clients to disconnect and reconnect gracefully. Notably:

1. New keepalive goroutine to regularly ping the broker according to the specified keepalive interval.
2. Ability to set keep alive and ping timeout values in the options (with defaults).
3. If keepalive or any other routine determines the connection is broken (interrupted socket, ping timeout, etc), all routines shut down gracefully and connection status is updated. `IsConnected()` now accurately shows the connection status, and `Disconnect()` now works to force a disconnect.
4. A reconnect can be safely performed by simply calling `Connect()` again on the existing instance of the mqtt client.

I have tested consecutively disconnecting and reconnecting, and show no memory leaks.

Also,
5. Retain flag support has been added back in, so clients can set an "away message".