### PR TITLE
Lorawan regional parameters initial implementation

### DIFF
--- a/examples/lora/lorawan/atcmd/main.go
+++ b/examples/lora/lorawan/atcmd/main.go
@@ -15,6 +15,7 @@ import (
 	"tinygo.org/x/drivers/examples/lora/lorawan/common"
 	"tinygo.org/x/drivers/lora"
 	"tinygo.org/x/drivers/lora/lorawan"
+	"tinygo.org/x/drivers/lora/lorawan/region"
 )
 
 // change these to test a different UART or pins if available
@@ -43,6 +44,8 @@ func main() {
 	session = &lorawan.Session{}
 	otaa = &lorawan.Otaa{}
 	lorawan.UseRadio(radio)
+
+	lorawan.UseRegionSettings(region.EU868())
 
 	for {
 		if uart.Buffered() > 0 {

--- a/examples/lora/lorawan/basic-demo/README.md
+++ b/examples/lora/lorawan/basic-demo/README.md
@@ -33,3 +33,12 @@ tinygo flash -target pybadge -tags featherwing ./examples/lora/lorawan/basic-dem
 tinygo flash -target lorae5 ./examples/lora/lorawan/basic-demo
 ```
 
+
+## Enable debugging
+
+You can also enable some debug logs with ldflags :
+
+```
+$ tinygo build -ldflags="-X 'main.debug=true'" -target=lorae5
+```
+

--- a/examples/lora/lorawan/basic-demo/main.go
+++ b/examples/lora/lorawan/basic-demo/main.go
@@ -92,7 +92,7 @@ func main() {
 		println("main: Network joined")
 		println("main: DevEui, " + otaa.GetDevEUI())
 		println("main: AppEui, " + otaa.GetAppEUI())
-		println("main: DevAddr, " + session.GetDevAddr())
+		println("main: DevAddr, " + otaa.GetAppKey())
 	}
 
 	// Try to connect Lorawan network

--- a/examples/lora/lorawan/basic-demo/main.go
+++ b/examples/lora/lorawan/basic-demo/main.go
@@ -9,9 +9,11 @@ import (
 	"tinygo.org/x/drivers/examples/lora/lorawan/common"
 	"tinygo.org/x/drivers/lora"
 	"tinygo.org/x/drivers/lora/lorawan"
+	"tinygo.org/x/drivers/lora/lorawan/region"
 )
 
 const (
+	debug                       = true
 	LORAWAN_JOIN_TIMEOUT_SEC    = 180
 	LORAWAN_RECONNECT_DELAY_SEC = 15
 	LORAWAN_UPLINK_DELAY_SEC    = 60
@@ -81,14 +83,29 @@ func main() {
 	// Connect the lorawan with the Lora Radio device.
 	lorawan.UseRadio(radio)
 
+	lorawan.UseRegionSettings(region.EU868())
+
 	// Configure AppEUI, DevEUI, APPKey
 	setLorawanKeys()
+
+	if debug {
+		println("main: Network joined")
+		println("main: DevEui, " + otaa.GetDevEUI())
+		println("main: AppEui, " + otaa.GetAppEUI())
+		println("main: DevAddr, " + session.GetDevAddr())
+	}
 
 	// Try to connect Lorawan network
 	if err := loraConnect(); err != nil {
 		failMessage(err)
 	}
 
+	if debug {
+		println("main: NetID, " + otaa.GetNetID())
+		println("main: NwkSKey, " + session.GetNwkSKey())
+		println("main: AppSKey, " + session.GetAppSKey())
+		println("main: Done")
+	}
 	// Try to periodicaly send an uplink sample message
 	upCount := 1
 	for {

--- a/examples/lora/lorawan/basic-demo/main.go
+++ b/examples/lora/lorawan/basic-demo/main.go
@@ -12,8 +12,9 @@ import (
 	"tinygo.org/x/drivers/lora/lorawan/region"
 )
 
+var debug string
+
 const (
-	debug                       = true
 	LORAWAN_JOIN_TIMEOUT_SEC    = 180
 	LORAWAN_RECONNECT_DELAY_SEC = 15
 	LORAWAN_UPLINK_DELAY_SEC    = 60
@@ -88,7 +89,7 @@ func main() {
 	// Configure AppEUI, DevEUI, APPKey
 	setLorawanKeys()
 
-	if debug {
+	if debug != "" {
 		println("main: Network joined")
 		println("main: DevEui, " + otaa.GetDevEUI())
 		println("main: AppEui, " + otaa.GetAppEUI())
@@ -100,7 +101,7 @@ func main() {
 		failMessage(err)
 	}
 
-	if debug {
+	if debug != "" {
 		println("main: NetID, " + otaa.GetNetID())
 		println("main: NwkSKey, " + session.GetNwkSKey())
 		println("main: AppSKey, " + session.GetAppSKey())

--- a/lora/lorawan/adaptor.go
+++ b/lora/lorawan/adaptor.go
@@ -119,7 +119,7 @@ func SendUplink(data []uint8, session *Session) error {
 
 	ApplyChannelConfig(regionSettings.UplinkChannel())
 	ActiveRadio.SetCrc(true)
-	ActiveRadio.SetIqMode(lora.IQInverted)
+	ActiveRadio.SetIqMode(lora.IQStandard)
 	ActiveRadio.Tx(payload, LORA_TX_TIMEOUT)
 	if err != nil {
 		return err

--- a/lora/lorawan/otaa.go
+++ b/lora/lorawan/otaa.go
@@ -20,7 +20,6 @@ type Otaa struct {
 // Initialize DevNonce
 func (o *Otaa) Init() {
 	o.buf = make([]uint8, 0)
-
 	o.generateDevNonce()
 }
 

--- a/lora/lorawan/region/au915.go
+++ b/lora/lorawan/region/au915.go
@@ -1,0 +1,22 @@
+package region
+
+import "tinygo.org/x/drivers/lora"
+
+type RegionSettingsAU915 struct {
+}
+
+func AU915() *RegionSettingsAU915 {
+	return &RegionSettingsAU915{}
+}
+
+func (r *RegionSettingsAU915) GetJoinRequestChannel() Channel {
+	return Channel{916800000, lora.Bandwidth_125_0, lora.SpreadingFactor9, lora.CodingRate4_5}
+}
+
+func (r *RegionSettingsAU915) GetJoinAcceptChannel() Channel {
+	return Channel{923300000, lora.Bandwidth_500_0, lora.SpreadingFactor9, lora.CodingRate4_5}
+}
+
+func (r *RegionSettingsAU915) GetUplinkChannel() Channel {
+	return Channel{868500000, lora.Bandwidth_125_0, lora.SpreadingFactor9, lora.CodingRate4_5}
+}

--- a/lora/lorawan/region/au915.go
+++ b/lora/lorawan/region/au915.go
@@ -2,21 +2,48 @@ package region
 
 import "tinygo.org/x/drivers/lora"
 
+const (
+	AU915_DEFAULT_PREAMBLE_LEN = 8
+	AU915_DEFAULT_TX_POWER_DBM = 20
+)
+
 type RegionSettingsAU915 struct {
+	joinRequestChannel *Channel
+	joinAcceptChannel  *Channel
+	uplinkChannel      *Channel
 }
 
 func AU915() *RegionSettingsAU915 {
-	return &RegionSettingsAU915{}
+	return &RegionSettingsAU915{
+		joinRequestChannel: &Channel{916800000,
+			lora.Bandwidth_125_0,
+			lora.SpreadingFactor9,
+			lora.CodingRate4_7,
+			AU915_DEFAULT_PREAMBLE_LEN,
+			AU915_DEFAULT_TX_POWER_DBM},
+		joinAcceptChannel: &Channel{923300000,
+			lora.Bandwidth_500_0,
+			lora.SpreadingFactor9,
+			lora.CodingRate4_7,
+			AU915_DEFAULT_PREAMBLE_LEN,
+			AU915_DEFAULT_TX_POWER_DBM},
+		uplinkChannel: &Channel{868500000,
+			lora.Bandwidth_125_0,
+			lora.SpreadingFactor9,
+			lora.CodingRate4_7,
+			AU915_DEFAULT_PREAMBLE_LEN,
+			AU915_DEFAULT_TX_POWER_DBM},
+	}
 }
 
-func (r *RegionSettingsAU915) GetJoinRequestChannel() Channel {
-	return Channel{916800000, lora.Bandwidth_125_0, lora.SpreadingFactor9, lora.CodingRate4_5}
+func (r *RegionSettingsAU915) JoinRequestChannel() *Channel {
+	return r.joinRequestChannel
 }
 
-func (r *RegionSettingsAU915) GetJoinAcceptChannel() Channel {
-	return Channel{923300000, lora.Bandwidth_500_0, lora.SpreadingFactor9, lora.CodingRate4_5}
+func (r *RegionSettingsAU915) JoinAcceptChannel() *Channel {
+	return r.joinAcceptChannel
 }
 
-func (r *RegionSettingsAU915) GetUplinkChannel() Channel {
-	return Channel{868500000, lora.Bandwidth_125_0, lora.SpreadingFactor9, lora.CodingRate4_5}
+func (r *RegionSettingsAU915) UplinkChannel() *Channel {
+	return r.uplinkChannel
 }

--- a/lora/lorawan/region/eu868.go
+++ b/lora/lorawan/region/eu868.go
@@ -2,21 +2,48 @@ package region
 
 import "tinygo.org/x/drivers/lora"
 
+const (
+	EU868_DEFAULT_PREAMBLE_LEN = 8
+	EU868_DEFAULT_TX_POWER_DBM = 20
+)
+
 type RegionSettingsEU868 struct {
+	joinRequestChannel *Channel
+	joinAcceptChannel  *Channel
+	uplinkChannel      *Channel
 }
 
 func EU868() *RegionSettingsEU868 {
-	return &RegionSettingsEU868{}
+	return &RegionSettingsEU868{
+		joinRequestChannel: &Channel{868100000,
+			lora.Bandwidth_125_0,
+			lora.SpreadingFactor9,
+			lora.CodingRate4_7,
+			EU868_DEFAULT_PREAMBLE_LEN,
+			EU868_DEFAULT_TX_POWER_DBM},
+		joinAcceptChannel: &Channel{868100000,
+			lora.Bandwidth_125_0,
+			lora.SpreadingFactor9,
+			lora.CodingRate4_7,
+			EU868_DEFAULT_PREAMBLE_LEN,
+			EU868_DEFAULT_TX_POWER_DBM},
+		uplinkChannel: &Channel{868100000,
+			lora.Bandwidth_125_0,
+			lora.SpreadingFactor9,
+			lora.CodingRate4_7,
+			EU868_DEFAULT_PREAMBLE_LEN,
+			EU868_DEFAULT_TX_POWER_DBM},
+	}
 }
 
-func (r *RegionSettingsEU868) GetJoinRequestChannel() Channel {
-	return Channel{868100000, lora.Bandwidth_125_0, lora.SpreadingFactor9, lora.CodingRate4_7}
+func (r *RegionSettingsEU868) JoinRequestChannel() *Channel {
+	return r.joinRequestChannel
 }
 
-func (r *RegionSettingsEU868) GetJoinAcceptChannel() Channel {
-	return Channel{868100000, lora.Bandwidth_125_0, lora.SpreadingFactor9, lora.CodingRate4_7}
+func (r *RegionSettingsEU868) JoinAcceptChannel() *Channel {
+	return r.joinAcceptChannel
 }
 
-func (r *RegionSettingsEU868) GetUplinkChannel() Channel {
-	return Channel{868100000, lora.Bandwidth_125_0, lora.SpreadingFactor9, lora.CodingRate4_7}
+func (r *RegionSettingsEU868) UplinkChannel() *Channel {
+	return r.uplinkChannel
 }

--- a/lora/lorawan/region/eu868.go
+++ b/lora/lorawan/region/eu868.go
@@ -1,0 +1,22 @@
+package region
+
+import "tinygo.org/x/drivers/lora"
+
+type RegionSettingsEU868 struct {
+}
+
+func EU868() *RegionSettingsEU868 {
+	return &RegionSettingsEU868{}
+}
+
+func (r *RegionSettingsEU868) GetJoinRequestChannel() Channel {
+	return Channel{868100000, lora.Bandwidth_125_0, lora.SpreadingFactor9, lora.CodingRate4_7}
+}
+
+func (r *RegionSettingsEU868) GetJoinAcceptChannel() Channel {
+	return Channel{868100000, lora.Bandwidth_125_0, lora.SpreadingFactor9, lora.CodingRate4_7}
+}
+
+func (r *RegionSettingsEU868) GetUplinkChannel() Channel {
+	return Channel{868100000, lora.Bandwidth_125_0, lora.SpreadingFactor9, lora.CodingRate4_7}
+}

--- a/lora/lorawan/region/regionset.go
+++ b/lora/lorawan/region/regionset.go
@@ -1,0 +1,14 @@
+package region
+
+type Channel struct {
+	Frequency       uint32
+	Bandwidth       uint8
+	SpreadingFactor uint8
+	CodingRate      uint8
+}
+
+type RegionSettings interface {
+	GetJoinRequestChannel() Channel
+	GetJoinAcceptChannel() Channel
+	GetUplinkChannel() Channel
+}

--- a/lora/lorawan/region/regionset.go
+++ b/lora/lorawan/region/regionset.go
@@ -5,10 +5,12 @@ type Channel struct {
 	Bandwidth       uint8
 	SpreadingFactor uint8
 	CodingRate      uint8
+	PreambleLength  uint16
+	TxPowerDBm      int8
 }
 
 type RegionSettings interface {
-	GetJoinRequestChannel() Channel
-	GetJoinAcceptChannel() Channel
-	GetUplinkChannel() Channel
+	JoinRequestChannel() *Channel
+	JoinAcceptChannel() *Channel
+	UplinkChannel() *Channel
 }

--- a/lora/radio.go
+++ b/lora/radio.go
@@ -10,5 +10,7 @@ type Radio interface {
 	SetBandwidth(bw uint8)
 	SetCrc(enable bool)
 	SetSpreadingFactor(sf uint8)
+	SetPreambleLength(plen uint16)
+	SetTxPower(txpow int8)
 	LoraConfig(cnf Config)
 }

--- a/sx126x/sx126x.go
+++ b/sx126x/sx126x.go
@@ -545,7 +545,7 @@ func (d *Device) SetCodingRate(cr uint8) {
 // SetBandwidth() sets current Lora Bandwidth
 // NB: Change will be applied at next RX / TX
 func (d *Device) SetBandwidth(bw uint8) {
-	d.loraConf.Cr = bw
+	d.loraConf.Bw = bw
 }
 
 // SetCrc() sets current CRC mode (ON/OFF)

--- a/sx126x/sx126x.go
+++ b/sx126x/sx126x.go
@@ -640,6 +640,7 @@ func (d *Device) Rx(timeoutMs uint32) ([]uint8, error) {
 	irqVal := uint16(SX126X_IRQ_RX_DONE | SX126X_IRQ_TIMEOUT | SX126X_IRQ_CRC_ERR)
 	d.SetStandby()
 	d.SetBufferBaseAddress(0, 0)
+	d.SetRfFrequency(d.loraConf.Freq)
 	d.SetModulationParams(d.loraConf.Sf, bandwidth(d.loraConf.Bw), d.loraConf.Cr, d.loraConf.Ldr)
 	d.SetPacketParam(d.loraConf.Preamble, d.loraConf.HeaderType, d.loraConf.Crc, 0xFF, d.loraConf.Iq)
 	d.SetDioIrqParams(irqVal, irqVal, SX126X_IRQ_NONE, SX126X_IRQ_NONE)

--- a/sx126x/sx126x.go
+++ b/sx126x/sx126x.go
@@ -558,10 +558,22 @@ func (d *Device) SetCrc(enable bool) {
 	}
 }
 
-// SetSpreadingFactor setc surrent Lora Spreading Factor
+// SetSpreadingFactor sets current Lora Spreading Factor
 // NB: Change will be applied at next RX / TX
 func (d *Device) SetSpreadingFactor(sf uint8) {
 	d.loraConf.Sf = sf
+}
+
+// SetPreambleLength sets current Lora Preamble Length
+// NB: Change will be applied at next RX / TX
+func (d *Device) SetPreambleLength(pl uint16) {
+	d.loraConf.Preamble = pl
+}
+
+// SetTxPowerDbm sets current Lora TX Power in DBm
+// NB: Change will be applied at next RX / TX
+func (d *Device) SetTxPower(txpow int8) {
+	d.loraConf.LoraTxPowerDBm = txpow
 }
 
 //

--- a/sx127x/sx127x.go
+++ b/sx127x/sx127x.go
@@ -145,8 +145,13 @@ func (d *Device) GetBandwidth() int32 {
 }
 */
 
-// SetTxPower sets the transmitter output power
-func (d *Device) SetTxPower(txPower int8, paBoost bool) {
+// SetTxPower sets the transmitter output (with paBoost ON)
+func (d *Device) SetTxPower(txPower int8) {
+	d.SetTxPowerWithPaBoost(txPower, true)
+}
+
+// SetTxPowerWithPaBoost sets the transmitter output power and may activate paBoost
+func (d *Device) SetTxPowerWithPaBoost(txPower int8, paBoost bool) {
 	if !paBoost {
 		// RFO
 		if txPower < 0 {
@@ -315,7 +320,7 @@ func (d *Device) SetCrc(enable bool) {
 	}
 }
 
-func (d *Device) SetPreamble(pLen uint16) {
+func (d *Device) SetPreambleLength(pLen uint16) {
 	// Sets preamble length
 	d.WriteRegister(SX127X_REG_PREAMBLE_MSB, uint8((pLen>>8)&0xFF))
 	d.WriteRegister(SX127X_REG_PREAMBLE_LSB, uint8(pLen&0xFF))
@@ -353,14 +358,14 @@ func (d *Device) Tx(pkt []uint8, timeoutMs uint32) error {
 	d.WriteRegister(SX127X_REG_LNA, SX127X_LNA_MAX_GAIN)                                // Set Low Noise Amplifier to MAX
 
 	d.SetFrequency(d.loraConf.Freq)
-	d.SetPreamble(d.loraConf.Preamble)
+	d.SetPreambleLength(d.loraConf.Preamble)
 	d.SetSyncWord(d.loraConf.SyncWord)
 	d.SetBandwidth(d.loraConf.Bw)
 	d.SetSpreadingFactor(d.loraConf.Sf)
 	d.SetIqMode(d.loraConf.Iq)
 	d.SetCodingRate(d.loraConf.Cr)
 	d.SetCrc(d.loraConf.Crc == lora.CRCOn)
-	d.SetTxPower(d.loraConf.LoraTxPowerDBm, true)
+	d.SetTxPower(d.loraConf.LoraTxPowerDBm)
 	d.SetHeaderMode(d.loraConf.HeaderType)
 	d.SetAgcAuto(SX127X_AGC_AUTO_ON)
 
@@ -409,14 +414,14 @@ func (d *Device) Rx(timeoutMs uint32) ([]uint8, error) {
 	d.WriteRegister(SX127X_REG_LNA, SX127X_LNA_MAX_GAIN)                                // Set Low Noise Amplifier to MAX
 
 	d.SetFrequency(d.loraConf.Freq)
-	d.SetPreamble(d.loraConf.Preamble)
+	d.SetPreambleLength(d.loraConf.Preamble)
 	d.SetSyncWord(d.loraConf.SyncWord)
 	d.SetBandwidth(d.loraConf.Bw)
 	d.SetSpreadingFactor(d.loraConf.Sf)
 	d.SetIqMode(d.loraConf.Iq)
 	d.SetCodingRate(d.loraConf.Cr)
 	d.SetCrc(d.loraConf.Crc == lora.CRCOn)
-	d.SetTxPower(d.loraConf.LoraTxPowerDBm, true)
+	d.SetTxPower(d.loraConf.LoraTxPowerDBm)
 	d.SetHeaderMode(d.loraConf.HeaderType)
 	d.SetAgcAuto(SX127X_AGC_AUTO_ON)
 


### PR DESCRIPTION

Lorawan Regional Parameters document describes the rules to properly use radio modulation during Lorawan communication (frequency, bandwidth, channel hopping, duty cycles...):

[https://lora-alliance.org/resource_hub/rp2-1-0-3-lorawan-regional-parameters/](url)

This draft PR aims at providing a minimal implementation so your devices can connect  Lorawan Network in all regions.

In a second time, the code will be improved to improve Lorawan 1.0.3 compliance. 

Any comments welcome.


 
