### PR TITLE
build: remove older format build tags

### DIFF
--- a/apds9960/apds9960_generic.go
+++ b/apds9960/apds9960_generic.go
@@ -1,5 +1,4 @@
 //go:build !nano_33_ble
-// +build !nano_33_ble
 
 package apds9960
 

--- a/apds9960/apds9960_nano_33_ble.go
+++ b/apds9960/apds9960_nano_33_ble.go
@@ -1,5 +1,4 @@
 //go:build nano_33_ble
-// +build nano_33_ble
 
 package apds9960
 

--- a/dht/constants.go
+++ b/dht/constants.go
@@ -1,5 +1,4 @@
 //go:build tinygo
-// +build tinygo
 
 // Package dht provides a driver for DHTXX family temperature and humidity sensors.
 //

--- a/dht/highfreq.go
+++ b/dht/highfreq.go
@@ -1,5 +1,4 @@
 //go:build mimxrt1062 || stm32f405 || atsamd51 || stm32f103xx || k210 || stm32f407
-// +build mimxrt1062 stm32f405 atsamd51 stm32f103xx k210 stm32f407
 
 package dht // import "tinygo.org/x/drivers/dht"
 

--- a/dht/lowfreq.go
+++ b/dht/lowfreq.go
@@ -1,5 +1,4 @@
 //go:build !mimxrt1062 && !stm32f405 && !atsamd51 && !stm32f103xx && !k210 && !stm32f407
-// +build !mimxrt1062,!stm32f405,!atsamd51,!stm32f103xx,!k210,!stm32f407
 
 package dht // import "tinygo.org/x/drivers/dht"
 

--- a/dht/thermometer.go
+++ b/dht/thermometer.go
@@ -1,5 +1,4 @@
 //go:build tinygo
-// +build tinygo
 
 // Package dht provides a driver for DHTXX family temperature and humidity sensors.
 //

--- a/dht/timesafethermometer.go
+++ b/dht/timesafethermometer.go
@@ -1,5 +1,4 @@
 //go:build tinygo
-// +build tinygo
 
 // Package dht provides a driver for DHTXX family temperature and humidity sensors.
 //

--- a/dht/util.go
+++ b/dht/util.go
@@ -1,5 +1,4 @@
 //go:build tinygo
-// +build tinygo
 
 package dht // import "tinygo.org/x/drivers/dht"
 

--- a/examples/ft6336/basic/m5stack_core2.go
+++ b/examples/ft6336/basic/m5stack_core2.go
@@ -1,5 +1,4 @@
 //go:build m5stack_core2
-// +build m5stack_core2
 
 package main
 

--- a/examples/ft6336/touchpaint/m5stack_core2.go
+++ b/examples/ft6336/touchpaint/m5stack_core2.go
@@ -1,5 +1,4 @@
 //go:build m5stack_core2
-// +build m5stack_core2
 
 package main
 

--- a/examples/ili9341/initdisplay/atsamd21.go
+++ b/examples/ili9341/initdisplay/atsamd21.go
@@ -1,5 +1,4 @@
 //go:build atsamd21
-// +build atsamd21
 
 package initdisplay
 

--- a/examples/ili9341/initdisplay/feather.go
+++ b/examples/ili9341/initdisplay/feather.go
@@ -1,5 +1,4 @@
 //go:build feather_m0 || feather_m4 || feather_m4_can || feather_nrf52840 || feather_nrf52840_sense || feather_stm32f405 || feather_rp2040
-// +build feather_m0 feather_m4 feather_m4_can feather_nrf52840 feather_nrf52840_sense feather_stm32f405 feather_rp2040
 
 package initdisplay
 

--- a/examples/ili9341/initdisplay/m5stack.go
+++ b/examples/ili9341/initdisplay/m5stack.go
@@ -1,5 +1,4 @@
 //go:build m5stack
-// +build m5stack
 
 package initdisplay
 

--- a/examples/ili9341/initdisplay/m5stack_core2.go
+++ b/examples/ili9341/initdisplay/m5stack_core2.go
@@ -1,5 +1,4 @@
 //go:build m5stack_core2
-// +build m5stack_core2
 
 package initdisplay
 

