### PR TITLE
ili9341: st7735: st7789: unify rotation support

### DIFF
--- a/displayer.go
+++ b/displayer.go
@@ -12,3 +12,19 @@ type Displayer interface {
 	// Display sends the buffer (if any) to the screen.
 	Display() error
 }
+
+// Rotation is how much a display has been rotated. Displays can be rotated, and
+// sometimes also mirrored.
+type Rotation uint8
+
+// Clockwise rotation of the screen.
+const (
+	Rotation0 = iota
+	Rotation90
+	Rotation180
+	Rotation270
+	Rotation0Mirror
+	Rotation90Mirror
+	Rotation180Mirror
+	Rotation270Mirror
+)

--- a/ili9341/ili9341.go
+++ b/ili9341/ili9341.go
@@ -5,19 +5,21 @@ import (
 	"image/color"
 	"machine"
 	"time"
+
+	"tinygo.org/x/drivers"
 )
 
 type Config struct {
 	Width            int16
 	Height           int16
-	Rotation         Rotation
+	Rotation         drivers.Rotation
 	DisplayInversion bool
 }
 
 type Device struct {
 	width    int16
 	height   int16
-	rotation Rotation
+	rotation drivers.Rotation
 	driver   driver
 
 	x0, x1 int16 // cached address window; prevents useless/expensive
@@ -262,13 +264,20 @@ func (d *Device) Sleep(sleepEnabled bool) error {
 	return nil
 }
 
-// GetRotation returns the current rotation of the device
-func (d *Device) GetRotation() Rotation {
+// Rotation returns the current rotation of the device.
+func (d *Device) Rotation() drivers.Rotation {
 	return d.rotation
 }
 
-// SetRotation changes the rotation of the device (clock-wise)
-func (d *Device) SetRotation(rotation Rotation) {
+// GetRotation returns the current rotation of the device.
+//
+// Deprecated: use Rotation instead.
+func (d *Device) GetRotation() drivers.Rotation {
+	return d.rotation
+}
+
+// SetRotation changes the rotation of the device (clock-wise).
+func (d *Device) SetRotation(rotation drivers.Rotation) error {
 	madctl := uint8(0)
 	switch rotation % 8 {
 	case Rotation0:
@@ -291,6 +300,7 @@ func (d *Device) SetRotation(rotation Rotation) {
 	cmdBuf[0] = madctl
 	d.sendCommand(MADCTL, cmdBuf[:1])
 	d.rotation = rotation
+	return nil
 }
 
 // SetScrollArea sets an area to scroll with fixed top/bottom or left/right parts of the display

--- a/ili9341/registers.go
+++ b/ili9341/registers.go
@@ -1,5 +1,7 @@
 package ili9341
 
+import "tinygo.org/x/drivers"
+
 type Rotation uint8
 
 const (
@@ -77,13 +79,13 @@ const (
 )
 
 const (
-	Rotation0   Rotation = 0
-	Rotation90  Rotation = 1 // 90 degrees clock-wise rotation
-	Rotation180 Rotation = 2
-	Rotation270 Rotation = 3
+	Rotation0   = drivers.Rotation0
+	Rotation90  = drivers.Rotation90 // 90 degrees clock-wise rotation
+	Rotation180 = drivers.Rotation180
+	Rotation270 = drivers.Rotation270
 
-	Rotation0Mirror   Rotation = 4
-	Rotation90Mirror  Rotation = 5
-	Rotation180Mirror Rotation = 6
-	Rotation270Mirror Rotation = 7
+	Rotation0Mirror   = drivers.Rotation0Mirror
+	Rotation90Mirror  = drivers.Rotation90Mirror
+	Rotation180Mirror = drivers.Rotation180Mirror
+	Rotation270Mirror = drivers.Rotation270Mirror
 )

--- a/st7735/registers.go
+++ b/st7735/registers.go
@@ -1,5 +1,7 @@
 package st7735
 
+import "tinygo.org/x/drivers"
+
 // Registers
 const (
 	NOP        = 0x00
@@ -52,8 +54,8 @@ const (
 	GREENTAB   Model = 0
 	MINI80x160 Model = 1
 
-	NO_ROTATION  Rotation = 0
-	ROTATION_90  Rotation = 1 // 90 degrees clock-wise rotation
-	ROTATION_180 Rotation = 2
-	ROTATION_270 Rotation = 3
+	NO_ROTATION  = drivers.Rotation0
+	ROTATION_90  = drivers.Rotation90 // 90 degrees clock-wise rotation
+	ROTATION_180 = drivers.Rotation180
+	ROTATION_270 = drivers.Rotation270
 )

--- a/st7789/registers.go
+++ b/st7789/registers.go
@@ -1,5 +1,7 @@
 package st7789
 
+import "tinygo.org/x/drivers"
+
 // Registers
 const (
 	NOP        = 0x00
@@ -53,10 +55,10 @@ const (
 	VSCRDEF    = 0x33
 	VSCRSADD   = 0x37
 
-	NO_ROTATION  Rotation = 0
-	ROTATION_90  Rotation = 1 // 90 degrees clock-wise rotation
-	ROTATION_180 Rotation = 2
-	ROTATION_270 Rotation = 3
+	NO_ROTATION  = drivers.Rotation0
+	ROTATION_90  = drivers.Rotation90 // 90 degrees clock-wise rotation
+	ROTATION_180 = drivers.Rotation180
+	ROTATION_270 = drivers.Rotation270
 
 	// Allowable frame rate codes for FRCTRL2 (Identifier is in Hz)
 	FRAMERATE_111 FrameRate = 0x01


### PR DESCRIPTION
  * Unify the Rotation type, so that SetRotation can be used in interfaces.
  * Add Rotation() method to these displays, so that the current rotation can be read.
  * Change SetRotation() so that it can return an error (if the given rotation isn't supported).

I believe this should be entirely backwards compatible.

The goal of this change is so that `Rotation` and `SetRotation` can be used in interfaces, so that code using those interfaces can get and set the screen rotation.