### PR TITLE
sx127x: add RadioController interface to match sx126x

### DIFF
--- a/examples/lora/lorawan/common/featherwing.go
+++ b/examples/lora/lorawan/common/featherwing.go
@@ -1,0 +1,14 @@
+//go:build featherwing
+
+package common
+
+import "machine"
+
+var (
+	// We assume LoRa Featherwing module with sx127x is connected to PyBadge
+	rstPin  = machine.D11
+	csPin   = machine.D10
+	dio0Pin = machine.D6
+	dio1Pin = machine.D9
+	spi     = machine.SPI0
+)

--- a/examples/lora/lorawan/common/lgt92.go
+++ b/examples/lora/lorawan/common/lgt92.go
@@ -1,0 +1,13 @@
+//go:build lgt92
+
+package common
+
+import "machine"
+
+var (
+	rstPin  = machine.PB0
+	csPin   = machine.PA15
+	dio0Pin = machine.PC13
+	dio1Pin = machine.PB10
+	spi     = machine.SPI0
+)

--- a/examples/lora/lorawan/common/sim.go
+++ b/examples/lora/lorawan/common/sim.go
@@ -1,4 +1,4 @@
-//go:build !featherwing && !stm32wlx && !sx126x
+//go:build !featherwing && !lgt92 && !stm32wlx && !sx126x
 
 package common
 

--- a/examples/lora/lorawan/common/sx127x.go
+++ b/examples/lora/lorawan/common/sx127x.go
@@ -18,12 +18,6 @@ const (
 )
 
 var (
-	// We assume LoRa Featherwing module is connected to PyBadge:
-	rstPin    = machine.D11
-	csPin     = machine.D10
-	dio0Pin   = machine.D6
-	dio1Pin   = machine.D9
-	spi       = machine.SPI0
 	loraRadio *sx127x.Device
 )
 

--- a/examples/lora/lorawan/common/sx127x.go
+++ b/examples/lora/lorawan/common/sx127x.go
@@ -1,4 +1,4 @@
-//go:build featherwing
+//go:build featherwing || lgt92
 
 package common
 

--- a/examples/sx127x/lora_rxtx/lora_rxtx.go
+++ b/examples/sx127x/lora_rxtx/lora_rxtx.go
@@ -40,29 +40,19 @@ func main() {
 	println("# ----------------------")
 	machine.LED.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	SX127X_PIN_RST.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	SX127X_PIN_CS.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	SX127X_PIN_DIO0.Configure(machine.PinConfig{Mode: machine.PinInputPullup})
-	SX127X_PIN_DIO1.Configure(machine.PinConfig{Mode: machine.PinInputPullup})
+
 	SX127X_SPI.Configure(machine.SPIConfig{Frequency: 500000, Mode: 0})
 
 	println("main: create and start SX127x driver")
-	loraRadio = sx127x.New(SX127X_SPI, SX127X_PIN_CS, SX127X_PIN_RST)
+	loraRadio = sx127x.New(SX127X_SPI, SX127X_PIN_RST)
+	loraRadio.SetRadioController(sx127x.NewRadioControl(SX127X_PIN_CS, SX127X_PIN_DIO0, SX127X_PIN_DIO1))
+
 	loraRadio.Reset()
 	state := loraRadio.DetectDevice()
 	if !state {
 		panic("main: sx127x NOT FOUND !!!")
 	} else {
 		println("main: sx127x found")
-	}
-
-	// Setup DIO0 interrupt Handling
-	if err := SX127X_PIN_DIO0.SetInterrupt(machine.PinRising, dioIrqHandler); err != nil {
-		println("could not configure DIO0 pin interrupt:", err.Error())
-	}
-
-	// Setup DIO1 interrupt Handling
-	if err := SX127X_PIN_DIO1.SetInterrupt(machine.PinRising, dioIrqHandler); err != nil {
-		println("could not configure DIO1 pin interrupt:", err.Error())
 	}
 
 	// Prepare for Lora Operation

--- a/sx127x/radiocontrol.go
+++ b/sx127x/radiocontrol.go
@@ -1,0 +1,10 @@
+package sx127x
+
+// SX127X radio transceiver has several pins that control NSS,
+// and that are signalled when RX or TX operations are completed.
+// This interface allows the creation of types that can control this
+type RadioController interface {
+	Init() error
+	SetNss(state bool) error
+	SetupInterrupts(handler func()) error
+}

--- a/sx127x/radiocontrol_pins.go
+++ b/sx127x/radiocontrol_pins.go
@@ -1,0 +1,55 @@
+package sx127x
+
+import (
+	"machine"
+)
+
+// RadioControl for boards that are connected using normal pins.
+type RadioControl struct {
+	nssPin, dio0Pin, dio1Pin machine.Pin
+}
+
+func NewRadioControl(nssPin, dio0Pin, dio1Pin machine.Pin) *RadioControl {
+	return &RadioControl{
+		nssPin:  nssPin,
+		dio0Pin: dio0Pin,
+		dio1Pin: dio1Pin,
+	}
+}
+
+// SetNss sets the NSS line aka chip select for SPI.
+func (rc *RadioControl) SetNss(state bool) error {
+	rc.nssPin.Set(state)
+	return nil
+}
+
+// Init() configures whatever needed for sx127x radio control
+func (rc *RadioControl) Init() error {
+	rc.nssPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	rc.dio0Pin.Configure(machine.PinConfig{Mode: machine.PinInputPulldown})
+	rc.dio1Pin.Configure(machine.PinConfig{Mode: machine.PinInputPulldown})
+	return nil
+}
+
+// add interrupt handlers for Radio IRQs for pins
+func (rc *RadioControl) SetupInterrupts(handler func()) error {
+	irqHandler = handler
+
+	// Setup DIO0 interrupt Handling
+	if err := rc.dio0Pin.SetInterrupt(machine.PinRising, handleInterrupt); err != nil {
+		return err
+	}
+
+	// Setup DIO1 interrupt Handling
+	if err := rc.dio1Pin.SetInterrupt(machine.PinRising, handleInterrupt); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var irqHandler func()
+
+func handleInterrupt(machine.Pin) {
+	irqHandler()
+}


### PR DESCRIPTION
This PR adds a `RadioController` interface and implementation to the `sx127x` to provide a similar pattern as the `sx126x`.