### PR TITLE
st7735: add DrawRGBBitmap8 method to draw raw RGB565 buffers

### DIFF
--- a/st7735/st7735.go
+++ b/st7735/st7735.go
@@ -16,6 +16,10 @@ import (
 type Model uint8
 type Rotation uint8
 
+var (
+	errOutOfBounds = errors.New("rectangle coordinates outside display area")
+)
+
 // Device wraps an SPI connection.
 type Device struct {
 	bus          drivers.SPI
@@ -271,6 +275,18 @@ func (d *Device) FillRectangle(x, y, width, height int16, c color.RGBA) error {
 		}
 		i -= d.batchLength
 	}
+	return nil
+}
+
+// DrawRGBBitmap8 copies an RGB bitmap to the internal buffer at given coordinates
+func (d *Device) DrawRGBBitmap8(x, y int16, data []uint8, w, h int16) error {
+	k, i := d.Size()
+	if x < 0 || y < 0 || w <= 0 || h <= 0 ||
+		x >= k || (x+w) > k || y >= i || (y+h) > i {
+		return errOutOfBounds
+	}
+	d.setWindow(x, y, w, h)
+	d.Tx(data, false)
 	return nil
 }
 


### PR DESCRIPTION
This is needed for high performance graphics. It's the same API as on the ili9341.
Using this API, and using partial updates to the screen (no full screen refreshes), I've been able to get well over 60fps of updates.