### PR TITLE
sx12xx: add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ The following 90 devices are supported.
 | [WS2812 RGB LED](https://cdn-shop.adafruit.com/datasheets/WS2812.pdf)                                                                                                                               | GPIO |
 | [XPT2046 touch controller](http://grobotronics.com/images/datasheets/xpt2046-datasheet.pdf)                                                                                                         | GPIO |
 | [Semtech SX126x Lora](https://www.semtech.com/products/wireless-rf/lora-connect/sx1261)                                                                                                             | SPI |
+| [Semtech SX127x Lora](https://www.semtech.com/products/wireless-rf/lora-connect/sx1276)                                                                                                             | SPI |
 | [SSD1289 TFT color display](http://aitendo3.sakura.ne.jp/aitendo_data/product_img/lcd/tft2/M032C1289TP/3.2-SSD1289.pdf)                                                                             | GPIO |
 
 ## Contributing

--- a/sx126x/README.md
+++ b/sx126x/README.md
@@ -1,0 +1,27 @@
+# SX126x LoRa Radio
+
+The Semtech SX126x family of sub-Ghz radio transceivers come in a number of different formats.
+
+SX126x radios have a wide continuous frequency coverage from 150 MHz to 960 MHz.
+
+SX1261 can transmit up to +15 dBm and the SX1262 can transmit up to +22 dBm
+
+Some development boards are specific to a particular frequency range, so for example you need a different variation of that board for EU868 vs. for AU915.
+
+## LAMBDA62 RF module
+
+Cost effective radio module featuring the Semtech SX1262.
+
+## STM32 STM32WLE5JC 
+
+ST Micro STM32WLE5/E4xx is 32-bit ARM Cortex M4 processor with Semtech SX126x processor on a single die.
+
+https://www.st.com/en/microcontrollers-microprocessors/stm32wle5jc.html
+
+Several boards have been made using this processor.
+
+### Wio-E5 mini
+
+https://www.seeedstudio.com/LoRa-E5-mini-STM32WLE5JC-p-4869.html
+
+Wio-E5 mini is a compacted-sized dev board suitable for the rapid testing and building of small-size LoRa device and application prototyping. Wio-E5 mini is embedded with and leads out full GPIOs of Wio-E5 STM32WLE5JC

--- a/sx127x/README.md
+++ b/sx127x/README.md
@@ -1,0 +1,24 @@
+# SX127x LoRa Radio
+
+This processor comes in several different packages.
+
+## Adafruit LoRa Radio Featherwing
+
+https://www.adafruit.com/product/3231
+
+This is the LoRa 9x @ 900 MHz radio version, which can be used for either 868MHz or 915MHz transmission/reception - the exact radio frequency is determined when you load the software since it can be tuned around dynamically. They can easily go 2 Km line of sight using simple wire antennas, or up to 20Km with directional antennas and settings tweaks.
+
+### Connecting
+
+To use the LoRa Featherwing with a Pybadge/Gobadge, you need to connect some pads on the board itself. Solder some jumper wires as follows:
+
+RST  -> A
+CS   -> B
+DIO1 -> C
+IRQ  -> D 
+
+You also need to connect an antenna. The easiest is to cut a small piece of wire to the correct length based on the desired frequency:
+
+EU868 Mhz - 34.54 cm
+
+You can also use a fancier solution such as a uFL SMA connector with matching antenna.


### PR DESCRIPTION
This PR adds very basic READMEs for the sx126x and 127x LoRa radios. It also updates the main README so that both are listed as being supported.