--- a/examples/ili9341/initdisplay/pyportal.go
+++ b/examples/ili9341/initdisplay/pyportal.go
@@ -1,5 +1,4 @@
 //go:build pyportal
-// +build pyportal
 
 package initdisplay
 

--- a/examples/ili9341/initdisplay/wioterminal.go
+++ b/examples/ili9341/initdisplay/wioterminal.go
@@ -1,5 +1,4 @@
 //go:build wioterminal
-// +build wioterminal
 
 package initdisplay
 

--- a/examples/sdcard/console/feather-m4.go
+++ b/examples/sdcard/console/feather-m4.go
@@ -1,5 +1,4 @@
 //go:build feather_m4 || feather_m4_can || feather_nrf52840
-// +build feather_m4 feather_m4_can feather_nrf52840
 
 package main
 

--- a/examples/sdcard/console/grandcentral-m4.go
+++ b/examples/sdcard/console/grandcentral-m4.go
@@ -1,5 +1,4 @@
 //go:build grandcentral_m4
-// +build grandcentral_m4
 
 package main
 

--- a/examples/sdcard/console/m0.go
+++ b/examples/sdcard/console/m0.go
@@ -1,5 +1,4 @@
 //go:build atsamd21 && !p1am_100
-// +build atsamd21,!p1am_100
 
 package main
 

--- a/examples/sdcard/console/p1am-100.go
+++ b/examples/sdcard/console/p1am-100.go
@@ -1,5 +1,4 @@
 //go:build p1am_100
-// +build p1am_100
 
 package main
 

--- a/examples/sdcard/console/pygamer.go
+++ b/examples/sdcard/console/pygamer.go
@@ -1,5 +1,4 @@
 //go:build pygamer
-// +build pygamer
 
 package main
 

--- a/examples/sdcard/console/pyportal.go
+++ b/examples/sdcard/console/pyportal.go
@@ -1,5 +1,4 @@
 //go:build pyportal
-// +build pyportal
 
 package main
 

--- a/examples/sdcard/console/thingplus-rp2040.go
+++ b/examples/sdcard/console/thingplus-rp2040.go
@@ -1,5 +1,4 @@
 //go:build thingplus_rp2040
-// +build thingplus_rp2040
 
 package main
 

--- a/examples/sdcard/console/wioterminal.go
+++ b/examples/sdcard/console/wioterminal.go
@@ -1,5 +1,4 @@
 //go:build wioterminal
-// +build wioterminal
 
 package main
 

--- a/examples/sdcard/tinyfs/console/console.go
+++ b/examples/sdcard/tinyfs/console/console.go
@@ -1,5 +1,4 @@
 //go:build tinygo
-// +build tinygo
 
 package console
 

--- a/examples/sdcard/tinyfs/feather-m4.go
+++ b/examples/sdcard/tinyfs/feather-m4.go
@@ -1,5 +1,4 @@
 //go:build feather_m4 || feather_m4_can || feather_nrf52840
-// +build feather_m4 feather_m4_can feather_nrf52840
 
 package main
 

--- a/examples/sdcard/tinyfs/grandcentral-m4.go
+++ b/examples/sdcard/tinyfs/grandcentral-m4.go
@@ -1,5 +1,4 @@
 //go:build grandcentral_m4
-// +build grandcentral_m4
 
 package main
 

--- a/examples/sdcard/tinyfs/m0.go
+++ b/examples/sdcard/tinyfs/m0.go
@@ -1,5 +1,4 @@
 //go:build atsamd21 && !p1am_100
-// +build atsamd21,!p1am_100
 
 package main
 

--- a/examples/sdcard/tinyfs/p1am-100.go
+++ b/examples/sdcard/tinyfs/p1am-100.go
@@ -1,5 +1,4 @@
 //go:build p1am_100
-// +build p1am_100
 
 package main
 

--- a/examples/sdcard/tinyfs/pygamer.go
+++ b/examples/sdcard/tinyfs/pygamer.go
@@ -1,5 +1,4 @@
 //go:build pygamer
-// +build pygamer
 
 package main
 

--- a/examples/sdcard/tinyfs/pyportal.go
+++ b/examples/sdcard/tinyfs/pyportal.go
@@ -1,5 +1,4 @@
 //go:build pyportal
-// +build pyportal
 
 package main
 

