### PR TITLE
apds9960: fix compile by removing unused import

### DIFF
--- a/apds9960/apds9960_generic.go
+++ b/apds9960/apds9960_generic.go
@@ -3,8 +3,6 @@
 
 package apds9960
 
-import "tinygo.org/x/drivers"
-
 // Configure sets up the APDS-9960 device.
 func (d *Device) Configure(cfg Configuration) {
 	// configure device


### PR DESCRIPTION
The apds9960 package does not compile because it has an unused import. This change simply removes that unused import.