### PR TITLE
mpu6050: return I2C error when configuring fails

### DIFF
--- a/mpu6050/mpu6050.go
+++ b/mpu6050/mpu6050.go
@@ -31,8 +31,8 @@ func (d Device) Connected() bool {
 }
 
 // Configure sets up the device for communication.
-func (d Device) Configure() {
-	d.bus.WriteRegister(uint8(d.Address), PWR_MGMT_1, []uint8{0})
+func (d Device) Configure() error {
+	return d.bus.WriteRegister(uint8(d.Address), PWR_MGMT_1, []uint8{0})
 }
 
 // ReadAcceleration reads the current acceleration from the device and returns


### PR DESCRIPTION
An I2C bus can generate errors (like any I/O can), but they weren't returned. This commit fixes this oversight.

Found while trying to figure out why LLVM 15 is broken just for the itsybitsy-m4.

There are a lot more drivers that could be fixed in a similar way. This commit doesn't do that yet, it just fixes the part that I can actually test.

Side note: I found that the code in TinyHCI will in fact _always_ return a bus error while configuring. I don't know yet why. (EDIT: not always, but it will about half of the time).