### PR TITLE
Seesaw Neopixel Support

### DIFF
--- a/seesaw/i2c.go
+++ b/seesaw/i2c.go
@@ -1,0 +1,12 @@
+package seesaw
+
+import "machine"
+
+// assert the machine.I2C conforms to our interface
+var _ = I2C(&machine.I2C{})
+
+// I2C represents an I2C bus. It is notably implemented by the
+// machine.I2C type.
+type I2C interface {
+	Tx(addr uint16, w, r []byte) error
+}

--- a/seesaw/neopixel/const.go
+++ b/seesaw/neopixel/const.go
@@ -1,0 +1,133 @@
+package neopixel
+
+// Constants for NeoPixels on the Seesaw
+// https://github.com/adafruit/Adafruit_Seesaw/blob/master/seesaw_neopixel.h#L49
+
+// PixelType defines the order of primary colors in the NeoPixel data stream, which can vary
+// among device types, manufacturers and even different revisions of
+// the same item.  The PixelType encodes the per-pixel byte offsets of the red, green
+// and blue primaries (plus white, if present) in the data stream.
+//
+// Below an easier-to-use named version for
+// each permutation.  e.g. PixelTypeGRB indicates a NeoPixel-compatible
+// device expecting three bytes per pixel, with the first byte
+// containing the green value, second containing red and third
+// containing blue.  The in-memory representation of a chain of
+// NeoPixels is the same as the data-stream order; no re-ordering of
+// bytes is required when issuing data to the chain.
+//
+// Bits 5,4 of this value are the offset (0-3) from the first byte of
+// a pixel to the location of the red color byte.  Bits 3,2 are the
+// green offset and 1,0 are the blue offset.  If it is an RGBW-type
+// device (supporting a white primary in addition to R,G,B), bits 7,6
+// are the offset to the white byte...otherwise, bits 7,6 are set to
+// the same value as 5,4 (red) to indicate an RGB (not RGBW) device.
+//
+// i.e. binary representation:
+//
+//	0bWWRRGGBB for RGBW devices
+//	0bRRRRGGBB for RGB
+type PixelType uint16
+
+// BlueOffset returns the byte offset for the blue component
+func (p PixelType) BlueOffset() int {
+	return int(byte(p) & 0b11)
+}
+
+// GreenOffset returns the byte offset for the green component
+func (p PixelType) GreenOffset() int {
+	return int((byte(p) >> 2) & 0b11)
+}
+
+// RedOffset returns the byte offset for the red component
+func (p PixelType) RedOffset() int {
+	return int((byte(p) >> 4) & 0b11)
+}
+
+// WhiteOffset returns the byte offset for the white component
+func (p PixelType) WhiteOffset() int {
+	return int((byte(p) >> 6) & 0b11)
+}
+
+// IsRGBW returns true if the pixel has a W component, false otherwise.
+func (p PixelType) IsRGBW() bool {
+	return p.RedOffset() != p.WhiteOffset()
+}
+
+// EncodedLen returns the number of bytes this pixel type needs in encoded form
+func (p PixelType) EncodedLen() int {
+	if p.IsRGBW() {
+		return 4
+	}
+	return 3
+}
+
+// Is800KHz whether the pixel operates at 800 Khz or not. Implicitly runs at 400 Khz otherwise
+func (p PixelType) Is800KHz() bool {
+	return (uint16(p) & 0xFf00) == SpeedKHz800
+}
+
+// PutRGBW encodes color components into a PixelType and appends it to a buffer. Depending on the PixelType it will
+// write a different amount of bytes, the count of which will be returned.
+func (p PixelType) PutRGBW(buf []byte, color RGBW) int {
+	buf[p.RedOffset()] = color.R
+	buf[p.GreenOffset()] = color.G
+	buf[p.BlueOffset()] = color.B
+	if !p.IsRGBW() {
+		// if we don't have white, skip it
+		return 3
+	}
+	buf[p.WhiteOffset()] = color.W
+	return 4
+}
+
+// Rgb NeoPixel permutations; white and red offsets are always same
+// Offset:                       W          R          G          B
+const (
+	PixelTypeRGB PixelType = (0 << 6) | (0 << 4) | (1 << 2) | (2)
+	PixelTypeRBG PixelType = (0 << 6) | (0 << 4) | (2 << 2) | (1)
+	PixelTypeGRB PixelType = (1 << 6) | (1 << 4) | (0 << 2) | (2)
+	PixelTypeGBR PixelType = (2 << 6) | (2 << 4) | (0 << 2) | (1)
+	PixelTypeBRG PixelType = (1 << 6) | (1 << 4) | (2 << 2) | (0)
+	PixelTypeBGR PixelType = (2 << 6) | (2 << 4) | (1 << 2) | (0)
+)
+
+// Rgbw NeoPixel permutations; all 4 offsets are distinct
+// Offset:                        W          R          G          B
+const (
+	PixelTypeWRGB PixelType = (0 << 6) | (1 << 4) | (2 << 2) | (3)
+	PixelTypeWRBG PixelType = (0 << 6) | (1 << 4) | (3 << 2) | (2)
+	PixelTypeWGRB PixelType = (0 << 6) | (2 << 4) | (1 << 2) | (3)
+	PixelTypeWGBR PixelType = (0 << 6) | (3 << 4) | (1 << 2) | (2)
+	PixelTypeWBRG PixelType = (0 << 6) | (2 << 4) | (3 << 2) | (1)
+	PixelTypeWBGR PixelType = (0 << 6) | (3 << 4) | (2 << 2) | (1)
+
+	PixelTypeRWGB PixelType = (1 << 6) | (0 << 4) | (2 << 2) | (3)
+	PixelTypeRWBG PixelType = (1 << 6) | (0 << 4) | (3 << 2) | (2)
+	PixelTypeRGWB PixelType = (2 << 6) | (0 << 4) | (1 << 2) | (3)
+	PixelTypeRGBW PixelType = (3 << 6) | (0 << 4) | (1 << 2) | (2)
+	PixelTypeRBWG PixelType = (2 << 6) | (0 << 4) | (3 << 2) | (1)
+	PixelTypeRBGW PixelType = (3 << 6) | (0 << 4) | (2 << 2) | (1)
+
+	PixelTypeGWRB PixelType = (1 << 6) | (2 << 4) | (0 << 2) | (3)
+	PixelTypeGWBR PixelType = (1 << 6) | (3 << 4) | (0 << 2) | (2)
+	PixelTypeGRWB PixelType = (2 << 6) | (1 << 4) | (0 << 2) | (3)
+	PixelTypeGRBW PixelType = (3 << 6) | (1 << 4) | (0 << 2) | (2)
+	PixelTypeGBWR PixelType = (2 << 6) | (3 << 4) | (0 << 2) | (1)
+	PixelTypeGBRW PixelType = (3 << 6) | (2 << 4) | (0 << 2) | (1)
+
+	PixelTypeBWRG PixelType = (1 << 6) | (2 << 4) | (3 << 2) | (0)
+	PixelTypeBWGR PixelType = (1 << 6) | (3 << 4) | (2 << 2) | (0)
+	PixelTypeBRWG PixelType = (2 << 6) | (1 << 4) | (3 << 2) | (0)
+	PixelTypeBRGW PixelType = (3 << 6) | (1 << 4) | (2 << 2) | (0)
+	PixelTypeBGWR PixelType = (2 << 6) | (3 << 4) | (1 << 2) | (0)
+	PixelTypeBGRW PixelType = (3 << 6) | (2 << 4) | (1 << 2) | (0)
+)
+
+const (
+	// SpeedKHz800 represents the encoded value for a 800KHz datastream
+	SpeedKHz800 = 0x0000
+
+	// SpeedKHz400 represents the encoded value for a 400KHz datastream
+	SpeedKHz400 = 0x0100
+)

