### PR TITLE
wifinina: remove stale comment...code is reached

### DIFF
--- a/examples/wifinina/tcpclient/main.go
+++ b/examples/wifinina/tcpclient/main.go
@@ -106,7 +106,6 @@ func sendBatch() {
 		println("error:", err.Error(), "\r")
 	}
 
-	// Right now this code is never reached. Need a way to trigger it...
 	println("Disconnecting TCP...")
 	conn.Close()
 }

--- a/examples/wifinina/tcpclient/main.go
+++ b/examples/wifinina/tcpclient/main.go
@@ -67,7 +67,7 @@ func main() {
 func sendBatch() {
 
 	// make TCP connection
-	ip := net.ParseIP(serverIP)
+	ip := net.IP([]byte(serverIP))
 	raddr := &net.TCPAddr{IP: ip, Port: 8080}
 	laddr := &net.TCPAddr{Port: 8080}
 


### PR DESCRIPTION
main() calls sendBatch() in a loop, and each time sendBatch() does finish and close the connection, so remove the stale comment.