--- a/examples/sdcard/tinyfs/thingplus-rp2040.go
+++ b/examples/sdcard/tinyfs/thingplus-rp2040.go
@@ -1,5 +1,4 @@
 //go:build thingplus_rp2040
-// +build thingplus_rp2040
 
 package main
 

--- a/examples/sdcard/tinyfs/wioterminal.go
+++ b/examples/sdcard/tinyfs/wioterminal.go
@@ -1,5 +1,4 @@
 //go:build wioterminal
-// +build wioterminal
 
 package main
 

--- a/examples/sx126x/rfswitch/gnse.go
+++ b/examples/sx126x/rfswitch/gnse.go
@@ -1,5 +1,4 @@
 //go:build gnse
-// +build gnse
 
 /*
 Generic Node Sensor Edition

--- a/examples/sx126x/rfswitch/lorae5.go
+++ b/examples/sx126x/rfswitch/lorae5.go
@@ -1,5 +1,4 @@
 //go:build lorae5
-// +build lorae5
 
 package radio
 

--- a/examples/sx126x/rfswitch/wl55jc.go
+++ b/examples/sx126x/rfswitch/wl55jc.go
@@ -1,5 +1,4 @@
 //go:build nucleowl55jc
-// +build nucleowl55jc
 
 /*
 	Nucleo WL55JC1

--- a/examples/wifi/tcpclient/espat.go
+++ b/examples/wifi/tcpclient/espat.go
@@ -1,5 +1,4 @@
 //go:build espat
-// +build espat
 
 package main
 

--- a/examples/wifi/tcpclient/rtl8720dn.go
+++ b/examples/wifi/tcpclient/rtl8720dn.go
@@ -1,5 +1,4 @@
 //go:build rtl8720dn
-// +build rtl8720dn
 
 package main
 

--- a/examples/wifi/tcpclient/wifinina.go
+++ b/examples/wifi/tcpclient/wifinina.go
@@ -1,5 +1,4 @@
 //go:build wifinina
-// +build wifinina
 
 package main
 

--- a/examples/wifinina/pins/main.go
+++ b/examples/wifinina/pins/main.go
@@ -1,5 +1,4 @@
 //go:build nano_rp2040
-// +build nano_rp2040
 
 // This examples shows how to control RGB LED connected to
 // NINA-W102 chip on Arduino Nano RP2040 Connect board

--- a/examples/ws2812/arduino.go
+++ b/examples/ws2812/arduino.go
@@ -1,5 +1,4 @@
 //go:build arduino
-// +build arduino
 
 package main
 

--- a/examples/ws2812/digispark.go
+++ b/examples/ws2812/digispark.go
@@ -1,5 +1,4 @@
 //go:build digispark
-// +build digispark
 
 package main
 

--- a/examples/ws2812/others.go
+++ b/examples/ws2812/others.go
@@ -1,5 +1,4 @@
 //go:build !digispark && !arduino && !qtpy && !m5stamp_c3 && !thingplus_rp2040
-// +build !digispark,!arduino,!qtpy,!m5stamp_c3,!thingplus_rp2040
 
 package main
 

--- a/examples/ws2812/others_wo_led.go
+++ b/examples/ws2812/others_wo_led.go
@@ -1,5 +1,4 @@
 //go:build qtpy || m5stamp_c3
-// +build qtpy m5stamp_c3
 
 package main
 

--- a/examples/ws2812/qtpy.go
+++ b/examples/ws2812/qtpy.go
@@ -1,5 +1,4 @@
 //go:build qtpy
-// +build qtpy
 
 package main
 

--- a/examples/ws2812/thingplus-rp2040.go
+++ b/examples/ws2812/thingplus-rp2040.go
@@ -1,5 +1,4 @@
 //go:build thingplus_rp2040
-// +build thingplus_rp2040
 
 package main
 

--- a/flash/transport_qspi_samd.go
+++ b/flash/transport_qspi_samd.go
@@ -1,5 +1,4 @@
 //go:build atsamd51
-// +build atsamd51
 
 package flash
 

--- a/hts221/hts221_generic.go
+++ b/hts221/hts221_generic.go
@@ -1,5 +1,4 @@
 //go:build !nano_33_ble
-// +build !nano_33_ble
 
 package hts221
 

--- a/hts221/hts221_nano_33_ble.go
+++ b/hts221/hts221_nano_33_ble.go
@@ -1,5 +1,4 @@
 //go:build nano_33_ble
-// +build nano_33_ble
 
 package hts221
 

--- a/i2csoft/i2csoft_atsamd51.go
+++ b/i2csoft/i2csoft_atsamd51.go
@@ -1,5 +1,4 @@
 //go:build atsamd51 || atsame5x
-// +build atsamd51 atsame5x
 
 package i2csoft
 

--- a/i2csoft/i2csoft_esp32.go
+++ b/i2csoft/i2csoft_esp32.go
@@ -1,5 +1,4 @@
 //go:build esp32
-// +build esp32
 
 package i2csoft
 

--- a/i2csoft/i2csoft_nrf52840.go
+++ b/i2csoft/i2csoft_nrf52840.go
@@ -1,5 +1,4 @@
 //go:build nrf52840
-// +build nrf52840
 
 package i2csoft
 

--- a/i2csoft/i2csoft_other.go
+++ b/i2csoft/i2csoft_other.go
@@ -1,5 +1,4 @@
 //go:build !esp32 && !atsamd51 && !atsame5x && !stm32f4 && !rp2040 && !nrf52840
-// +build !esp32,!atsamd51,!atsame5x,!stm32f4,!rp2040,!nrf52840
 
 package i2csoft
 

--- a/i2csoft/i2csoft_rp2040.go
+++ b/i2csoft/i2csoft_rp2040.go
@@ -1,5 +1,4 @@
 //go:build rp2040
-// +build rp2040
 
 package i2csoft
 

--- a/i2csoft/i2csoft_stm32f4.go
+++ b/i2csoft/i2csoft_stm32f4.go
@@ -1,5 +1,4 @@
 //go:build stm32f4
-// +build stm32f4
 
 package i2csoft
 

--- a/ili9341/parallel_atsamd51.go
+++ b/ili9341/parallel_atsamd51.go
@@ -1,5 +1,4 @@
 //go:build atsamd51
-// +build atsamd51
 
 package ili9341
 

--- a/ili9341/spi.go
+++ b/ili9341/spi.go
@@ -1,5 +1,4 @@
 //go:build !atsamd51 && !atsame5x && !atsamd21
-// +build !atsamd51,!atsame5x,!atsamd21
 
 package ili9341
 

--- a/ili9341/spi_atsamd21.go
+++ b/ili9341/spi_atsamd21.go
@@ -1,5 +1,4 @@
 //go:build atsamd21
-// +build atsamd21
 
 package ili9341
 

--- a/ili9341/spi_atsamd51.go
+++ b/ili9341/spi_atsamd51.go
@@ -1,5 +1,4 @@
 //go:build atsamd51 || atsame5x
-// +build atsamd51 atsame5x
 
 package ili9341
 

--- a/image/internal/imageutil/gen.go
+++ b/image/internal/imageutil/gen.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/image/png/fuzz.go
+++ b/image/png/fuzz.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build gofuzz
-// +build gofuzz
 
 package png
 

--- a/lps22hb/lps22hb_generic.go
+++ b/lps22hb/lps22hb_generic.go
@@ -1,5 +1,4 @@
 //go:build !nano_33_ble
-// +build !nano_33_ble
 
 package lps22hb
 

--- a/lps22hb/lps22hb_nano_33_ble.go
+++ b/lps22hb/lps22hb_nano_33_ble.go
@@ -1,5 +1,4 @@
 //go:build nano_33_ble
-// +build nano_33_ble
 
 package lps22hb
 

--- a/lsm6ds3tr/lsm6ds3tr_generic.go
+++ b/lsm6ds3tr/lsm6ds3tr_generic.go
@@ -1,5 +1,4 @@
 //go:build !xiao_ble
-// +build !xiao_ble
 
 package lsm6ds3tr
 

--- a/lsm6ds3tr/lsm6ds3tr_xiao_ble.go
+++ b/lsm6ds3tr/lsm6ds3tr_xiao_ble.go
@@ -1,5 +1,4 @@
 //go:build xiao_ble
-// +build xiao_ble
 
 package lsm6ds3tr
 

--- a/lsm9ds1/lsm9ds1_generic.go
+++ b/lsm9ds1/lsm9ds1_generic.go
@@ -1,5 +1,4 @@
 //go:build !nano_33_ble
-// +build !nano_33_ble
 
 package lsm9ds1
 

--- a/lsm9ds1/lsm9ds1_nano_33_ble.go
+++ b/lsm9ds1/lsm9ds1_nano_33_ble.go
@@ -1,5 +1,4 @@
 //go:build nano_33_ble
-// +build nano_33_ble
 
 // Nano 33 BLE [Sense] has LSM9DS1 unit on-board.
 // This custom Configure function powers unit up

--- a/microbitmatrix/microbitmatrix-v1.go
+++ b/microbitmatrix/microbitmatrix-v1.go
@@ -1,5 +1,4 @@
 //go:build microbit
-// +build microbit
 
 // Package microbitmatrix implements a driver for the BBC micro:bit's LED matrix.
 //

--- a/microbitmatrix/microbitmatrix-v2.go
+++ b/microbitmatrix/microbitmatrix-v2.go
@@ -1,5 +1,4 @@
 //go:build microbit_v2
-// +build microbit_v2
 
 // Package microbitmatrix implements a driver for the BBC micro:bit version 2 LED matrix.
 //

--- a/shifter/pybadge.go
+++ b/shifter/pybadge.go
@@ -1,5 +1,4 @@
 //go:build pybadge
-// +build pybadge
 
 package shifter
 

--- a/ssd1289/rp2040bus.go
+++ b/ssd1289/rp2040bus.go
@@ -1,5 +1,4 @@
 //go:build rp2040
-// +build rp2040
 
 package ssd1289
 

--- a/sx126x/spi_stm32wl.go
+++ b/sx126x/spi_stm32wl.go
@@ -1,5 +1,4 @@
 //go:build stm32wlx
-// +build stm32wlx
 
 package sx126x
 

--- a/ws2812/gen-ws2812.go
+++ b/ws2812/gen-ws2812.go
@@ -1,5 +1,4 @@
 //go:build none
-// +build none
 
 package main
 
@@ -285,7 +284,6 @@ func main() {
 	}
 	defer f.Close()
 	fmt.Fprintln(f, "//go:build", architectures[*arch].buildTag)
-	fmt.Fprintln(f, "// +build", architectures[*arch].buildTag)
 	f.WriteString(`
 package ws2812
 

--- a/ws2812/ws2812-asm_cortexm.go
+++ b/ws2812/ws2812-asm_cortexm.go
@@ -1,5 +1,4 @@
 //go:build cortexm
-// +build cortexm
 
 package ws2812
 

--- a/ws2812/ws2812-asm_tinygoriscv.go
+++ b/ws2812/ws2812-asm_tinygoriscv.go
@@ -1,5 +1,4 @@
 //go:build tinygo.riscv32
-// +build tinygo.riscv32
 
 package ws2812
 

--- a/ws2812/ws2812_avr.go
+++ b/ws2812/ws2812_avr.go
@@ -1,5 +1,4 @@
 //go:build avr
-// +build avr
 
 package ws2812
 

--- a/ws2812/ws2812_cortexm.go
+++ b/ws2812/ws2812_cortexm.go
@@ -1,5 +1,4 @@
 //go:build cortexm
-// +build cortexm
 
 package ws2812
 

--- a/ws2812/ws2812_generic.go
+++ b/ws2812/ws2812_generic.go
@@ -1,5 +1,4 @@
 //go:build !baremetal
-// +build !baremetal
 
 package ws2812
 

--- a/ws2812/ws2812_tinygoriscv.go
+++ b/ws2812/ws2812_tinygoriscv.go
@@ -1,5 +1,4 @@
 //go:build tinygo.riscv32
-// +build tinygo.riscv32
 
 package ws2812
 

--- a/ws2812/ws2812_xtensa.go
+++ b/ws2812/ws2812_xtensa.go
@@ -1,5 +1,4 @@
 //go:build xtensa
-// +build xtensa
 
 package ws2812
 


### PR DESCRIPTION
This PR removes all of the build tags in the older format in similar fashion to https://github.com/tinygo-org/tinygo/pull/3348