### PR TITLE
wifinina: connect improvements

### DIFF
--- a/examples/wifinina/connect/main.go
+++ b/examples/wifinina/connect/main.go
@@ -128,17 +128,29 @@ func waitSerial() {
 	}
 }
 
+const retriesBeforeFailure = 3
+
 // connect to access point
 func connectToAP() {
 	time.Sleep(2 * time.Second)
-	println("Connecting to " + ssid)
-	err := adaptor.ConnectToAccessPoint(ssid, pass, 10*time.Second)
-	if err != nil { // error connecting to AP
-		for {
-			println(err)
-			time.Sleep(1 * time.Second)
+	var err error
+	for i := 0; i < retriesBeforeFailure; i++ {
+		println("Connecting to " + ssid)
+		err = adaptor.ConnectToAccessPoint(ssid, pass, 10*time.Second)
+		if err == nil {
+			println("Connected.")
+
+			return
 		}
 	}
 
-	println("Connected.")
+	// error connecting to AP
+	failMessage(err.Error())
+}
+
+func failMessage(msg string) {
+	for {
+		println(msg)
+		time.Sleep(1 * time.Second)
+	}
 }

--- a/examples/wifinina/http-get/main.go
+++ b/examples/wifinina/http-get/main.go
@@ -74,6 +74,7 @@ func main() {
 	waitSerial()
 
 	connectToAP()
+	displayIP()
 
 	// You can send and receive cookies in the following way
 	// 	import "tinygo.org/x/drivers/net/http/cookiejar"
@@ -131,28 +132,42 @@ func waitSerial() {
 	}
 }
 
+const retriesBeforeFailure = 3
+
 // connect to access point
 func connectToAP() {
 	time.Sleep(2 * time.Second)
-	println("Connecting to " + ssid)
-	err := adaptor.ConnectToAccessPoint(ssid, pass, 10*time.Second)
-	if err != nil { // error connecting to AP
-		for {
-			println(err)
-			time.Sleep(1 * time.Second)
+	var err error
+	for i := 0; i < retriesBeforeFailure; i++ {
+		println("Connecting to " + ssid)
+		err = adaptor.ConnectToAccessPoint(ssid, pass, 10*time.Second)
+		if err == nil {
+			println("Connected.")
+
+			return
 		}
 	}
 
-	println("Connected.")
+	// error connecting to AP
+	failMessage(err.Error())
+}
 
+func displayIP() {
 	ip, _, _, err := adaptor.GetIP()
 	for ; err != nil; ip, _, _, err = adaptor.GetIP() {
 		message(err.Error())
 		time.Sleep(1 * time.Second)
 	}
-	message(ip.String())
+	message("IP address: " + ip.String())
 }
 
 func message(msg string) {
 	println(msg, "\r")
+}
+
+func failMessage(msg string) {
+	for {
+		println(msg)
+		time.Sleep(1 * time.Second)
+	}
 }

--- a/examples/wifinina/mqttclient/main.go
+++ b/examples/wifinina/mqttclient/main.go
@@ -65,6 +65,7 @@ func main() {
 	adaptor.Configure()
 
 	connectToAP()
+	displayIP()
 
 	opts := mqtt.NewClientOptions()
 	opts.AddBroker(server).SetClientID("tinygo-client-" + randomString(10))
@@ -101,26 +102,33 @@ func main() {
 	println("Done.")
 }
 
+const retriesBeforeFailure = 3
+
 // connect to access point
 func connectToAP() {
 	time.Sleep(2 * time.Second)
-	println("Connecting to " + ssid)
-	err := adaptor.ConnectToAccessPoint(ssid, pass, 10*time.Second)
-	if err != nil { // error connecting to AP
-		for {
-			println(err)
-			time.Sleep(1 * time.Second)
+	var err error
+	for i := 0; i < retriesBeforeFailure; i++ {
+		println("Connecting to " + ssid)
+		err = adaptor.ConnectToAccessPoint(ssid, pass, 10*time.Second)
+		if err == nil {
+			println("Connected.")
+
+			return
 		}
 	}
 
-	println("Connected.")
+	// error connecting to AP
+	failMessage(err.Error())
+}
 
+func displayIP() {
 	ip, _, _, err := adaptor.GetIP()
 	for ; err != nil; ip, _, _, err = adaptor.GetIP() {
 		println(err.Error())
 		time.Sleep(1 * time.Second)
 	}
-	println(ip.String())
+	println("IP address: " + ip.String())
 }
 
 // Returns an int >= min, < max

--- a/examples/wifinina/mqttsub/main.go
+++ b/examples/wifinina/mqttsub/main.go
@@ -71,6 +71,7 @@ func main() {
 	adaptor.Configure()
 
 	connectToAP()
+	displayIP()
 
 	opts := mqtt.NewClientOptions()
 	opts.AddBroker(server).SetClientID("tinygo-client-" + randomString(10))
@@ -113,27 +114,33 @@ func publishing() {
 	}
 }
 
+const retriesBeforeFailure = 3
+
 // connect to access point
 func connectToAP() {
 	time.Sleep(2 * time.Second)
-	println("Connecting to " + ssid)
-	err := adaptor.ConnectToAccessPoint(ssid, pass, 10*time.Second)
-	if err != nil { // error connecting to AP
-		for {
-			println(err)
-			time.Sleep(1 * time.Second)
+	var err error
+	for i := 0; i < retriesBeforeFailure; i++ {
+		println("Connecting to " + ssid)
+		err = adaptor.ConnectToAccessPoint(ssid, pass, 10*time.Second)
+		if err == nil {
+			println("Connected.")
+
+			return
 		}
 	}
 
-	println("Connected.")
+	// error connecting to AP
+	failMessage(err.Error())
+}
 
-	time.Sleep(2 * time.Second)
+func displayIP() {
 	ip, _, _, err := adaptor.GetIP()
 	for ; err != nil; ip, _, _, err = adaptor.GetIP() {
 		println(err.Error())
 		time.Sleep(1 * time.Second)
 	}
-	println(ip.String())
+	println("IP address: " + ip.String())
 }
 
 // Returns an int >= min, < max

--- a/examples/wifinina/ntpclient/main.go
+++ b/examples/wifinina/ntpclient/main.go
@@ -61,6 +61,7 @@ func main() {
 	waitSerial()
 
 	connectToAP()
+	displayIP()
 
 	// now make UDP connection
 	ip := net.ParseIP(ntpHost)
@@ -149,29 +150,42 @@ func clearBuffer() {
 	}
 }
 
+const retriesBeforeFailure = 3
+
 // connect to access point
 func connectToAP() {
 	time.Sleep(2 * time.Second)
-	println("Connecting to " + ssid)
-	err := adaptor.ConnectToAccessPoint(ssid, pass, 10*time.Second)
-	if err != nil { // error connecting to AP
-		for {
-			println(err)
-			time.Sleep(1 * time.Second)
+	var err error
+	for i := 0; i < retriesBeforeFailure; i++ {
+		println("Connecting to " + ssid)
+		err = adaptor.ConnectToAccessPoint(ssid, pass, 10*time.Second)
+		if err == nil {
+			println("Connected.")
+
+			return
 		}
 	}
 
-	println("Connected.")
+	// error connecting to AP
+	failMessage(err.Error())
+}
 
-	time.Sleep(2 * time.Second)
+func displayIP() {
 	ip, _, _, err := adaptor.GetIP()
 	for ; err != nil; ip, _, _, err = adaptor.GetIP() {
 		message(err.Error())
 		time.Sleep(1 * time.Second)
 	}
-	message(ip.String())
+	message("IP address: " + ip.String())
 }
 
 func message(format string, args ...interface{}) {
 	println(fmt.Sprintf(format, args...), "\r")
+}
+
+func failMessage(msg string) {
+	for {
+		println(msg)
+		time.Sleep(1 * time.Second)
+	}
 }

--- a/examples/wifinina/tcpclient/main.go
+++ b/examples/wifinina/tcpclient/main.go
@@ -56,6 +56,7 @@ func main() {
 	adaptor.Configure()
 
 	connectToAP()
+	displayIP()
 
 	for {
 		sendBatch()
@@ -111,29 +112,42 @@ func sendBatch() {
 	conn.Close()
 }
 
+const retriesBeforeFailure = 3
+
 // connect to access point
 func connectToAP() {
 	time.Sleep(2 * time.Second)
-	println("Connecting to " + ssid)
-	err := adaptor.ConnectToAccessPoint(ssid, pass, 10*time.Second)
-	if err != nil { // error connecting to AP
-		for {
-			println(err)
-			time.Sleep(1 * time.Second)
+	var err error
+	for i := 0; i < retriesBeforeFailure; i++ {
+		println("Connecting to " + ssid)
+		err = adaptor.ConnectToAccessPoint(ssid, pass, 10*time.Second)
+		if err == nil {
+			println("Connected.")
+
+			return
 		}
 	}
 
-	println("Connected.")
+	// error connecting to AP
+	failMessage(err.Error())
+}
 
-	time.Sleep(2 * time.Second)
+func displayIP() {
 	ip, _, _, err := adaptor.GetIP()
 	for ; err != nil; ip, _, _, err = adaptor.GetIP() {
 		message(err.Error())
 		time.Sleep(1 * time.Second)
 	}
-	message(ip.String())
+	message("IP address: " + ip.String())
 }
 
 func message(msg string) {
 	println(msg, "\r")
+}
+
+func failMessage(msg string) {
+	for {
+		println(msg)
+		time.Sleep(1 * time.Second)
+	}
 }

--- a/examples/wifinina/tlsclient/main.go
+++ b/examples/wifinina/tlsclient/main.go
@@ -66,6 +66,7 @@ func main() {
 	waitSerial()
 
 	connectToAP()
+	displayIP()
 
 	for {
 		readConnection()
@@ -121,29 +122,42 @@ func makeHTTPSRequest() {
 	lastRequestTime = time.Now()
 }
 
+const retriesBeforeFailure = 3
+
 // connect to access point
 func connectToAP() {
 	time.Sleep(2 * time.Second)
-	println("Connecting to " + ssid)
-	err := adaptor.ConnectToAccessPoint(ssid, pass, 10*time.Second)
-	if err != nil { // error connecting to AP
-		for {
-			println(err)
-			time.Sleep(1 * time.Second)
+	var err error
+	for i := 0; i < retriesBeforeFailure; i++ {
+		println("Connecting to " + ssid)
+		err = adaptor.ConnectToAccessPoint(ssid, pass, 10*time.Second)
+		if err == nil {
+			println("Connected.")
+
+			return
 		}
 	}
 
-	println("Connected.")
+	// error connecting to AP
+	failMessage(err.Error())
+}
 
-	time.Sleep(2 * time.Second)
+func displayIP() {
 	ip, _, _, err := adaptor.GetIP()
 	for ; err != nil; ip, _, _, err = adaptor.GetIP() {
 		message(err.Error())
 		time.Sleep(1 * time.Second)
 	}
-	message(ip.String())
+	message("IP address: " + ip.String())
 }
 
 func message(msg string) {
 	println(msg, "\r")
+}
+
+func failMessage(msg string) {
+	for {
+		println(msg)
+		time.Sleep(1 * time.Second)
+	}
 }

--- a/examples/wifinina/webclient/main.go
+++ b/examples/wifinina/webclient/main.go
@@ -20,8 +20,8 @@ var (
 	pass string
 )
 
-// IP address of the server aka "hub". Replace with your own info.
-const server = "tinygo.org"
+// IP address of the "example.com" server. Replace with your own info.
+const server = "93.184.216.34"
 
 // these are the default pins for the Arduino Nano33 IoT.
 // change these to connect to a different UART or pins for the ESP8266/ESP32
@@ -63,6 +63,7 @@ func main() {
 	waitSerial()
 
 	connectToAP()
+	displayIP()
 
 	for {
 		readConnection()
@@ -123,28 +124,42 @@ func makeHTTPRequest() {
 	lastRequestTime = time.Now()
 }
 
+const retriesBeforeFailure = 3
+
 // connect to access point
 func connectToAP() {
 	time.Sleep(2 * time.Second)
-	println("Connecting to " + ssid)
-	err := adaptor.ConnectToAccessPoint(ssid, pass, 10*time.Second)
-	if err != nil { // error connecting to AP
-		for {
-			println(err)
-			time.Sleep(1 * time.Second)
+	var err error
+	for i := 0; i < retriesBeforeFailure; i++ {
+		println("Connecting to " + ssid)
+		err = adaptor.ConnectToAccessPoint(ssid, pass, 10*time.Second)
+		if err == nil {
+			println("Connected.")
+
+			return
 		}
 	}
 
-	println("Connected.")
+	// error connecting to AP
+	failMessage(err.Error())
+}
 
+func displayIP() {
 	ip, _, _, err := adaptor.GetIP()
 	for ; err != nil; ip, _, _, err = adaptor.GetIP() {
 		message(err.Error())
 		time.Sleep(1 * time.Second)
 	}
-	message(ip.String())
+	message("IP address: " + ip.String())
 }
 
 func message(msg string) {
 	println(msg, "\r")
+}
+
+func failMessage(msg string) {
+	for {
+		println(msg)
+		time.Sleep(1 * time.Second)
+	}
 }

--- a/wifinina/wifinina.go
+++ b/wifinina/wifinina.go
@@ -151,12 +151,12 @@ func (d *Device) Configure() {
 	d.GPIO0.High()
 	d.CS.High()
 	d.RESET.Low()
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	d.RESET.High()
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(750 * time.Millisecond)
 
 	d.GPIO0.Low()
-	d.GPIO0.Configure(machine.PinConfig{Mode: machine.PinInput})
+	d.GPIO0.Configure(machine.PinConfig{Mode: machine.PinInputPullup})
 
 }
 


### PR DESCRIPTION
This PR adds a few improvements for connecting the WiFiNINA.

It corrects the timing used for the RESET pins when calling `Configure()` to match other libraries. 

It also adds a new `ResetIsHigh`  property to allow changing the behavior of the RESET pin for boards like the Arduino MKR 1010, which correct #386 

Lastly, it makes some changes to the various examples to make a few retry attempts when connecting to the WiFi access point, which appears to solve most of the issues when connecting especially right after flashing.

Note that this PR depends on #560 which needs to be merged first, and then this PR rebased.