### PR TITLE
[gps] make the date available in addition to the time

### DIFF
--- a/gps/gpsparser.go
+++ b/gps/gpsparser.go
@@ -179,7 +179,7 @@ func findSatellites(val string) (n int16) {
 	return 0
 }
 
-// findDate returns the speed from an RMC NMEA sentence.
+// findDate returns the date from an RMC NMEA sentence.
 func findDate(val string) time.Time {
 	if len(val) < 6 {
 		return time.Time{}

--- a/gps/gpsparser.go
+++ b/gps/gpsparser.go
@@ -95,6 +95,8 @@ func (parser *Parser) Parse(sentence string) (Fix, error) {
 		fix.Longitude = findLongitude(fields[5], fields[6])
 		fix.Speed = findSpeed(fields[7])
 		fix.Heading = findHeading(fields[8])
+		date := findDate(fields[9])
+		fix.Time = fix.Time.AddDate(date.Year(), int(date.Month()), date.Day())
 
 		return fix, nil
 	}
@@ -175,6 +177,20 @@ func findSatellites(val string) (n int16) {
 		return n
 	}
 	return 0
+}
+
+// findDate returns the speed from an RMC NMEA sentence.
+func findDate(val string) time.Time {
+	if len(val) < 6 {
+		return time.Time{}
+	}
+
+	d, _ := strconv.ParseInt(val[0:2], 10, 8)
+	m, _ := strconv.ParseInt(val[2:4], 10, 8)
+	y, _ := strconv.ParseInt(val[4:6], 10, 8)
+	t := time.Date(int(2000+y), time.Month(m), int(d), 0, 0, 0, 0, time.UTC)
+
+	return t
 }
 
 // findSpeed returns the speed from an RMC NMEA sentence.

--- a/gps/gpsparser_test.go
+++ b/gps/gpsparser_test.go
@@ -76,6 +76,12 @@ func TestParseRMC(t *testing.T) {
 		t.Error("should have parsed")
 	}
 
+	c.Assert(fix.Time.Year(), qt.Equals, 2022)
+	c.Assert(fix.Time.Month(), qt.Equals, time.May)
+	c.Assert(fix.Time.Day(), qt.Equals, 13)
+	c.Assert(fix.Time.Hour(), qt.Equals, 20)
+	c.Assert(fix.Time.Minute(), qt.Equals, 35)
+	c.Assert(fix.Time.Second(), qt.Equals, 22)
 	c.Assert(fix.Latitude, qt.Equals, float32(51.15043640136719))
 	c.Assert(fix.Longitude, qt.Equals, float32(-114.03067779541016))
 }


### PR DESCRIPTION
I was using the GPS driver and found that while getting the time out of the library worked great, I had no way to get the date.  This PR references the [spec](https://docs.novatel.com/OEM7/Content/Logs/GPRMC.htm) present in the code comments for the RMC Sentence Type to grab the date and adds unit test coverage parsing for both time and date.