### PR TITLE
all: add sleep mode to various SPI displays

### DIFF
--- a/ili9341/ili9341.go
+++ b/ili9341/ili9341.go
@@ -241,6 +241,27 @@ func (d *Device) FillScreen(c color.RGBA) {
 	}
 }
 
+// Set the sleep mode for this LCD panel. When sleeping, the panel uses a lot
+// less power. The LCD won't display an image anymore, but the memory contents
+// will be kept.
+func (d *Device) Sleep(sleepEnabled bool) error {
+	if sleepEnabled {
+		// Shut down LCD panel.
+		d.sendCommand(SLPIN, nil)
+		time.Sleep(5 * time.Millisecond) // 5ms required by the datasheet
+	} else {
+		// Turn the LCD panel back on.
+		d.sendCommand(SLPOUT, nil)
+		// Note: the ili9341 documentation says that it is needed to wait at
+		// least 120ms before going to sleep again. Sleeping here would not be
+		// practical (delays turning on the screen too much), so just hope the
+		// screen won't need to sleep again for at least 120ms.
+		// In practice, it's unlikely the user will set the display to sleep
+		// again within 120ms.
+	}
+	return nil
+}
+
 // GetRotation returns the current rotation of the device
 func (d *Device) GetRotation() Rotation {
 	return d.rotation

--- a/st7735/st7735.go
+++ b/st7735/st7735.go
@@ -409,6 +409,24 @@ func (d *Device) EnableBacklight(enable bool) {
 	}
 }
 
+// Set the sleep mode for this LCD panel. When sleeping, the panel uses a lot
+// less power. The LCD won't display an image anymore, but the memory contents
+// will be kept.
+func (d *Device) Sleep(sleepEnabled bool) error {
+	if sleepEnabled {
+		// Shut down LCD panel.
+		d.Command(SLPIN)
+		time.Sleep(5 * time.Millisecond) // 5ms required by the datasheet
+	} else {
+		// Turn the LCD panel back on.
+		d.Command(SLPOUT)
+		// The st7735 datasheet says it is necessary to wait 120ms before
+		// sending another command.
+		time.Sleep(120 * time.Millisecond)
+	}
+	return nil
+}
+
 // InverColors inverts the colors of the screen
 func (d *Device) InvertColors(invert bool) {
 	if invert {

--- a/st7789/st7789.go
+++ b/st7789/st7789.go
@@ -124,8 +124,7 @@ func (d *Device) Configure(cfg Config) {
 	d.Command(SWRESET)                 // Soft reset
 	time.Sleep(150 * time.Millisecond) //
 
-	d.Command(SLPOUT)                  // Exit sleep mode
-	time.Sleep(500 * time.Millisecond) //
+	d.Sleep(false) // Exit sleep mode
 
 	// Memory initialization
 	d.Command(COLMOD)                 // Set color mode
@@ -451,6 +450,26 @@ func (d *Device) EnableBacklight(enable bool) {
 	} else {
 		d.blPin.Low()
 	}
+}
+
+// Set the sleep mode for this LCD panel. When sleeping, the panel uses a lot
+// less power. The LCD won't display an image anymore, but the memory contents
+// will be kept.
+func (d *Device) Sleep(sleepEnabled bool) error {
+	if sleepEnabled {
+		d.Command(SLPIN)
+		time.Sleep(5 * time.Millisecond) // 5ms required by the datasheet
+	} else {
+		// Turn the LCD panel back on.
+		d.Command(SLPOUT)
+		// Note: the st7789 documentation says that it is needed to wait at
+		// least 120ms before going to sleep again. Sleeping here would not be
+		// practical (delays turning on the screen too much), so just hope the
+		// screen won't need to sleep again for at least 120ms.
+		// In practice, it's unlikely the user will set the display to sleep
+		// again within 120ms.
+	}
+	return nil
 }
 
 // InvertColors inverts the colors of the screen


### PR DESCRIPTION
The API looks like this and is based on the PCA9685 PWM chip:

```go
Sleep(sleepEnabled bool) error
```

It will set the LCD panel to a low power state (not displaying any image) but memory contents will be preserved.