--- a/seesaw/neopixel/neopixel.go
+++ b/seesaw/neopixel/neopixel.go
@@ -1,0 +1,181 @@
+package neopixel
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+	"tinygo.org/x/drivers/seesaw"
+)
+
+// seesawWriteDelay the seesaw is quite timing sensitive and times out if not given enough time,
+// this is an empirically determined delay that seems to have good results
+const seesawWriteDelay = time.Millisecond * 10
+
+// RGBW represents the RGBW color of an LED.
+type RGBW struct {
+	R, G, B, W uint8
+}
+
+type Device struct {
+	seesaw          *seesaw.Device
+	ledCount        int
+	pin             uint8
+	pixelType       PixelType
+	lastOperationAt time.Time
+}
+
+func New(dev *seesaw.Device, pin uint8, ledCount int, pixelType PixelType) (*Device, error) {
+
+	pixel := &Device{
+		seesaw:    dev,
+		ledCount:  ledCount,
+		pin:       pin,
+		pixelType: pixelType,
+	}
+
+	if !pixel.checkBufferLength(ledCount) {
+		return nil, fmt.Errorf("invalid LED count: %d", ledCount)
+	}
+
+	time.Sleep(seesawWriteDelay)
+
+	err := pixel.setupPin()
+	if err != nil {
+		return nil, fmt.Errorf("failed to update NeoPixel pin %d: %w", pin, err)
+	}
+
+	time.Sleep(seesawWriteDelay)
+
+	err = pixel.setupLedCount()
+	if err != nil {
+		return nil, fmt.Errorf("failed to update LED count %d: %w", ledCount, err)
+	}
+
+	time.Sleep(seesawWriteDelay)
+
+	err = pixel.setupSpeed()
+	if err != nil {
+		return nil, fmt.Errorf("failed to update pixel type: %w", err)
+	}
+
+	time.Sleep(seesawWriteDelay)
+
+	return pixel, nil
+}
+
+func (s *Device) setupLedCount() error {
+
+	lenBytes := calculateBufferLength(s.ledCount, s.pixelType)
+	buf := []byte{byte(lenBytes >> 8), byte(lenBytes & 0xFF)}
+	return s.seesaw.Write(seesaw.ModuleNeoPixelBase, seesaw.FunctionNeopixelBufLength, buf)
+}
+
+func calculateBufferLength(ledCount int, pixelType PixelType) int {
+	return ledCount * pixelType.EncodedLen()
+}
+
+func (s *Device) setupSpeed() error {
+	speed := byte(0)
+	if s.pixelType.Is800KHz() {
+		speed = 1
+	}
+	return s.seesaw.WriteRegister(seesaw.ModuleNeoPixelBase, seesaw.FunctionNeopixelSpeed, speed)
+}
+
+func (s *Device) setupPin() error {
+	return s.seesaw.WriteRegister(seesaw.ModuleNeoPixelBase, seesaw.FunctionNeopixelPin, s.pin)
+}
+
+// WriteColorAtOffset updates the color for a single LED at the given offset
+func (s *Device) WriteColorAtOffset(offset uint16, color RGBW) error {
+
+	encodedLen := s.pixelType.EncodedLen()
+
+	buf := make([]byte, encodedLen)
+	l := s.pixelType.PutRGBW(buf, color)
+	if l != encodedLen {
+		panic("unexpected encoded length: " + strconv.Itoa(l) + " != " + strconv.Itoa(encodedLen))
+	}
+	byteOffset := offset * uint16(encodedLen)
+	return s.writeBuffer(byteOffset, buf)
+}
+
+// WriteColors writes the given colors to the seesaws NeoPixel buffer
+func (s *Device) WriteColors(buf []RGBW) error {
+
+	if len(buf) > s.ledCount {
+		return fmt.Errorf("buffer too big, only %d LEDs setup: %d > %d", s.ledCount, len(buf), s.ledCount)
+	}
+
+	encodedLen := s.pixelType.EncodedLen()
+
+	tx := make([]byte, encodedLen*len(buf))
+	pos := 0
+	for _, c := range buf {
+		w := tx[pos:]
+		n := s.pixelType.PutRGBW(w, c)
+		pos += n
+	}
+
+	// the seesaw can at most deal with 30 bytes according to the datasheet, but
+	// crashes after 29 bytes. So we only send 29 data bytes at a time
+	const chunkSize = 29
+
+	// write the data chunk-by-chunk
+	for i := 0; i < len(tx); i += chunkSize {
+		toSend := tx[i:min(i+chunkSize, len(tx))]
+		err := s.writeBuffer(uint16(i), toSend)
+		if err != nil {
+			return fmt.Errorf("failed to write NeoPixel buffer offset %d: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+func (s *Device) writeBuffer(byteOffset uint16, buf []byte) error {
+	tx := make([]byte, 2+len(buf))
+	tx[0] = uint8(byteOffset >> 8)
+	tx[1] = uint8(byteOffset)
+	copy(tx[2:], buf)
+	return s.seesaw.Write(seesaw.ModuleNeoPixelBase, seesaw.FunctionNeopixelBuf, tx)
+}
+
+func (s *Device) ShowPixels() error {
+
+	// at most every 300us
+	// https://github.com/adafruit/Adafruit_Seesaw/blob/8a2dc5e0645239cb34e23a4b62c456436b098ab3/seesaw_neopixel.cpp#L109
+	s.waitSinceLastOperation(time.Microsecond * 300)
+
+	return s.seesaw.Write(seesaw.ModuleNeoPixelBase, seesaw.FunctionNeopixelShow, nil)
+}
+
+func (s *Device) waitSinceLastOperation(d time.Duration) {
+	diff := time.Since(s.lastOperationAt)
+	for diff < d {
+		time.Sleep(50 * time.Microsecond)
+		diff = time.Since(s.lastOperationAt)
+	}
+}
+
+// checkBufferLength checks whether the length is supported by seesaw. This depends on the pixel type.
+// The seesaw has built in NeoPixel support for up to 170 RGB or 127 RGBW pixels. The
+// output pin as well as the communication protocol frequency are configurable. Note:
+// older firmware is limited to 63 pixels max.
+func (s *Device) checkBufferLength(l int) bool {
+	const maxRgbwPixelCount = 127
+	const maxRgbPixelCount = 170
+
+	if s.pixelType.IsRGBW() {
+		return l <= maxRgbwPixelCount
+	}
+
+	return l <= maxRgbPixelCount
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/seesaw/registers.go
+++ b/seesaw/registers.go
@@ -1,0 +1,144 @@
+package seesaw
+
+type ModuleBaseAddress byte
+
+/** Module Base Addreses
+ *  The module base addresses for different seesaw modules.
+ */
+const (
+	ModuleStatusBase  ModuleBaseAddress = 0x00
+	ModuleGpioBase    ModuleBaseAddress = 0x01
+	ModuleSercom0Base ModuleBaseAddress = 0x02
+
+	ModuleTimerBase     ModuleBaseAddress = 0x08
+	ModuleAdcBase       ModuleBaseAddress = 0x09
+	ModuleDacBase       ModuleBaseAddress = 0x0A
+	ModuleInterruptBase ModuleBaseAddress = 0x0B
+	ModuleDapBase       ModuleBaseAddress = 0x0C
+	ModuleEepromBase    ModuleBaseAddress = 0x0D
+	ModuleNeoPixelBase  ModuleBaseAddress = 0x0E
+	ModuleTouchBase     ModuleBaseAddress = 0x0F
+	ModuleKeypadBase    ModuleBaseAddress = 0x10
+	ModuleEncoderBase   ModuleBaseAddress = 0x11
+	ModuleSpectrumBase  ModuleBaseAddress = 0x12
+)
+
+type FunctionAddress byte
+
+/** GPIO module function address registers
+ */
+const (
+	FunctionGpioDirsetBulk FunctionAddress = 0x02
+	FunctionGpioDirclrBulk FunctionAddress = 0x03
+	FunctionGpioBulk       FunctionAddress = 0x04
+	FunctionGpioBulkSet    FunctionAddress = 0x05
+	FunctionGpioBulkClr    FunctionAddress = 0x06
+	FunctionGpioBulkToggle FunctionAddress = 0x07
+	FunctionGpioIntenset   FunctionAddress = 0x08
+	FunctionGpioIntenclr   FunctionAddress = 0x09
+	FunctionGpioIntflag    FunctionAddress = 0x0A
+	FunctionGpioPullenset  FunctionAddress = 0x0B
+	FunctionGpioPullenclr  FunctionAddress = 0x0C
+)
+
+/** status module function address registers
+ */
+const (
+	FunctionStatusHwId    FunctionAddress = 0x01
+	FunctionStatusVersion FunctionAddress = 0x02
+	FunctionStatusOptions FunctionAddress = 0x03
+	FunctionStatusTemp    FunctionAddress = 0x04
+	FunctionStatusSwrst   FunctionAddress = 0x7F
+)
+
+/** timer module function address registers
+ */
+const (
+	FunctionTimerStatus FunctionAddress = 0x00
+	FunctionTimerPwm    FunctionAddress = 0x01
+	FunctionTimerFreq   FunctionAddress = 0x02
+)
+
+/** ADC module function address registers
+ */
+const (
+	FunctionAdcStatus        FunctionAddress = 0x00
+	FunctionAdcInten         FunctionAddress = 0x02
+	FunctionAdcIntenclr      FunctionAddress = 0x03
+	FunctionAdcWinmode       FunctionAddress = 0x04
+	FunctionAdcWinthresh     FunctionAddress = 0x05
+	FunctionAdcChannelOffset FunctionAddress = 0x07
+)
+
+/** Sercom module function address registers
+ */
+const (
+	FunctionSercomStatus   FunctionAddress = 0x00
+	FunctionSercomInten    FunctionAddress = 0x02
+	FunctionSercomIntenclr FunctionAddress = 0x03
+	FunctionSercomBaud     FunctionAddress = 0x04
+	FunctionSercomData     FunctionAddress = 0x05
+)
+
+/** neopixel module function address registers
+ */
+const (
+	FunctionNeopixelStatus    FunctionAddress = 0x00
+	FunctionNeopixelPin       FunctionAddress = 0x01
+	FunctionNeopixelSpeed     FunctionAddress = 0x02
+	FunctionNeopixelBufLength FunctionAddress = 0x03
+	FunctionNeopixelBuf       FunctionAddress = 0x04
+	FunctionNeopixelShow      FunctionAddress = 0x05
+)
+
+/** touch module function address registers
+ */
+const (
+	FunctionTouchChannelOffset FunctionAddress = 0x10
+)
+
+/** keypad module function address registers
+ */
+const (
+	FunctionKeypadStatus   FunctionAddress = 0x00
+	FunctionKeypadEvent    FunctionAddress = 0x01
+	FunctionKeypadIntenset FunctionAddress = 0x02
+	FunctionKeypadIntenclr FunctionAddress = 0x03
+	FunctionKeypadCount    FunctionAddress = 0x04
+	FunctionKeypadFifo     FunctionAddress = 0x10
+)
+
+/** keypad module edge definitions
+ */
+const (
+	KeypadEdgeHigh = 0
+	KeypadEdgeLow
+	KeypadEdgeFalling
+	KeypadEdgeRising
+)
+
+/** encoder module edge definitions
+ */
+const (
+	EncoderStatus   = 0x00
+	EncoderIntenset = 0x10
+	EncoderIntenclr = 0x20
+	EncoderPosition = 0x30
+	EncoderDelta    = 0x40
+)
+
+/** Audio spectrum module function address registers
+ */
+const (
+	FunctionSpectrumResultsLower FunctionAddress = 0x00 // Audio spectrum bins 0-31
+	FunctionSpectrumResultsUpper FunctionAddress = 0x01 // Audio spectrum bins 32-63
+
+	// If some future device supports a larger spectrum can add additional
+	// "bins" working upward from here. Configurable setting registers then
+	// work downward from the top to avoid collision between spectrum bins
+	// and configurables.
+
+	FunctionSpectrumChannel FunctionAddress = 0xFD
+	FunctionSpectrumRate    FunctionAddress = 0xFE
+	FunctionSpectrumStatus  FunctionAddress = 0xFF
+)

--- a/seesaw/seesaw.go
+++ b/seesaw/seesaw.go
@@ -1,0 +1,113 @@
+package seesaw
+
+import (
+	"errors"
+	"strconv"
+	"time"
+)
+
+const DefaultSeesawAddress = 0x49
+
+// empirically determined delay, the one from the official library seems to be too short (250us)
+const defaultDelay = 10 * time.Millisecond
+
+const (
+	seesawHwIdCodeSAMD09  = 0x55 // HW ID code for SAMD09
+	seesawHwIdCodeTINY8x7 = 0x87 // HW ID code for ATtiny817
+)
+
+type Device struct {
+	bus  I2C
+	addr uint16
+	hwid byte
+}
+
+func New(addr uint16, bus I2C) *Device {
+	return &Device{
+		bus:  bus,
+		addr: addr,
+	}
+}
+
+// Begin resets and initializes the seesaw chip
+func (d *Device) Begin() error {
+
+	err := d.SoftReset()
+	if err != nil {
+		return err
+	}
+
+	var lastErr error
+	for i := 0; i < 10; i++ {
+		hwid, err := d.ReadHardwareID()
+		if err == nil {
+			d.hwid = hwid
+			lastErr = nil
+			break
+		}
+		lastErr = err
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if lastErr != nil {
+		return lastErr
+	}
+
+	return nil
+}
+
+// ReadHardwareID reads the ID of the seesaw device
+func (d *Device) ReadHardwareID() (byte, error) {
+	hwid, err := d.ReadRegister(ModuleStatusBase, FunctionStatusHwId)
+	if err != nil {
+		return 0, err
+	}
+
+	if hwid == seesawHwIdCodeSAMD09 || hwid == seesawHwIdCodeTINY8x7 {
+		return hwid, nil
+	}
+
+	return 0, errors.New("unknown hardware ID: " + strconv.Itoa(int(hwid)))
+}
+
+// SoftReset triggers a soft-reset of seesaw
+func (d *Device) SoftReset() error {
+	return d.WriteRegister(ModuleStatusBase, FunctionStatusSwrst, 0xFF)
+}
+
+// WriteRegister writes a single seesaw register
+func (d *Device) WriteRegister(module ModuleBaseAddress, function FunctionAddress, value byte) error {
+	buf := []byte{byte(module), byte(function), value}
+	return d.bus.Tx(d.addr, buf, nil)
+}
+
+// ReadRegister reads a single register from seesaw
+func (d *Device) ReadRegister(module ModuleBaseAddress, function FunctionAddress) (byte, error) {
+	buf := make([]byte, 1)
+	err := d.Read(module, function, buf, defaultDelay)
+	if err != nil {
+		return 0, err
+	}
+	return buf[0], nil
+}
+
+// Read reads a number of bytes from the device after sending the read command and waiting 'delay'. The delays depend
+// on the module and function and are documented in the seesaw datasheet
+func (d *Device) Read(module ModuleBaseAddress, function FunctionAddress, buf []byte, delay time.Duration) error {
+	prefix := []byte{byte(module), byte(function)}
+	err := d.bus.Tx(d.addr, prefix, nil)
+	if err != nil {
+		return err
+	}
+
+	//see seesaw datasheet
+	time.Sleep(delay)
+
+	return d.bus.Tx(d.addr, nil, buf)
+}
+
+func (d *Device) Write(module ModuleBaseAddress, function FunctionAddress, buf []byte) error {
+	prefix := []byte{byte(module), byte(function)}
+	data := append(prefix, buf...)
+	return d.bus.Tx(d.addr, data, nil)
+}


### PR DESCRIPTION
As advertised in https://github.com/tinygo-org/drivers/issues/564

Most of it is refactored and goifyed from the offical Arduino driver: https://github.com/adafruit/Adafruit_Seesaw/blob/master/Adafruit_seesaw.cpp

This is support for the seesaw device as well as its usage with NeoPixels.