### PR TITLE
rtl8720dn: add handling when connect fails

### DIFF
--- a/rtl8720dn/netdriver.go
+++ b/rtl8720dn/netdriver.go
@@ -71,9 +71,12 @@ func (d *Driver) ConnectTCPSocket(addr, port string) error {
 	name[6] = byte(ipaddr[2])
 	name[7] = byte(ipaddr[3])
 
-	_, err = d.Rpc_lwip_connect(socket, name, uint32(len(name)))
+	result, err := d.Rpc_lwip_connect(socket, name, uint32(len(name)))
 	if err != nil {
 		return err
+	}
+	if result == -1 {
+		return fmt.Errorf("failed to connect to %d.%d.%d.%d port %s", addr[0], addr[1], addr[2], addr[3], port)
 	}
 
 	readset := []byte{}


### PR DESCRIPTION
This PR adds handling when rtl8720dn fails to connect to a specific TCP destination.

-1 represents many rpc failures, but details are unknown.
In fact, rtl8720dn returns -1 when a connection fails.