### PR TITLE
Update waveshare-epd examples to use new machine pin constants

### DIFF
--- a/examples/waveshare-epd/epd2in13/main.go
+++ b/examples/waveshare-epd/epd2in13/main.go
@@ -18,7 +18,7 @@ func main() {
 		Mode:      0,
 	})
 
-	display = epd2in13.New(machine.SPI0, machine.P6, machine.P7, machine.P8, machine.P9)
+	display = epd2in13.New(machine.SPI0, machine.GPIO6, machine.GPIO7, machine.GPIO8, machine.GPIO9)
 	display.Configure(epd2in13.Config{})
 
 	black := color.RGBA{1, 1, 1, 255}

--- a/examples/waveshare-epd/epd2in13x/main.go
+++ b/examples/waveshare-epd/epd2in13x/main.go
@@ -16,7 +16,7 @@ func main() {
 		Mode:      0,
 	})
 
-	display = epd2in13x.New(machine.SPI0, machine.P6, machine.P7, machine.P8, machine.P9)
+	display = epd2in13x.New(machine.SPI0, machine.GPIO6, machine.GPIO7, machine.GPIO8, machine.GPIO9)
 	display.Configure(epd2in13x.Config{})
 
 	white := color.RGBA{0, 0, 0, 255}

--- a/examples/waveshare-epd/epd4in2/main.go
+++ b/examples/waveshare-epd/epd4in2/main.go
@@ -18,7 +18,7 @@ func main() {
 		Mode:      0,
 	})
 
-	display = epd4in2.New(machine.SPI0, machine.P6, machine.P7, machine.P8, machine.P9)
+	display = epd4in2.New(machine.SPI0, machine.GPIO6, machine.GPIO7, machine.GPIO8, machine.GPIO9)
 	display.Configure(epd4in2.Config{})
 
 	black := color.RGBA{1, 1, 1, 255}


### PR DESCRIPTION
The examples appear to be using constants that are no longer present.
Updating to make use of GPIO constants present in machine package