### PR TITLE
rtl8720dn: add UDP close function

### DIFF
--- a/rtl8720dn/netdriver.go
+++ b/rtl8720dn/netdriver.go
@@ -227,7 +227,7 @@ func (r *RTL8720DN) DisconnectSocket() error {
 		fmt.Printf("DisconnectSocket()\r\n")
 	}
 	switch r.connectionType {
-	case ConnectionTypeTCP:
+	case ConnectionTypeTCP, ConnectionTypeUDP:
 		_, err := r.Rpc_lwip_close(r.socket)
 		if err != nil {
 			return err


### PR DESCRIPTION
I noticed that close was not implemented when I tried to use it as a webserver after NTP.
By adding this, UDP can be closed.