### PR TITLE
ili9341: support tear-free display updates

### DIFF
--- a/ili9341/ili9341.go
+++ b/ili9341/ili9341.go
@@ -158,6 +158,18 @@ func (d *Device) Display() error {
 	return nil
 }
 
+// EnableTEOutput enables the TE ("tearing effect") line.
+// The TE line goes high when the screen is not currently being updated and can
+// be used to start drawing. When used correctly, it can avoid tearing entirely.
+func (d *Device) EnableTEOutput(on bool) {
+	if on {
+		cmdBuf[0] = 0
+		d.sendCommand(TEON, cmdBuf[:1]) // M=0 (V-blanking only, no H-blanking)
+	} else {
+		d.sendCommand(TEOFF, nil) // TEOFF
+	}
+}
+
 // DrawRGBBitmap copies an RGB bitmap to the internal buffer at given coordinates
 func (d *Device) DrawRGBBitmap(x, y int16, data []uint16, w, h int16) error {
 	k, i := d.Size()
@@ -257,17 +269,17 @@ func (d *Device) SetRotation(rotation Rotation) {
 	case Rotation90:
 		madctl = MADCTL_MV | MADCTL_BGR
 	case Rotation180:
-		madctl = MADCTL_MY | MADCTL_BGR
+		madctl = MADCTL_MY | MADCTL_BGR | MADCTL_ML
 	case Rotation270:
-		madctl = MADCTL_MX | MADCTL_MY | MADCTL_MV | MADCTL_BGR
+		madctl = MADCTL_MX | MADCTL_MY | MADCTL_MV | MADCTL_BGR | MADCTL_ML
 	case Rotation0Mirror:
 		madctl = MADCTL_BGR
 	case Rotation90Mirror:
-		madctl = MADCTL_MY | MADCTL_MV | MADCTL_BGR
+		madctl = MADCTL_MY | MADCTL_MV | MADCTL_BGR | MADCTL_ML
 	case Rotation180Mirror:
-		madctl = MADCTL_MX | MADCTL_MY | MADCTL_BGR
+		madctl = MADCTL_MX | MADCTL_MY | MADCTL_BGR | MADCTL_ML
 	case Rotation270Mirror:
-		madctl = MADCTL_MX | MADCTL_MY | MADCTL_MV | MADCTL_BGR
+		madctl = MADCTL_MX | MADCTL_MY | MADCTL_MV | MADCTL_BGR | MADCTL_ML
 	}
 	cmdBuf[0] = madctl
 	d.sendCommand(MADCTL, cmdBuf[:1])

--- a/ili9341/ili9341.go
+++ b/ili9341/ili9341.go
@@ -136,10 +136,12 @@ func (d *Device) Configure(config Config) {
 
 // Size returns the current size of the display.
 func (d *Device) Size() (x, y int16) {
-	if d.rotation == 1 || d.rotation == 3 {
+	switch d.rotation {
+	case Rotation90, Rotation270, Rotation90Mirror, Rotation270Mirror:
 		return d.height, d.width
+	default: // Rotation0, Rotation180, etc
+		return d.width, d.height
 	}
-	return d.width, d.height
 }
 
 // SetPixel modifies the internal buffer.

--- a/ili9341/registers.go
+++ b/ili9341/registers.go
@@ -39,6 +39,8 @@ const (
 
 	PTLAR    = 0x30 ///< Partial Area
 	VSCRDEF  = 0x33 ///< Vertical Scrolling Definition
+	TEOFF    = 0x34 ///< TEOFF: Tearing Effect Line OFF
+	TEON     = 0x35 ///< TEON: Tearing Effect Line ON
 	MADCTL   = 0x36 ///< Memory Access Control
 	VSCRSADD = 0x37 ///< Vertical Scrolling Start Address
 	PIXFMT   = 0x3A ///< COLMOD: Pixel Format Set


### PR DESCRIPTION
Many displays don't have the TE pin exposed. But those that do have the pin (for example, the PyPortal) can use it to synchronize writing a new image to the display. When implemented correctly, tearing can be avoided entirely.

This commit also changes the LCD refresh direction to either top-to-bottom or left-to-right depending on the rotation. Previously it might refresh from right-to-left or bottom-to-top. This has little impact on code that doesn't use the TE line, but code that does now only needs to worry about two cases (top-to-bottom and left-to-right) instead of four.
(Unfortunately, it appears that the hardware doesn't support changing the major LCD refresh order so code that wants to do tear-free rendering still needs to care about these two cases).