### PR TITLE
st7789: update saved rotation in SetRotation

### DIFF
--- a/st7789/st7789.go
+++ b/st7789/st7789.go
@@ -441,6 +441,7 @@ func (d *Device) Rotation() drivers.Rotation {
 
 // SetRotation changes the rotation of the device (clock-wise)
 func (d *Device) SetRotation(rotation Rotation) error {
+	d.rotation = rotation
 	d.startWrite()
 	err := d.setRotation(rotation)
 	d.endWrite()


### PR DESCRIPTION
I missed this issue in https://github.com/tinygo-org/drivers/pull/550. Without it, `Rotation()` returns the wrong rotation value.