### PR TITLE
st7789: allow changing the color format using COLMOD

### DIFF
--- a/st7789/registers.go
+++ b/st7789/registers.go
@@ -55,6 +55,10 @@ const (
 	VSCRDEF    = 0x33
 	VSCRSADD   = 0x37
 
+	ColorRGB444 ColorFormat = 0b011
+	ColorRGB565 ColorFormat = 0b101
+	ColorRGB666 ColorFormat = 0b111
+
 	NO_ROTATION  = drivers.Rotation0
 	ROTATION_90  = drivers.Rotation90 // 90 degrees clock-wise rotation
 	ROTATION_180 = drivers.Rotation180


### PR DESCRIPTION
This is only really useful for applications that use DrawRGBBitmap8. The RGB444 format has fewer colors, but can be up to 25% faster than the default RGB565.

I have tested this change on the Gopher Badge and the PineTime. Both can be substantially faster once the code is modified to output RGB444 instead of RGB565.