### PR TITLE
Trim quotes from IP returned by espat's GetDNS()

### DIFF
--- a/espat/tcp.go
+++ b/espat/tcp.go
@@ -29,7 +29,7 @@ func (d *Device) GetDNS(domain string) (string, error) {
 		return "", errors.New("Invalid domain lookup result")
 	}
 	res := strings.Split(r[1], "\r\n")
-	return res[0], nil
+	return strings.Trim(res[0], `"`), nil
 }
 
 // ConnectTCPSocket creates a new TCP socket connection for the ESP8266/ESP32.


### PR DESCRIPTION
The `espat` driver is unable to dial any socket because the IP returned by `GetDNS()` has quotes around it, and then `ConnectTCPSocket()` adds quotes as well, and you end up with a string that looks like `""0.0.0.0""`.

This PR fixes the `GetDNS()` function by removing the quotes at the ends of the string before returning it.