### PR TITLE
Skip Xtensa smoke tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,12 +169,10 @@ smoke-test:
 	@md5sum ./build/test.bin
 	tinygo build -size short -o ./build/test.hex -target=feather-nrf52840 ./examples/is31fl3731/main.go
 	@md5sum ./build/test.hex
-ifneq ($(AVR), 0)
 	tinygo build -size short -o ./build/test.hex -target=arduino   ./examples/ws2812
 	@md5sum ./build/test.hex
 	tinygo build -size short -o ./build/test.hex -target=digispark ./examples/ws2812
 	@md5sum ./build/test.hex
-endif
 	tinygo build -size short -o ./build/test.hex -target=trinket-m0 ./examples/bme280/main.go
 	@md5sum ./build/test.hex
 	tinygo build -size short -o ./build/test.hex -target=circuitplay-express ./examples/microphone/main.go

--- a/Makefile
+++ b/Makefile
@@ -231,10 +231,12 @@ smoke-test:
 	@md5sum ./build/test.hex
 	tinygo build -size short -o ./build/test.uf2 -target=pico ./examples/xpt2046/main.go
 	@md5sum ./build/test.uf2
+ifneq ($(XTENSA), 0)
 	tinygo build -size short -o ./build/test.elf -target=m5stack-core2 ./examples/ft6336/basic/
 	@md5sum ./build/test.elf
 	tinygo build -size short -o ./build/test.elf -target=m5stack-core2 ./examples/ft6336/touchpaint/
 	@md5sum ./build/test.elf
+endif
 	tinygo build -size short -o ./build/test.hex -target=nucleo-wl55jc ./examples/sx126x/lora_rxtx/
 	@md5sum ./build/test.hex
 	tinygo build -size short -o ./build/test.uf2 -target=pico ./examples/ssd1289/main.go


### PR DESCRIPTION
This can be useful, to quickly run the smoke tests without compiler errors because of missing Xtensa support.