### PR TITLE
I2C: discard WriteRegister and ReadRegister methods in interface

### DIFF
--- a/adt7410/adt7410.go
+++ b/adt7410/adt7410.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
 )
 
 type Error uint8
@@ -54,7 +55,7 @@ func (d *Device) Configure() (err error) {
 // Connected returns whether sensor has been found.
 func (d *Device) Connected() bool {
 	data := []byte{0}
-	d.bus.ReadRegister(uint8(d.Address), RegID, data)
+	legacy.ReadRegister(d.bus, uint8(d.Address), RegID, data)
 	return data[0]&0xF8 == 0xC8
 }
 
@@ -81,11 +82,11 @@ func (d *Device) writeByte(reg uint8, data byte) {
 }
 
 func (d *Device) readByte(reg uint8) byte {
-	d.bus.ReadRegister(d.Address, reg, d.buf)
+	legacy.ReadRegister(d.bus, d.Address, reg, d.buf)
 	return d.buf[0]
 }
 
 func (d *Device) readUint16(reg uint8) uint16 {
-	d.bus.ReadRegister(d.Address, reg, d.buf)
+	legacy.ReadRegister(d.bus, d.Address, reg, d.buf)
 	return uint16(d.buf[0])<<8 | uint16(d.buf[1])
 }

--- a/adxl345/adxl345.go
+++ b/adxl345/adxl345.go
@@ -5,7 +5,10 @@
 // Datasheet JP: http://www.analog.com/media/jp/technical-documentation/data-sheets/ADXL345_jp.pdf
 package adxl345 // import "tinygo.org/x/drivers/adxl345"
 
-import "tinygo.org/x/drivers"
+import (
+	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
+)
 
 type Range uint8
 type Rate uint8
@@ -68,21 +71,21 @@ func New(bus drivers.I2C) Device {
 
 // Configure sets up the device for communication
 func (d *Device) Configure() {
-	d.bus.WriteRegister(uint8(d.Address), REG_BW_RATE, []byte{d.bwRate.toByte()})
-	d.bus.WriteRegister(uint8(d.Address), REG_POWER_CTL, []byte{d.powerCtl.toByte()})
-	d.bus.WriteRegister(uint8(d.Address), REG_DATA_FORMAT, []byte{d.dataFormat.toByte()})
+	legacy.WriteRegister(d.bus, uint8(d.Address), REG_BW_RATE, []byte{d.bwRate.toByte()})
+	legacy.WriteRegister(d.bus, uint8(d.Address), REG_POWER_CTL, []byte{d.powerCtl.toByte()})
+	legacy.WriteRegister(d.bus, uint8(d.Address), REG_DATA_FORMAT, []byte{d.dataFormat.toByte()})
 }
 
 // Halt stops the sensor, values will not updated
 func (d *Device) Halt() {
 	d.powerCtl.measure = 0
-	d.bus.WriteRegister(uint8(d.Address), REG_POWER_CTL, []byte{d.powerCtl.toByte()})
+	legacy.WriteRegister(d.bus, uint8(d.Address), REG_POWER_CTL, []byte{d.powerCtl.toByte()})
 }
 
 // Restart makes reading the sensor working again after a halt
 func (d *Device) Restart() {
 	d.powerCtl.measure = 1
-	d.bus.WriteRegister(uint8(d.Address), REG_POWER_CTL, []byte{d.powerCtl.toByte()})
+	legacy.WriteRegister(d.bus, uint8(d.Address), REG_POWER_CTL, []byte{d.powerCtl.toByte()})
 }
 
 // ReadAcceleration reads the current acceleration from the device and returns
@@ -103,7 +106,7 @@ func (d *Device) ReadAcceleration() (x int32, y int32, z int32, err error) {
 // from the adxl345.
 func (d *Device) ReadRawAcceleration() (x int32, y int32, z int32) {
 	data := []byte{0, 0, 0, 0, 0, 0}
-	d.bus.ReadRegister(uint8(d.Address), REG_DATAX0, data)
+	legacy.ReadRegister(d.bus, uint8(d.Address), REG_DATAX0, data)
 
 	x = readIntLE(data[0], data[1])
 	y = readIntLE(data[2], data[3])
@@ -119,20 +122,20 @@ func (d *Device) UseLowPower(power bool) {
 	} else {
 		d.bwRate.lowPower = 0
 	}
-	d.bus.WriteRegister(uint8(d.Address), REG_BW_RATE, []byte{d.bwRate.toByte()})
+	legacy.WriteRegister(d.bus, uint8(d.Address), REG_BW_RATE, []byte{d.bwRate.toByte()})
 }
 
 // SetRate change the current rate of the sensor
 func (d *Device) SetRate(rate Rate) bool {
 	d.bwRate.rate = rate & 0x0F
-	d.bus.WriteRegister(uint8(d.Address), REG_BW_RATE, []byte{d.bwRate.toByte()})
+	legacy.WriteRegister(d.bus, uint8(d.Address), REG_BW_RATE, []byte{d.bwRate.toByte()})
 	return true
 }
 
 // SetRange change the current range of the sensor
 func (d *Device) SetRange(sensorRange Range) bool {
 	d.dataFormat.sensorRange = sensorRange & 0x03
-	d.bus.WriteRegister(uint8(d.Address), REG_DATA_FORMAT, []byte{d.dataFormat.toByte()})
+	legacy.WriteRegister(d.bus, uint8(d.Address), REG_DATA_FORMAT, []byte{d.dataFormat.toByte()})
 	return true
 }
 

--- a/amg88xx/amg88xx.go
+++ b/amg88xx/amg88xx.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
 )
 
 // Device wraps an I2C connection to a AMG88xx device.
@@ -48,7 +49,7 @@ func (d *Device) Configure(cfg Config) {
 
 // ReadPixels returns the 64 values (8x8 grid) of the sensor converted to  millicelsius
 func (d *Device) ReadPixels(buffer *[64]int16) {
-	d.bus.ReadRegister(uint8(d.Address), PIXEL_OFFSET, d.data)
+	legacy.ReadRegister(d.bus, uint8(d.Address), PIXEL_OFFSET, d.data)
 	for i := 0; i < 64; i++ {
 		buffer[i] = int16((uint16(d.data[2*i+1]) << 8) | uint16(d.data[2*i]))
 		if (buffer[i] & (1 << 11)) > 0 { // temperature negative
@@ -61,17 +62,17 @@ func (d *Device) ReadPixels(buffer *[64]int16) {
 
 // SetPCTL sets the PCTL
 func (d *Device) SetPCTL(pctl uint8) {
-	d.bus.WriteRegister(uint8(d.Address), PCTL, []byte{pctl})
+	legacy.WriteRegister(d.bus, uint8(d.Address), PCTL, []byte{pctl})
 }
 
 // SetReset sets the reset value
 func (d *Device) SetReset(rst uint8) {
-	d.bus.WriteRegister(uint8(d.Address), RST, []byte{rst})
+	legacy.WriteRegister(d.bus, uint8(d.Address), RST, []byte{rst})
 }
 
 // SetFrameRate configures the frame rate
 func (d *Device) SetFrameRate(framerate uint8) {
-	d.bus.WriteRegister(uint8(d.Address), FPSC, []byte{framerate & 0x01})
+	legacy.WriteRegister(d.bus, uint8(d.Address), FPSC, []byte{framerate & 0x01})
 }
 
 // SetMovingAverageMode sets the moving average mode
@@ -80,7 +81,7 @@ func (d *Device) SetMovingAverageMode(mode bool) {
 	if mode {
 		value = 1
 	}
-	d.bus.WriteRegister(uint8(d.Address), AVE, []byte{value << 5})
+	legacy.WriteRegister(d.bus, uint8(d.Address), AVE, []byte{value << 5})
 }
 
 // SetInterruptLevels sets the interrupt levels
@@ -97,8 +98,8 @@ func (d *Device) SetInterruptLevelsHysteresis(high int16, low int16, hysteresis 
 	if high > 4095 {
 		high = 4095
 	}
-	d.bus.WriteRegister(uint8(d.Address), INTHL, []byte{uint8(high & 0xFF)})
-	d.bus.WriteRegister(uint8(d.Address), INTHL, []byte{uint8((high & 0xFF) >> 4)})
+	legacy.WriteRegister(d.bus, uint8(d.Address), INTHL, []byte{uint8(high & 0xFF)})
+	legacy.WriteRegister(d.bus, uint8(d.Address), INTHL, []byte{uint8((high & 0xFF) >> 4)})
 
 	low = low / PIXEL_TEMP_CONVERSION
 	if low < -4095 {
@@ -107,8 +108,8 @@ func (d *Device) SetInterruptLevelsHysteresis(high int16, low int16, hysteresis 
 	if low > 4095 {
 		low = 4095
 	}
-	d.bus.WriteRegister(uint8(d.Address), INTHL, []byte{uint8(low & 0xFF)})
-	d.bus.WriteRegister(uint8(d.Address), INTHL, []byte{uint8((low & 0xFF) >> 4)})
+	legacy.WriteRegister(d.bus, uint8(d.Address), INTHL, []byte{uint8(low & 0xFF)})
+	legacy.WriteRegister(d.bus, uint8(d.Address), INTHL, []byte{uint8((low & 0xFF) >> 4)})
 
 	hysteresis = hysteresis / PIXEL_TEMP_CONVERSION
 	if hysteresis < -4095 {
@@ -117,32 +118,32 @@ func (d *Device) SetInterruptLevelsHysteresis(high int16, low int16, hysteresis 
 	if hysteresis > 4095 {
 		hysteresis = 4095
 	}
-	d.bus.WriteRegister(uint8(d.Address), INTHL, []byte{uint8(hysteresis & 0xFF)})
-	d.bus.WriteRegister(uint8(d.Address), INTHL, []byte{uint8((hysteresis & 0xFF) >> 4)})
+	legacy.WriteRegister(d.bus, uint8(d.Address), INTHL, []byte{uint8(hysteresis & 0xFF)})
+	legacy.WriteRegister(d.bus, uint8(d.Address), INTHL, []byte{uint8((hysteresis & 0xFF) >> 4)})
 }
 
 // EnableInterrupt enables the interrupt pin on the device
 func (d *Device) EnableInterrupt() {
 	d.interruptEnable = 1
-	d.bus.WriteRegister(uint8(d.Address), INTC, []byte{((uint8(d.interruptMode) << 1) | d.interruptEnable) & 0x03})
+	legacy.WriteRegister(d.bus, uint8(d.Address), INTC, []byte{((uint8(d.interruptMode) << 1) | d.interruptEnable) & 0x03})
 }
 
 // DisableInterrupt disables the interrupt pin on the device
 func (d *Device) DisableInterrupt() {
 	d.interruptEnable = 0
-	d.bus.WriteRegister(uint8(d.Address), INTC, []byte{((uint8(d.interruptMode) << 1) | d.interruptEnable) & 0x03})
+	legacy.WriteRegister(d.bus, uint8(d.Address), INTC, []byte{((uint8(d.interruptMode) << 1) | d.interruptEnable) & 0x03})
 }
 
 // SetInterruptMode sets the interrupt mode
 func (d *Device) SetInterruptMode(mode InterruptMode) {
 	d.interruptMode = mode
-	d.bus.WriteRegister(uint8(d.Address), INTC, []byte{((uint8(d.interruptMode) << 1) | d.interruptEnable) & 0x03})
+	legacy.WriteRegister(d.bus, uint8(d.Address), INTC, []byte{((uint8(d.interruptMode) << 1) | d.interruptEnable) & 0x03})
 }
 
 // GetInterrupt reads the state of the triggered interrupts
 func (d *Device) GetInterrupt() []uint8 {
 	data := make([]uint8, 8)
-	d.bus.ReadRegister(uint8(d.Address), INT_OFFSET, data)
+	legacy.ReadRegister(d.bus, uint8(d.Address), INT_OFFSET, data)
 	return data
 }
 
@@ -154,6 +155,6 @@ func (d *Device) ClearInterrupt() {
 // ReadThermistor reads the onboard thermistor
 func (d *Device) ReadThermistor() int16 {
 	data := make([]uint8, 2)
-	d.bus.ReadRegister(uint8(d.Address), TTHL, data)
+	legacy.ReadRegister(d.bus, uint8(d.Address), TTHL, data)
 	return (int16((uint16(data[1])<<8)|uint16(data[0])) * THERMISTOR_CONVERSION) / 10
 }

--- a/apds9960/apds9960.go
+++ b/apds9960/apds9960.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
 )
 
 // Device wraps an I2C connection to a APDS-9960 device.
@@ -68,7 +69,7 @@ func New(bus drivers.I2C) Device {
 // It does a "who am I" request and checks the response.
 func (d *Device) Connected() bool {
 	data := []byte{0}
-	d.bus.ReadRegister(d.Address, APDS9960_ID_REG, data)
+	legacy.ReadRegister(d.bus, d.Address, APDS9960_ID_REG, data)
 	return data[0] == 0xAB
 }
 
@@ -80,7 +81,7 @@ func (d *Device) GetMode() uint8 {
 // DisableAll turns off the device and all functions
 func (d *Device) DisableAll() {
 	d.enable(enableConfig{})
-	d.bus.WriteRegister(d.Address, APDS9960_GCONF4_REG, []byte{0x00})
+	legacy.WriteRegister(d.bus, d.Address, APDS9960_GCONF4_REG, []byte{0x00})
 	d.mode = MODE_NONE
 	d.gesture.detected = GESTURE_NONE
 }
@@ -88,13 +89,13 @@ func (d *Device) DisableAll() {
 // SetProximityPulse sets proximity pulse length (4, 8, 16, 32) and count (1~64)
 // default: 16, 64
 func (d *Device) SetProximityPulse(length, count uint8) {
-	d.bus.WriteRegister(d.Address, APDS9960_PPULSE_REG, []byte{getPulseLength(length)<<6 | getPulseCount(count)})
+	legacy.WriteRegister(d.bus, d.Address, APDS9960_PPULSE_REG, []byte{getPulseLength(length)<<6 | getPulseCount(count)})
 }
 
 // SetGesturePulse sets gesture pulse length (4, 8, 16, 32) and count (1~64)
 // default: 16, 64
 func (d *Device) SetGesturePulse(length, count uint8) {
-	d.bus.WriteRegister(d.Address, APDS9960_GPULSE_REG, []byte{getPulseLength(length)<<6 | getPulseCount(count)})
+	legacy.WriteRegister(d.bus, d.Address, APDS9960_GPULSE_REG, []byte{getPulseLength(length)<<6 | getPulseCount(count)})
 }
 
 // SetADCIntegrationCycles sets ALS/color ADC internal integration cycles (1~256, 1 cycle = 2.78 ms)
@@ -103,14 +104,14 @@ func (d *Device) SetADCIntegrationCycles(cycles uint16) {
 	if cycles > 256 {
 		cycles = 256
 	}
-	d.bus.WriteRegister(d.Address, APDS9960_ATIME_REG, []byte{uint8(256 - cycles)})
+	legacy.WriteRegister(d.bus, d.Address, APDS9960_ATIME_REG, []byte{uint8(256 - cycles)})
 }
 
 // SetGains sets proximity/gesture gain (1, 2, 4, 8x) and ALS/color gain (1, 4, 16, 64x)
 // default: 1, 1, 4
 func (d *Device) SetGains(proximityGain, gestureGain, colorGain uint8) {
-	d.bus.WriteRegister(d.Address, APDS9960_CONTROL_REG, []byte{getProximityGain(proximityGain)<<2 | getALSGain(colorGain)})
-	d.bus.WriteRegister(d.Address, APDS9960_GCONF2_REG, []byte{getProximityGain(gestureGain) << 5})
+	legacy.WriteRegister(d.bus, d.Address, APDS9960_CONTROL_REG, []byte{getProximityGain(proximityGain)<<2 | getALSGain(colorGain)})
+	legacy.WriteRegister(d.bus, d.Address, APDS9960_GCONF2_REG, []byte{getProximityGain(gestureGain) << 5})
 }
 
 // LEDBoost sets proximity and gesture LED current level (100, 150, 200, 300 (%))
@@ -127,7 +128,7 @@ func (d *Device) LEDBoost(percent uint16) {
 	case 300:
 		v = 3
 	}
-	d.bus.WriteRegister(d.Address, APDS9960_CONFIG2_REG, []byte{0x01 | v<<4})
+	legacy.WriteRegister(d.bus, d.Address, APDS9960_CONFIG2_REG, []byte{0x01 | v<<4})
 }
 
 // Setthreshold sets threshold (0~255) for detecting gestures
@@ -168,7 +169,7 @@ func (d *Device) ReadProximity() (proximity int32) {
 		return 0
 	}
 	data := []byte{0}
-	d.bus.ReadRegister(d.Address, APDS9960_PDATA_REG, data)
+	legacy.ReadRegister(d.bus, d.Address, APDS9960_PDATA_REG, data)
 	return 255 - int32(data[0])
 }
 
@@ -195,14 +196,14 @@ func (d *Device) ReadColor() (r int32, g int32, b int32, clear int32) {
 		return
 	}
 	data := []byte{0, 0, 0, 0, 0, 0, 0, 0}
-	d.bus.ReadRegister(d.Address, APDS9960_CDATAL_REG, data[:1])
-	d.bus.ReadRegister(d.Address, APDS9960_CDATAH_REG, data[1:2])
-	d.bus.ReadRegister(d.Address, APDS9960_RDATAL_REG, data[2:3])
-	d.bus.ReadRegister(d.Address, APDS9960_RDATAH_REG, data[3:4])
-	d.bus.ReadRegister(d.Address, APDS9960_GDATAL_REG, data[4:5])
-	d.bus.ReadRegister(d.Address, APDS9960_GDATAH_REG, data[5:6])
-	d.bus.ReadRegister(d.Address, APDS9960_BDATAL_REG, data[6:7])
-	d.bus.ReadRegister(d.Address, APDS9960_BDATAH_REG, data[7:])
+	legacy.ReadRegister(d.bus, d.Address, APDS9960_CDATAL_REG, data[:1])
+	legacy.ReadRegister(d.bus, d.Address, APDS9960_CDATAH_REG, data[1:2])
+	legacy.ReadRegister(d.bus, d.Address, APDS9960_RDATAL_REG, data[2:3])
+	legacy.ReadRegister(d.bus, d.Address, APDS9960_RDATAH_REG, data[3:4])
+	legacy.ReadRegister(d.bus, d.Address, APDS9960_GDATAL_REG, data[4:5])
+	legacy.ReadRegister(d.bus, d.Address, APDS9960_GDATAH_REG, data[5:6])
+	legacy.ReadRegister(d.bus, d.Address, APDS9960_BDATAL_REG, data[6:7])
+	legacy.ReadRegister(d.bus, d.Address, APDS9960_BDATAH_REG, data[7:])
 	clear = int32(uint16(data[1])<<8 | uint16(data[0]))
 	r = int32(uint16(data[3])<<8 | uint16(data[2]))
 	g = int32(uint16(data[5])<<8 | uint16(data[4]))
@@ -234,13 +235,13 @@ func (d *Device) GestureAvailable() bool {
 	data := []byte{0, 0, 0, 0}
 
 	// check GVALID
-	d.bus.ReadRegister(d.Address, APDS9960_GSTATUS_REG, data[:1])
+	legacy.ReadRegister(d.bus, d.Address, APDS9960_GSTATUS_REG, data[:1])
 	if data[0]&0x01 == 0 {
 		return false
 	}
 
 	// get number of data sets available in FIFO
-	d.bus.ReadRegister(d.Address, APDS9960_GFLVL_REG, data[:1])
+	legacy.ReadRegister(d.bus, d.Address, APDS9960_GFLVL_REG, data[:1])
 	availableDataSets := data[0]
 	if availableDataSets == 0 {
 		return false
@@ -249,10 +250,10 @@ func (d *Device) GestureAvailable() bool {
 	// read up, down, left and right proximity data from FIFO
 	var dataSets [32][4]uint8
 	for i := uint8(0); i < availableDataSets; i++ {
-		d.bus.ReadRegister(d.Address, APDS9960_GFIFO_U_REG, data[:1])
-		d.bus.ReadRegister(d.Address, APDS9960_GFIFO_D_REG, data[1:2])
-		d.bus.ReadRegister(d.Address, APDS9960_GFIFO_L_REG, data[2:3])
-		d.bus.ReadRegister(d.Address, APDS9960_GFIFO_R_REG, data[3:4])
+		legacy.ReadRegister(d.bus, d.Address, APDS9960_GFIFO_U_REG, data[:1])
+		legacy.ReadRegister(d.bus, d.Address, APDS9960_GFIFO_D_REG, data[1:2])
+		legacy.ReadRegister(d.bus, d.Address, APDS9960_GFIFO_L_REG, data[2:3])
+		legacy.ReadRegister(d.bus, d.Address, APDS9960_GFIFO_R_REG, data[3:4])
 		for j := uint8(0); j < 4; j++ {
 			dataSets[i][j] = data[j]
 		}
@@ -385,7 +386,7 @@ func (d *Device) enable(cfg enableConfig) {
 	}
 
 	data := []byte{gen<<6 | pien<<5 | aien<<4 | wen<<3 | pen<<2 | aen<<1 | pon}
-	d.bus.WriteRegister(d.Address, APDS9960_ENABLE_REG, data)
+	legacy.WriteRegister(d.bus, d.Address, APDS9960_ENABLE_REG, data)
 
 	if cfg.PON {
 		time.Sleep(time.Millisecond * 10)
@@ -394,7 +395,7 @@ func (d *Device) enable(cfg enableConfig) {
 
 func (d *Device) readStatus(param string) bool {
 	data := []byte{0}
-	d.bus.ReadRegister(d.Address, APDS9960_STATUS_REG, data)
+	legacy.ReadRegister(d.bus, d.Address, APDS9960_STATUS_REG, data)
 
 	switch param {
 	case "CPSAT":

--- a/as560x/i2c_register.go
+++ b/as560x/i2c_register.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
 )
 
 // registerAttributes is a bitfield of attributes for a register
@@ -94,7 +95,7 @@ func (r *i2cRegister) readShiftAndMask(bus drivers.I2C, deviceAddress uint8, shi
 			buf = buffer[:]
 		}
 		// Read the host register over I2C
-		err := bus.ReadRegister(deviceAddress, r.host.address, buf)
+		err := legacy.ReadRegister(bus, deviceAddress, r.host.address, buf)
 		if nil != err {
 			return 0, err
 		}

--- a/axp192/axp192.go
+++ b/axp192/axp192.go
@@ -7,6 +7,7 @@ package axp192 // import "tinygo.org/x/drivers/axp192"
 
 import (
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
 )
 
 type Error uint8
@@ -248,10 +249,10 @@ func (d *Device) SetLDOEnable(number uint8, state bool) {
 }
 
 func (d *Device) write1Byte(reg, data uint8) {
-	d.bus.WriteRegister(d.Address, reg, []byte{data})
+	legacy.WriteRegister(d.bus, d.Address, reg, []byte{data})
 }
 
 func (d *Device) read8bit(reg uint8) uint8 {
-	d.bus.ReadRegister(d.Address, reg, d.buf[:1])
+	legacy.ReadRegister(d.bus, d.Address, reg, d.buf[:1])
 	return d.buf[0]
 }

--- a/bmp180/bmp180.go
+++ b/bmp180/bmp180.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
 )
 
 // OversamplingMode is the oversampling ratio of the pressure measurement.
@@ -55,7 +56,7 @@ func New(bus drivers.I2C) Device {
 // It does a "who am I" request and checks the response.
 func (d *Device) Connected() bool {
 	data := []byte{0}
-	d.bus.ReadRegister(uint8(d.Address), WHO_AM_I, data)
+	legacy.ReadRegister(d.bus, uint8(d.Address), WHO_AM_I, data)
 	return data[0] == CHIP_ID
 }
 
@@ -63,7 +64,7 @@ func (d *Device) Connected() bool {
 // read the calibration coefficients.
 func (d *Device) Configure() {
 	data := make([]byte, 22)
-	err := d.bus.ReadRegister(uint8(d.Address), AC1_MSB, data)
+	err := legacy.ReadRegister(d.bus, uint8(d.Address), AC1_MSB, data)
 	if err != nil {
 		return
 	}
@@ -141,10 +142,10 @@ func (d *Device) ReadAltitude() (int32, error) {
 
 // rawTemp returns the sensor's raw values of the temperature
 func (d *Device) rawTemp() (int32, error) {
-	d.bus.WriteRegister(uint8(d.Address), REG_CTRL, []byte{CMD_TEMP})
+	legacy.WriteRegister(d.bus, uint8(d.Address), REG_CTRL, []byte{CMD_TEMP})
 	time.Sleep(5 * time.Millisecond)
 	data := make([]byte, 2)
-	err := d.bus.ReadRegister(uint8(d.Address), REG_TEMP_MSB, data)
+	err := legacy.ReadRegister(d.bus, uint8(d.Address), REG_TEMP_MSB, data)
 	if err != nil {
 		return 0, err
 	}
@@ -160,10 +161,10 @@ func (d *Device) calculateB5(rawTemp int32) int32 {
 
 // rawPressure returns the sensor's raw values of the pressure
 func (d *Device) rawPressure(mode OversamplingMode) (int32, error) {
-	d.bus.WriteRegister(uint8(d.Address), REG_CTRL, []byte{CMD_PRESSURE + byte(mode<<6)})
+	legacy.WriteRegister(d.bus, uint8(d.Address), REG_CTRL, []byte{CMD_PRESSURE + byte(mode<<6)})
 	time.Sleep(pauseForReading(mode))
 	data := make([]byte, 3)
-	err := d.bus.ReadRegister(uint8(d.Address), REG_PRESSURE_MSB, data)
+	err := legacy.ReadRegister(d.bus, uint8(d.Address), REG_PRESSURE_MSB, data)
 	if err != nil {
 		return 0, err
 	}

--- a/bmp388/bmp388.go
+++ b/bmp388/bmp388.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
 )
 
 var (
@@ -240,10 +241,10 @@ func (d *Device) configurationError() bool {
 
 func (d *Device) readRegister(register byte, len int) (data []byte, err error) {
 	data = make([]byte, len)
-	err = d.bus.ReadRegister(d.Address, register, data)
+	err = legacy.ReadRegister(d.bus, d.Address, register, data)
 	return
 }
 
 func (d *Device) writeRegister(register byte, data byte) error {
-	return d.bus.WriteRegister(d.Address, register, []byte{data})
+	return legacy.WriteRegister(d.bus, d.Address, register, []byte{data})
 }

--- a/ds1307/ds1307.go
+++ b/ds1307/ds1307.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
 )
 
 // Device wraps an I2C connection to a DS1307 device.
@@ -44,7 +45,7 @@ func (d *Device) SetTime(t time.Time) error {
 // ReadTime returns the date and time
 func (d *Device) ReadTime() (time.Time, error) {
 	data := make([]byte, 8)
-	err := d.bus.ReadRegister(d.Address, uint8(TimeDate), data)
+	err := legacy.ReadRegister(d.bus, d.Address, uint8(TimeDate), data)
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -105,7 +106,7 @@ func (d *Device) Read(data []uint8) (n int, err error) {
 	if int(d.AddressSRAM)+len(data)-1 > SRAMEndAddress {
 		return 0, errors.New("EOF")
 	}
-	err = d.bus.ReadRegister(d.Address, d.AddressSRAM, data)
+	err = legacy.ReadRegister(d.bus, d.Address, d.AddressSRAM, data)
 	if err != nil {
 		return 0, err
 	}
@@ -124,7 +125,7 @@ func (d *Device) SetOscillatorFrequency(sqw uint8) error {
 // IsOscillatorRunning returns if the oscillator is running
 func (d *Device) IsOscillatorRunning() bool {
 	data := []byte{0}
-	err := d.bus.ReadRegister(d.Address, uint8(TimeDate), data)
+	err := legacy.ReadRegister(d.bus, d.Address, uint8(TimeDate), data)
 	if err != nil {
 		return false
 	}
@@ -134,7 +135,7 @@ func (d *Device) IsOscillatorRunning() bool {
 // SetOscillatorRunning starts/stops internal oscillator by toggling halt bit
 func (d *Device) SetOscillatorRunning(running bool) error {
 	data := make([]byte, 3)
-	err := d.bus.ReadRegister(d.Address, uint8(TimeDate), data)
+	err := legacy.ReadRegister(d.bus, d.Address, uint8(TimeDate), data)
 	if err != nil {
 		return err
 	}

--- a/ds3231/ds3231.go
+++ b/ds3231/ds3231.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
 )
 
 type Mode uint8
@@ -37,7 +38,7 @@ func (d *Device) Configure() bool {
 // IsTimeValid return true/false is the time in the device is valid
 func (d *Device) IsTimeValid() bool {
 	data := []byte{0}
-	err := d.bus.ReadRegister(uint8(d.Address), REG_STATUS, data)
+	err := legacy.ReadRegister(d.bus, uint8(d.Address), REG_STATUS, data)
 	if err != nil {
 		return false
 	}
@@ -47,7 +48,7 @@ func (d *Device) IsTimeValid() bool {
 // IsRunning returns if the oscillator is running
 func (d *Device) IsRunning() bool {
 	data := []uint8{0}
-	err := d.bus.ReadRegister(uint8(d.Address), REG_CONTROL, data)
+	err := legacy.ReadRegister(d.bus, uint8(d.Address), REG_CONTROL, data)
 	if err != nil {
 		return false
 	}
@@ -57,7 +58,7 @@ func (d *Device) IsRunning() bool {
 // SetRunning starts the internal oscillator
 func (d *Device) SetRunning(isRunning bool) error {
 	data := []uint8{0}
-	err := d.bus.ReadRegister(uint8(d.Address), REG_CONTROL, data)
+	err := legacy.ReadRegister(d.bus, uint8(d.Address), REG_CONTROL, data)
 	if err != nil {
 		return err
 	}
@@ -66,7 +67,7 @@ func (d *Device) SetRunning(isRunning bool) error {
 	} else {
 		data[0] |= 1 << EOSC
 	}
-	err = d.bus.WriteRegister(uint8(d.Address), REG_CONTROL, data)
+	err = legacy.WriteRegister(d.bus, uint8(d.Address), REG_CONTROL, data)
 	if err != nil {
 		return err
 	}
@@ -86,12 +87,12 @@ func (d *Device) SetRunning(isRunning bool) error {
 // instead of 2100-03-01.
 func (d *Device) SetTime(dt time.Time) error {
 	data := []byte{0}
-	err := d.bus.ReadRegister(uint8(d.Address), REG_STATUS, data)
+	err := legacy.ReadRegister(d.bus, uint8(d.Address), REG_STATUS, data)
 	if err != nil {
 		return err
 	}
 	data[0] &^= 1 << OSF
-	err = d.bus.WriteRegister(uint8(d.Address), REG_STATUS, data)
+	err = legacy.WriteRegister(d.bus, uint8(d.Address), REG_STATUS, data)
 	if err != nil {
 		return err
 	}
@@ -117,7 +118,7 @@ func (d *Device) SetTime(dt time.Time) error {
 	data[5] = uint8ToBCD(uint8(dt.Month()) | centuryFlag)
 	data[6] = uint8ToBCD(year)
 
-	err = d.bus.WriteRegister(uint8(d.Address), REG_TIMEDATE, data)
+	err = legacy.WriteRegister(d.bus, uint8(d.Address), REG_TIMEDATE, data)
 	if err != nil {
 		return err
 	}
@@ -128,7 +129,7 @@ func (d *Device) SetTime(dt time.Time) error {
 // ReadTime returns the date and time
 func (d *Device) ReadTime() (dt time.Time, err error) {
 	data := make([]uint8, 7)
-	err = d.bus.ReadRegister(uint8(d.Address), REG_TIMEDATE, data)
+	err = legacy.ReadRegister(d.bus, uint8(d.Address), REG_TIMEDATE, data)
 	if err != nil {
 		return
 	}
@@ -150,7 +151,7 @@ func (d *Device) ReadTime() (dt time.Time, err error) {
 // ReadTemperature returns the temperature in millicelsius (mC)
 func (d *Device) ReadTemperature() (int32, error) {
 	data := make([]uint8, 2)
-	err := d.bus.ReadRegister(uint8(d.Address), REG_TEMP, data)
+	err := legacy.ReadRegister(d.bus, uint8(d.Address), REG_TEMP, data)
 	if err != nil {
 		return 0, err
 	}

--- a/ft6336/ft6336.go
+++ b/ft6336/ft6336.go
@@ -8,6 +8,7 @@ import (
 	"machine"
 
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
 	"tinygo.org/x/drivers/touch"
 )
 
@@ -98,10 +99,10 @@ func (d *Device) Touched() bool {
 }
 
 func (d *Device) write1Byte(reg, data uint8) {
-	d.bus.WriteRegister(d.Address, reg, []byte{data})
+	legacy.WriteRegister(d.bus, d.Address, reg, []byte{data})
 }
 
 func (d *Device) read8bit(reg uint8) uint8 {
-	d.bus.ReadRegister(d.Address, reg, d.buf[:1])
+	legacy.ReadRegister(d.bus, d.Address, reg, d.buf[:1])
 	return d.buf[0]
 }

--- a/hts221/hts221.go
+++ b/hts221/hts221.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
 )
 
 // Device wraps an I2C connection to a HTS221 device.
@@ -32,7 +33,7 @@ func New(bus drivers.I2C) Device {
 // It does a "who am I" request and checks the response.
 func (d *Device) Connected() bool {
 	data := []byte{0}
-	d.bus.ReadRegister(d.Address, HTS221_WHO_AM_I_REG, data)
+	legacy.ReadRegister(d.bus, d.Address, HTS221_WHO_AM_I_REG, data)
 	return data[0] == 0xBC
 }
 
@@ -42,7 +43,7 @@ func (d *Device) Power(status bool) {
 	if status {
 		data[0] = 0x84
 	}
-	d.bus.WriteRegister(d.Address, HTS221_CTRL1_REG, data)
+	legacy.WriteRegister(d.bus, d.Address, HTS221_CTRL1_REG, data)
 }
 
 // ReadHumidity returns the relative humidity in percent * 100.
@@ -55,8 +56,8 @@ func (d *Device) ReadHumidity() (humidity int32, err error) {
 
 	// read data and calibrate
 	data := []byte{0, 0}
-	d.bus.ReadRegister(d.Address, HTS221_HUMID_OUT_REG, data[:1])
-	d.bus.ReadRegister(d.Address, HTS221_HUMID_OUT_REG+1, data[1:])
+	legacy.ReadRegister(d.bus, d.Address, HTS221_HUMID_OUT_REG, data[:1])
+	legacy.ReadRegister(d.bus, d.Address, HTS221_HUMID_OUT_REG+1, data[1:])
 	hValue := readInt(data[1], data[0])
 	hValueCalib := float32(hValue)*d.humiditySlope + d.humidityZero
 
@@ -73,8 +74,8 @@ func (d *Device) ReadTemperature() (temperature int32, err error) {
 
 	// read data and calibrate
 	data := []byte{0, 0}
-	d.bus.ReadRegister(d.Address, HTS221_TEMP_OUT_REG, data[:1])
-	d.bus.ReadRegister(d.Address, HTS221_TEMP_OUT_REG+1, data[1:])
+	legacy.ReadRegister(d.bus, d.Address, HTS221_TEMP_OUT_REG, data[:1])
+	legacy.ReadRegister(d.bus, d.Address, HTS221_TEMP_OUT_REG+1, data[1:])
 	tValue := readInt(data[1], data[0])
 	tValueCalib := float32(tValue)*d.temperatureSlope + d.temperatureZero
 
@@ -91,7 +92,7 @@ func (d *Device) Resolution(h uint8, t uint8) {
 	if t > 7 {
 		t = 3 // default
 	}
-	d.bus.WriteRegister(d.Address, HTS221_AV_CONF_REG, []byte{h<<3 | t})
+	legacy.WriteRegister(d.bus, d.Address, HTS221_AV_CONF_REG, []byte{h<<3 | t})
 }
 
 // private functions
@@ -104,19 +105,19 @@ func (d *Device) calibration() {
 	h0t0Out, h1t0Out := []byte{0, 0}, []byte{0, 0}
 	t0Out, t1Out := []byte{0, 0}, []byte{0, 0}
 
-	d.bus.ReadRegister(d.Address, HTS221_H0_rH_x2_REG, h0rH)
-	d.bus.ReadRegister(d.Address, HTS221_H1_rH_x2_REG, h1rH)
-	d.bus.ReadRegister(d.Address, HTS221_T0_degC_x8_REG, t0degC)
-	d.bus.ReadRegister(d.Address, HTS221_T1_degC_x8_REG, t1degC)
-	d.bus.ReadRegister(d.Address, HTS221_T1_T0_MSB_REG, t1t0msb)
-	d.bus.ReadRegister(d.Address, HTS221_H0_T0_OUT_REG, h0t0Out[:1])
-	d.bus.ReadRegister(d.Address, HTS221_H0_T0_OUT_REG+1, h0t0Out[1:])
-	d.bus.ReadRegister(d.Address, HTS221_H1_T0_OUT_REG, h1t0Out[:1])
-	d.bus.ReadRegister(d.Address, HTS221_H1_T0_OUT_REG+1, h1t0Out[1:])
-	d.bus.ReadRegister(d.Address, HTS221_T0_OUT_REG, t0Out[:1])
-	d.bus.ReadRegister(d.Address, HTS221_T0_OUT_REG+1, t0Out[1:])
-	d.bus.ReadRegister(d.Address, HTS221_T1_OUT_REG, t1Out[:1])
-	d.bus.ReadRegister(d.Address, HTS221_T1_OUT_REG+1, t1Out[1:])
+	legacy.ReadRegister(d.bus, d.Address, HTS221_H0_rH_x2_REG, h0rH)
+	legacy.ReadRegister(d.bus, d.Address, HTS221_H1_rH_x2_REG, h1rH)
+	legacy.ReadRegister(d.bus, d.Address, HTS221_T0_degC_x8_REG, t0degC)
+	legacy.ReadRegister(d.bus, d.Address, HTS221_T1_degC_x8_REG, t1degC)
+	legacy.ReadRegister(d.bus, d.Address, HTS221_T1_T0_MSB_REG, t1t0msb)
+	legacy.ReadRegister(d.bus, d.Address, HTS221_H0_T0_OUT_REG, h0t0Out[:1])
+	legacy.ReadRegister(d.bus, d.Address, HTS221_H0_T0_OUT_REG+1, h0t0Out[1:])
+	legacy.ReadRegister(d.bus, d.Address, HTS221_H1_T0_OUT_REG, h1t0Out[:1])
+	legacy.ReadRegister(d.bus, d.Address, HTS221_H1_T0_OUT_REG+1, h1t0Out[1:])
+	legacy.ReadRegister(d.bus, d.Address, HTS221_T0_OUT_REG, t0Out[:1])
+	legacy.ReadRegister(d.bus, d.Address, HTS221_T0_OUT_REG+1, t0Out[1:])
+	legacy.ReadRegister(d.bus, d.Address, HTS221_T1_OUT_REG, t1Out[:1])
+	legacy.ReadRegister(d.bus, d.Address, HTS221_T1_OUT_REG+1, t1Out[1:])
 
 	h0rH_v := float32(h0rH[0]) / 2.0
 	h1rH_v := float32(h1rH[0]) / 2.0
@@ -138,7 +139,7 @@ func (d *Device) waitForOneShot(filter uint8) error {
 	data := []byte{0}
 
 	// check if the device is on
-	d.bus.ReadRegister(d.Address, HTS221_CTRL1_REG, data)
+	legacy.ReadRegister(d.bus, d.Address, HTS221_CTRL1_REG, data)
 	if data[0]&0x80 == 0 {
 		return errors.New("device is off, unable to query")
 	}
@@ -146,19 +147,19 @@ func (d *Device) waitForOneShot(filter uint8) error {
 	// wait until one shot (one conversion) is ready to go
 	data[0] = 1
 	for {
-		d.bus.ReadRegister(d.Address, HTS221_CTRL2_REG, data)
+		legacy.ReadRegister(d.bus, d.Address, HTS221_CTRL2_REG, data)
 		if data[0]&0x01 == 0 {
 			break
 		}
 	}
 
 	// trigger one shot
-	d.bus.WriteRegister(d.Address, HTS221_CTRL2_REG, []byte{0x01})
+	legacy.WriteRegister(d.bus, d.Address, HTS221_CTRL2_REG, []byte{0x01})
 
 	// wait until conversion completed
 	data[0] = 0
 	for {
-		d.bus.ReadRegister(d.Address, HTS221_STATUS_REG, data)
+		legacy.ReadRegister(d.bus, d.Address, HTS221_STATUS_REG, data)
 		if data[0]&filter == filter {
 			break
 		}

--- a/i2c.go
+++ b/i2c.go
@@ -3,7 +3,7 @@ package drivers
 // I2C represents an I2C bus. It is notably implemented by the
 // machine.I2C type.
 type I2C interface {
-	ReadRegister(addr uint8, r uint8, buf []byte) error
-	WriteRegister(addr uint8, r uint8, buf []byte) error
+	// ReadRegister(addr uint8, r uint8, buf []byte) error
+	// WriteRegister(addr uint8, r uint8, buf []byte) error
 	Tx(addr uint16, w, r []byte) error
 }

--- a/i2c.go
+++ b/i2c.go
@@ -3,7 +3,15 @@ package drivers
 // I2C represents an I2C bus. It is notably implemented by the
 // machine.I2C type.
 type I2C interface {
-	// ReadRegister(addr uint8, r uint8, buf []byte) error
-	// WriteRegister(addr uint8, r uint8, buf []byte) error
+	// Tx performs a [I²C] transaction with address addr.
+	// Most I2C peripherals have some sort of register mapping scheme to allow
+	// users to interact with them:
+	//
+	//  bus.Tx(addr, []byte{reg}, buf) // Reads register reg into buf.
+	//  bus.Tx(addr, append([]byte{reg}, buf...), nil) // Writes buf into register reg.
+	//
+	// The semantics of most I2C transactions require that the w write buffer be non-empty.
+	//
+	// [I²C]: https://en.wikipedia.org/wiki/I%C2%B2C
 	Tx(addr uint16, w, r []byte) error
 }

--- a/ina260/ina260.go
+++ b/ina260/ina260.go
@@ -1,6 +1,9 @@
 package ina260
 
-import "tinygo.org/x/drivers"
+import (
+	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
+)
 
 // Device wraps an I2C connection to an INA260 device.
 type Device struct {
@@ -97,7 +100,7 @@ func (d *Device) Power() int32 {
 // Read a register
 func (d *Device) ReadRegister(reg uint8) uint16 {
 	data := []byte{0, 0}
-	d.bus.ReadRegister(uint8(d.Address), reg, data)
+	legacy.ReadRegister(d.bus, uint8(d.Address), reg, data)
 	return (uint16(data[0]) << 8) | uint16(data[1])
 }
 
@@ -107,5 +110,5 @@ func (d *Device) WriteRegister(reg uint8, v uint16) {
 	data[0] = byte(v >> 8)
 	data[1] = byte(v & 0xff)
 
-	d.bus.WriteRegister(uint8(d.Address), reg, data)
+	legacy.WriteRegister(d.bus, uint8(d.Address), reg, data)
 }

--- a/internal/legacy/i2clegacy.go
+++ b/internal/legacy/i2clegacy.go
@@ -2,14 +2,13 @@ package legacy
 
 import "tinygo.org/x/drivers"
 
-type I2C struct {
-	i2c drivers.I2C
+func ReadRegister(bus drivers.I2C, addr uint8, reg uint8, data []byte) error {
+	return bus.Tx(uint16(addr), []byte{reg}, data)
 }
 
-func ReadRegister(i2c drivers.I2C, addr uint8, reg uint8, buf []byte) error {
-	return i2c.Tx(uint16(addr), []byte{reg}, buf)
-}
-
-func WriteRegister(i2c drivers.I2C, addr uint8, reg uint8, buf []byte) error {
-	return i2c.Tx(uint16(addr), append([]byte{reg}, buf...), nil)
+func WriteRegister(bus drivers.I2C, addr uint8, reg uint8, data []byte) error {
+	buf := make([]uint8, len(data)+1)
+	buf[0] = reg
+	copy(buf[1:], data)
+	return bus.Tx(uint16(addr), buf, nil)
 }

--- a/internal/legacy/i2clegacy.go
+++ b/internal/legacy/i2clegacy.go
@@ -1,0 +1,15 @@
+package legacy
+
+import "tinygo.org/x/drivers"
+
+type I2C struct {
+	i2c drivers.I2C
+}
+
+func ReadRegister(i2c drivers.I2C, addr uint8, reg uint8, buf []byte) error {
+	return i2c.Tx(uint16(addr), []byte{reg}, buf)
+}
+
+func WriteRegister(i2c drivers.I2C, addr uint8, reg uint8, buf []byte) error {
+	return i2c.Tx(uint16(addr), append([]byte{reg}, buf...), nil)
+}

--- a/is31fl3731/is31fl3731.go
+++ b/is31fl3731/is31fl3731.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
 )
 
 // Device implements TinyGo driver for Lumissil IS31FL3731 matrix LED driver
@@ -92,7 +93,7 @@ func (d *Device) Configure() (err error) {
 func (d *Device) selectCommand(command uint8) (err error) {
 	if command != d.selectedCommand {
 		d.selectedCommand = command
-		return d.bus.WriteRegister(d.Address, COMMAND, []byte{command})
+		return legacy.WriteRegister(d.bus, d.Address, COMMAND, []byte{command})
 	}
 
 	return nil
@@ -105,7 +106,7 @@ func (d *Device) writeFunctionRegister(operation uint8, data []byte) (err error)
 		return err
 	}
 
-	return d.bus.WriteRegister(d.Address, operation, data)
+	return legacy.WriteRegister(d.bus, d.Address, operation, data)
 }
 
 // enableLEDs enables only LEDs that are soldered on the set board. Enabled
@@ -119,7 +120,7 @@ func (d *Device) enableLEDs() (err error) {
 
 		// Enable every LED (16 columns x 9 rows)
 		for i := uint8(0); i < 16; i++ {
-			err = d.bus.WriteRegister(d.Address, i, []byte{0xFF})
+			err = legacy.WriteRegister(d.bus, d.Address, i, []byte{0xFF})
 			if err != nil {
 				return err
 			}
@@ -136,7 +137,7 @@ func (d *Device) setPixelPWD(frame, n, value uint8) (err error) {
 		return err
 	}
 
-	return d.bus.WriteRegister(d.Address, LED_PWM_OFFSET+n, []byte{value})
+	return legacy.WriteRegister(d.bus, d.Address, LED_PWM_OFFSET+n, []byte{value})
 }
 
 // SetActiveFrame sets frame to display with LEDs
@@ -165,7 +166,7 @@ func (d *Device) Fill(frame, value uint8) (err error) {
 	}
 
 	for i := uint8(0); i < 6; i++ {
-		err = d.bus.WriteRegister(d.Address, LED_PWM_OFFSET+i*24, data)
+		err = legacy.WriteRegister(d.bus, d.Address, LED_PWM_OFFSET+i*24, data)
 		if err != nil {
 			return err
 		}

--- a/is31fl3731/is31fl3731_acw15x7.go
+++ b/is31fl3731/is31fl3731_acw15x7.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
 )
 
 // DeviceAdafruitCharlieWing15x7 implements TinyGo driver for Lumissil
@@ -47,20 +48,20 @@ func (d *DeviceAdafruitCharlieWing15x7) enableLEDs() (err error) {
 
 		// Enable left half
 		for i := uint8(0); i < 16; i += 2 {
-			err = d.bus.WriteRegister(d.Address, i, []byte{0b11111110})
+			err = legacy.WriteRegister(d.bus, d.Address, i, []byte{0b11111110})
 			if err != nil {
 				return err
 			}
 		}
 		// Enable right half
 		for i := uint8(3); i < 16; i += 2 {
-			err = d.bus.WriteRegister(d.Address, i, []byte{0b01111111})
+			err = legacy.WriteRegister(d.bus, d.Address, i, []byte{0b01111111})
 			if err != nil {
 				return err
 			}
 		}
 		// Disable invisible column on the right side
-		err = d.bus.WriteRegister(d.Address, 1, []byte{0b00000000})
+		err = legacy.WriteRegister(d.bus, d.Address, 1, []byte{0b00000000})
 		if err != nil {
 			return err
 		}

--- a/l3gd20/i2c.go
+++ b/l3gd20/i2c.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
 )
 
 const (
@@ -87,15 +88,15 @@ func (d *DevI2C) Configure(cfg Config) error {
 }
 
 func (d *DevI2C) Update() error {
-	err := d.bus.ReadRegister(d.addr, OUT_X_L, d.databuf[:2])
+	err := legacy.ReadRegister(d.bus, d.addr, OUT_X_L, d.databuf[:2])
 	if err != nil {
 		return err
 	}
-	err = d.bus.ReadRegister(d.addr, OUT_Y_L, d.databuf[2:4])
+	err = legacy.ReadRegister(d.bus, d.addr, OUT_Y_L, d.databuf[2:4])
 	if err != nil {
 		return err
 	}
-	err = d.bus.ReadRegister(d.addr, OUT_Z_L, d.databuf[4:6])
+	err = legacy.ReadRegister(d.bus, d.addr, OUT_Z_L, d.databuf[4:6])
 	if err != nil {
 		return err
 	}
@@ -131,11 +132,11 @@ func (d *DevI2C) AngularVelocity() (x, y, z int32) {
 // func (d DevI2C) Update(measurement)
 
 func (d DevI2C) read8(reg uint8) (byte, error) {
-	err := d.bus.ReadRegister(d.addr, reg, d.buf[:1])
+	err := legacy.ReadRegister(d.bus, d.addr, reg, d.buf[:1])
 	return d.buf[0], err
 }
 
 func (d DevI2C) write8(reg uint8, val byte) error {
 	d.buf[0] = val
-	return d.bus.WriteRegister(d.addr, reg, d.buf[:1])
+	return legacy.WriteRegister(d.bus, d.addr, reg, d.buf[:1])
 }

--- a/lps22hb/lps22hb.go
+++ b/lps22hb/lps22hb.go
@@ -5,6 +5,7 @@ package lps22hb
 
 import (
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
 )
 
 // Device wraps an I2C connection to a HTS221 device.
@@ -27,9 +28,9 @@ func (d *Device) ReadPressure() (pressure int32, err error) {
 
 	// read data
 	data := []byte{0, 0, 0}
-	d.bus.ReadRegister(d.Address, LPS22HB_PRESS_OUT_REG, data[:1])
-	d.bus.ReadRegister(d.Address, LPS22HB_PRESS_OUT_REG+1, data[1:2])
-	d.bus.ReadRegister(d.Address, LPS22HB_PRESS_OUT_REG+2, data[2:])
+	legacy.ReadRegister(d.bus, d.Address, LPS22HB_PRESS_OUT_REG, data[:1])
+	legacy.ReadRegister(d.bus, d.Address, LPS22HB_PRESS_OUT_REG+1, data[1:2])
+	legacy.ReadRegister(d.bus, d.Address, LPS22HB_PRESS_OUT_REG+2, data[2:])
 	pValue := float32(uint32(data[2])<<16|uint32(data[1])<<8|uint32(data[0])) / 4096.0
 
 	return int32(pValue * 1000), nil
@@ -39,7 +40,7 @@ func (d *Device) ReadPressure() (pressure int32, err error) {
 // It does a "who am I" request and checks the response.
 func (d *Device) Connected() bool {
 	data := []byte{0}
-	d.bus.ReadRegister(d.Address, LPS22HB_WHO_AM_I_REG, data)
+	legacy.ReadRegister(d.bus, d.Address, LPS22HB_WHO_AM_I_REG, data)
 	return data[0] == 0xB1
 }
 
@@ -49,8 +50,8 @@ func (d *Device) ReadTemperature() (temperature int32, err error) {
 
 	// read data
 	data := []byte{0, 0}
-	d.bus.ReadRegister(d.Address, LPS22HB_TEMP_OUT_REG, data[:1])
-	d.bus.ReadRegister(d.Address, LPS22HB_TEMP_OUT_REG+1, data[1:])
+	legacy.ReadRegister(d.bus, d.Address, LPS22HB_TEMP_OUT_REG, data[:1])
+	legacy.ReadRegister(d.bus, d.Address, LPS22HB_TEMP_OUT_REG+1, data[1:])
 	tValue := float32(int16(uint16(data[1])<<8|uint16(data[0]))) / 100.0
 
 	return int32(tValue * 1000), nil
@@ -61,12 +62,12 @@ func (d *Device) ReadTemperature() (temperature int32, err error) {
 // wait and trigger one shot in block update
 func (d *Device) waitForOneShot() {
 	// trigger one shot
-	d.bus.WriteRegister(d.Address, LPS22HB_CTRL2_REG, []byte{0x01})
+	legacy.WriteRegister(d.bus, d.Address, LPS22HB_CTRL2_REG, []byte{0x01})
 
 	// wait until one shot is cleared
 	data := []byte{1}
 	for {
-		d.bus.ReadRegister(d.Address, LPS22HB_CTRL2_REG, data)
+		legacy.ReadRegister(d.bus, d.Address, LPS22HB_CTRL2_REG, data)
 		if data[0]&0x01 == 0 {
 			break
 		}

--- a/lps22hb/lps22hb_generic.go
+++ b/lps22hb/lps22hb_generic.go
@@ -2,10 +2,10 @@
 
 package lps22hb
 
-import "tinygo.org/x/drivers"
+import "tinygo.org/x/drivers/internal/legacy"
 
 // Configure sets up the LPS22HB device for communication.
 func (d *Device) Configure() {
 	// set to block update mode
-	d.bus.WriteRegister(d.Address, LPS22HB_CTRL1_REG, []byte{0x02})
+	legacy.WriteRegister(d.bus, d.Address, LPS22HB_CTRL1_REG, []byte{0x02})
 }

--- a/lps22hb/lps22hb_nano_33_ble.go
+++ b/lps22hb/lps22hb_nano_33_ble.go
@@ -18,5 +18,5 @@ func (d *Device) Configure() {
 	time.Sleep(10 * time.Millisecond)
 
 	// set to block update mode
-	d.bus.WriteRegister(d.Address, LPS22HB_CTRL1_REG, []byte{0x02})
+	legacy.WriteRegister(d.bus, d.Address, LPS22HB_CTRL1_REG, []byte{0x02})
 }

--- a/lsm6ds3/lsm6ds3.go
+++ b/lsm6ds3/lsm6ds3.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
 )
 
 type AccelRange uint8
@@ -95,7 +96,7 @@ func (d *Device) Configure(cfg Configuration) (err error) {
 	if cfg.IsPedometer { // CONFIGURE AS PEDOMETER
 		// Configure accelerometer: 2G + 26Hz
 		data[0] = uint8(ACCEL_2G) | uint8(ACCEL_SR_26)
-		err = d.bus.WriteRegister(uint8(d.Address), CTRL1_XL, data)
+		err = legacy.WriteRegister(d.bus, uint8(d.Address), CTRL1_XL, data)
 		if err != nil {
 			return
 		}
@@ -105,40 +106,40 @@ func (d *Device) Configure(cfg Configuration) (err error) {
 		if cfg.ResetStepCounter {
 			data[0] |= 0x02
 		}
-		err = d.bus.WriteRegister(uint8(d.Address), CTRL10_C, data)
+		err = legacy.WriteRegister(d.bus, uint8(d.Address), CTRL10_C, data)
 		if err != nil {
 			return
 		}
 
 		// Enable pedometer
 		data[0] = 0x40
-		err = d.bus.WriteRegister(uint8(d.Address), TAP_CFG, data)
+		err = legacy.WriteRegister(d.bus, uint8(d.Address), TAP_CFG, data)
 		if err != nil {
 			return
 		}
 	} else { // NORMAL USE
 		// Configure accelerometer
 		data[0] = uint8(d.accelRange) | uint8(d.accelSampleRate) | uint8(d.accelBandWidth)
-		err = d.bus.WriteRegister(uint8(d.Address), CTRL1_XL, data)
+		err = legacy.WriteRegister(d.bus, uint8(d.Address), CTRL1_XL, data)
 		if err != nil {
 			return
 		}
 
 		// Set ODR bit
-		err = d.bus.ReadRegister(uint8(d.Address), CTRL4_C, data)
+		err = legacy.ReadRegister(d.bus, uint8(d.Address), CTRL4_C, data)
 		if err != nil {
 			return
 		}
 		data[0] = data[0] &^ BW_SCAL_ODR_ENABLED
 		data[0] |= BW_SCAL_ODR_ENABLED
-		err = d.bus.WriteRegister(uint8(d.Address), CTRL4_C, data)
+		err = legacy.WriteRegister(d.bus, uint8(d.Address), CTRL4_C, data)
 		if err != nil {
 			return
 		}
 
 		// Configure gyroscope
 		data[0] = uint8(d.gyroRange) | uint8(d.gyroSampleRate)
-		err = d.bus.WriteRegister(uint8(d.Address), CTRL2_G, data)
+		err = legacy.WriteRegister(d.bus, uint8(d.Address), CTRL2_G, data)
 		if err != nil {
 			return
 		}
@@ -151,7 +152,7 @@ func (d *Device) Configure(cfg Configuration) (err error) {
 // It does a "who am I" request and checks the response.
 func (d *Device) Connected() bool {
 	data := d.buf[:1]
-	d.bus.ReadRegister(uint8(d.Address), WHO_AM_I, data)
+	legacy.ReadRegister(d.bus, uint8(d.Address), WHO_AM_I, data)
 	return data[0] == 0x69
 }
 
@@ -161,7 +162,7 @@ func (d *Device) Connected() bool {
 // -1000000.
 func (d *Device) ReadAcceleration() (x, y, z int32, err error) {
 	data := d.buf[:6]
-	err = d.bus.ReadRegister(uint8(d.Address), OUTX_L_XL, data)
+	err = legacy.ReadRegister(d.bus, uint8(d.Address), OUTX_L_XL, data)
 	if err != nil {
 		return
 	}
@@ -186,7 +187,7 @@ func (d *Device) ReadAcceleration() (x, y, z int32, err error) {
 // you would get a value close to 360000000.
 func (d *Device) ReadRotation() (x, y, z int32, err error) {
 	data := d.buf[:6]
-	err = d.bus.ReadRegister(uint8(d.Address), OUTX_L_G, data)
+	err = legacy.ReadRegister(d.bus, uint8(d.Address), OUTX_L_G, data)
 	if err != nil {
 		return
 	}
@@ -210,7 +211,7 @@ func (d *Device) ReadRotation() (x, y, z int32, err error) {
 // ReadTemperature returns the temperature in celsius milli degrees (°C/1000)
 func (d *Device) ReadTemperature() (t int32, err error) {
 	data := d.buf[:2]
-	err = d.bus.ReadRegister(uint8(d.Address), OUT_TEMP_L, data)
+	err = legacy.ReadRegister(d.bus, uint8(d.Address), OUT_TEMP_L, data)
 	if err != nil {
 		return
 	}
@@ -223,7 +224,7 @@ func (d *Device) ReadTemperature() (t int32, err error) {
 // ReadSteps returns the steps of the pedometer
 func (d *Device) ReadSteps() (s int32, err error) {
 	data := d.buf[:2]
-	err = d.bus.ReadRegister(uint8(d.Address), STEP_COUNTER_L, data)
+	err = legacy.ReadRegister(d.bus, uint8(d.Address), STEP_COUNTER_L, data)
 	if err != nil {
 		return
 	}

--- a/lsm6ds3tr/lsm6ds3tr.go
+++ b/lsm6ds3tr/lsm6ds3tr.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
 )
 
 type AccelRange uint8
@@ -87,26 +88,26 @@ func (d *Device) doConfigure(cfg Configuration) (err error) {
 
 	// Configure accelerometer
 	data[0] = uint8(d.accelRange) | uint8(d.accelSampleRate)
-	err = d.bus.WriteRegister(uint8(d.Address), CTRL1_XL, data)
+	err = legacy.WriteRegister(d.bus, uint8(d.Address), CTRL1_XL, data)
 	if err != nil {
 		return
 	}
 
 	// Set ODR bit
-	err = d.bus.ReadRegister(uint8(d.Address), CTRL4_C, data)
+	err = legacy.ReadRegister(d.bus, uint8(d.Address), CTRL4_C, data)
 	if err != nil {
 		return
 	}
 	data[0] = data[0] &^ BW_SCAL_ODR_ENABLED
 	data[0] |= BW_SCAL_ODR_ENABLED
-	err = d.bus.WriteRegister(uint8(d.Address), CTRL4_C, data)
+	err = legacy.WriteRegister(d.bus, uint8(d.Address), CTRL4_C, data)
 	if err != nil {
 		return
 	}
 
 	// Configure gyroscope
 	data[0] = uint8(d.gyroRange) | uint8(d.gyroSampleRate)
-	err = d.bus.WriteRegister(uint8(d.Address), CTRL2_G, data)
+	err = legacy.WriteRegister(d.bus, uint8(d.Address), CTRL2_G, data)
 	if err != nil {
 		return
 	}
@@ -118,7 +119,7 @@ func (d *Device) doConfigure(cfg Configuration) (err error) {
 // It does a "who am I" request and checks the response.
 func (d *Device) Connected() bool {
 	data := d.buf[:1]
-	d.bus.ReadRegister(uint8(d.Address), WHO_AM_I, data)
+	legacy.ReadRegister(d.bus, uint8(d.Address), WHO_AM_I, data)
 	return data[0] == 0x6A
 }
 
@@ -128,7 +129,7 @@ func (d *Device) Connected() bool {
 // -1000000.
 func (d *Device) ReadAcceleration() (x, y, z int32, err error) {
 	data := d.buf[:6]
-	err = d.bus.ReadRegister(uint8(d.Address), OUTX_L_XL, data)
+	err = legacy.ReadRegister(d.bus, uint8(d.Address), OUTX_L_XL, data)
 	if err != nil {
 		return
 	}
@@ -153,7 +154,7 @@ func (d *Device) ReadAcceleration() (x, y, z int32, err error) {
 // you would get a value close to 360000000.
 func (d *Device) ReadRotation() (x, y, z int32, err error) {
 	data := d.buf[:6]
-	err = d.bus.ReadRegister(uint8(d.Address), OUTX_L_G, data)
+	err = legacy.ReadRegister(d.bus, uint8(d.Address), OUTX_L_G, data)
 	if err != nil {
 		return
 	}
@@ -177,7 +178,7 @@ func (d *Device) ReadRotation() (x, y, z int32, err error) {
 // ReadTemperature returns the temperature in celsius milli degrees (°C/1000)
 func (d *Device) ReadTemperature() (t int32, err error) {
 	data := d.buf[:2]
-	err = d.bus.ReadRegister(uint8(d.Address), OUT_TEMP_L, data)
+	err = legacy.ReadRegister(d.bus, uint8(d.Address), OUT_TEMP_L, data)
 	if err != nil {
 		return
 	}

--- a/lsm6dsox/lsm6dsox.go
+++ b/lsm6dsox/lsm6dsox.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
 )
 
 type AccelRange uint8
@@ -78,13 +79,13 @@ func (d *Device) Configure(cfg Configuration) (err error) {
 	data := d.buf[:1]
 	// Configure accelerometer
 	data[0] = uint8(cfg.AccelRange) | uint8(cfg.AccelSampleRate)
-	err = d.bus.WriteRegister(uint8(d.Address), CTRL1_XL, data)
+	err = legacy.WriteRegister(d.bus, uint8(d.Address), CTRL1_XL, data)
 	if err != nil {
 		return
 	}
 	// Configure gyroscope
 	data[0] = uint8(cfg.GyroRange) | uint8(cfg.GyroSampleRate)
-	err = d.bus.WriteRegister(uint8(d.Address), CTRL2_G, data)
+	err = legacy.WriteRegister(d.bus, uint8(d.Address), CTRL2_G, data)
 	if err != nil {
 		return
 	}
@@ -96,7 +97,7 @@ func (d *Device) Configure(cfg Configuration) (err error) {
 // It does a "who am I" request and checks the response.
 func (d *Device) Connected() bool {
 	data := d.buf[:1]
-	d.bus.ReadRegister(uint8(d.Address), WHO_AM_I, data)
+	legacy.ReadRegister(d.bus, uint8(d.Address), WHO_AM_I, data)
 	return data[0] == 0x6C
 }
 
@@ -106,7 +107,7 @@ func (d *Device) Connected() bool {
 // -1000000.
 func (d *Device) ReadAcceleration() (x, y, z int32, err error) {
 	data := d.buf[:6]
-	err = d.bus.ReadRegister(uint8(d.Address), OUTX_L_A, data)
+	err = legacy.ReadRegister(d.bus, uint8(d.Address), OUTX_L_A, data)
 	if err != nil {
 		return
 	}
@@ -122,7 +123,7 @@ func (d *Device) ReadAcceleration() (x, y, z int32, err error) {
 // you would get a value close to 360000000.
 func (d *Device) ReadRotation() (x, y, z int32, err error) {
 	data := d.buf[:6]
-	err = d.bus.ReadRegister(uint8(d.Address), OUTX_L_G, data)
+	err = legacy.ReadRegister(d.bus, uint8(d.Address), OUTX_L_G, data)
 	if err != nil {
 		return
 	}
@@ -135,7 +136,7 @@ func (d *Device) ReadRotation() (x, y, z int32, err error) {
 // ReadTemperature returns the temperature in celsius milli degrees (°C/1000)
 func (d *Device) ReadTemperature() (t int32, err error) {
 	data := d.buf[:2]
-	err = d.bus.ReadRegister(uint8(d.Address), OUT_TEMP_L, data)
+	err = legacy.ReadRegister(d.bus, uint8(d.Address), OUT_TEMP_L, data)
 	if err != nil {
 		return
 	}

--- a/mag3110/mag3110.go
+++ b/mag3110/mag3110.go
@@ -4,7 +4,10 @@
 // Datasheet: https://www.nxp.com/docs/en/data-sheet/MAG3110.pdf
 package mag3110 // import "tinygo.org/x/drivers/mag3110"
 
-import "tinygo.org/x/drivers"
+import (
+	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
+)
 
 // Device wraps an I2C connection to a MAG3110 device.
 type Device struct {
@@ -24,22 +27,22 @@ func New(bus drivers.I2C) Device {
 // It does a "who am I" request and checks the response.
 func (d Device) Connected() bool {
 	data := []byte{0}
-	d.bus.ReadRegister(uint8(d.Address), WHO_AM_I, data)
+	legacy.ReadRegister(d.bus, uint8(d.Address), WHO_AM_I, data)
 	return data[0] == 0xC4
 }
 
 // Configure sets up the device for communication.
 func (d Device) Configure() {
-	d.bus.WriteRegister(uint8(d.Address), CTRL_REG2, []uint8{0x80}) // Power down when not used
+	legacy.WriteRegister(d.bus, uint8(d.Address), CTRL_REG2, []uint8{0x80}) // Power down when not used
 }
 
 // ReadMagnetic reads the vectors of the magnetic field of the device and
 // returns it.
 func (d Device) ReadMagnetic() (x int16, y int16, z int16) {
-	d.bus.WriteRegister(uint8(d.Address), CTRL_REG1, []uint8{0x1a}) // Request a measurement
+	legacy.WriteRegister(d.bus, uint8(d.Address), CTRL_REG1, []uint8{0x1a}) // Request a measurement
 
 	data := make([]byte, 6)
-	d.bus.ReadRegister(uint8(d.Address), OUT_X_MSB, data)
+	legacy.ReadRegister(d.bus, uint8(d.Address), OUT_X_MSB, data)
 	x = int16((uint16(data[0]) << 8) | uint16(data[1]))
 	y = int16((uint16(data[2]) << 8) | uint16(data[3]))
 	z = int16((uint16(data[4]) << 8) | uint16(data[5]))
@@ -50,6 +53,6 @@ func (d Device) ReadMagnetic() (x int16, y int16, z int16) {
 // celsius milli degrees (°C/1000).
 func (d Device) ReadTemperature() (int32, error) {
 	data := make([]byte, 1)
-	d.bus.ReadRegister(uint8(d.Address), DIE_TEMP, data)
+	legacy.ReadRegister(d.bus, uint8(d.Address), DIE_TEMP, data)
 	return int32(data[0]) * 1000, nil
 }

--- a/mcp23017/device.go
+++ b/mcp23017/device.go
@@ -8,6 +8,8 @@ package mcp23017
 
 import (
 	"errors"
+
+	"tinygo.org/x/drivers/internal/legacy"
 )
 
 const (
@@ -259,7 +261,7 @@ func (d *Device) writeRegisterAB(r register, val Pins) error {
 	// and the fact that registers alternate between A and B
 	// to write both ports in a single operation.
 	buf := [2]byte{uint8(val), uint8(val >> 8)}
-	return d.bus.WriteRegister(d.addr, uint8(r&^portB), buf[:])
+	return legacy.WriteRegister(d.bus, d.addr, uint8(r&^portB), buf[:])
 }
 
 func (d *Device) readRegisterAB(r register) (Pins, error) {
@@ -267,7 +269,7 @@ func (d *Device) readRegisterAB(r register) (Pins, error) {
 	// and the fact that registers alternate between A and B
 	// to read both ports in a single operation.
 	var buf [2]byte
-	if err := d.bus.ReadRegister(d.addr, uint8(r), buf[:]); err != nil {
+	if err := legacy.ReadRegister(d.bus, d.addr, uint8(r), buf[:]); err != nil {
 		return Pins(0), err
 	}
 	return Pins(buf[0]) | (Pins(buf[1]) << 8), nil

--- a/mcp23017/device.go
+++ b/mcp23017/device.go
@@ -9,6 +9,7 @@ package mcp23017
 import (
 	"errors"
 
+	"tinygo.org/x/drivers"
 	"tinygo.org/x/drivers/internal/legacy"
 )
 
@@ -77,19 +78,12 @@ const (
 // address pins).
 var ErrInvalidHWAddress = errors.New("invalid hardware address")
 
-// I2C represents an I2C bus. It is notably implemented by the
-// machine.I2C type.
-type I2C interface {
-	ReadRegister(addr uint8, r uint8, buf []byte) error
-	WriteRegister(addr uint8, r uint8, buf []byte) error
-}
-
 // New returns a new MCP23017 device at the given I2C address
 // on the given bus.
 // It returns ErrInvalidHWAddress if the address isn't possible for the device.
 //
 // By default all pins are configured as inputs.
-func NewI2C(bus I2C, address uint8) (*Device, error) {
+func NewI2C(bus drivers.I2C, address uint8) (*Device, error) {
 	if address&hwAddressMask != hwAddress {
 		return nil, ErrInvalidHWAddress
 	}
@@ -117,7 +111,7 @@ type Device struct {
 
 	// bus holds the reference the I2C bus that the device lives on.
 	// It's an interface so that we can write tests for it.
-	bus  I2C
+	bus  drivers.I2C
 	addr uint8
 	// pins caches the most recent pin values that have been set.
 	// This enables us to change individual pin values without

--- a/mcp23017/multidevice.go
+++ b/mcp23017/multidevice.go
@@ -1,5 +1,7 @@
 package mcp23017
 
+import "tinygo.org/x/drivers"
+
 // All is a convenience value that represents all pins high (or all mask bits one).
 var All = PinSlice{0xffff}
 
@@ -12,7 +14,7 @@ type Devices []*Device
 // NewI2CDevices returns a Devices slice holding the Device values
 // for all the given addresses on the given bus.
 // When more than one bus is in use, create the slice yourself.
-func NewI2CDevices(bus I2C, addrs ...uint8) (Devices, error) {
+func NewI2CDevices(bus drivers.I2C, addrs ...uint8) (Devices, error) {
 	devs := make(Devices, len(addrs))
 	for i, addr := range addrs {
 		dev, err := NewI2C(bus, addr)

--- a/mma8653/mma8653.go
+++ b/mma8653/mma8653.go
@@ -5,7 +5,10 @@
 // https://www.nxp.com/docs/en/data-sheet/MMA8653FC.pdf
 package mma8653 // import "tinygo.org/x/drivers/mma8653"
 
-import "tinygo.org/x/drivers"
+import (
+	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
+)
 
 // Device wraps an I2C connection to a MMA8653 device.
 type Device struct {
@@ -26,27 +29,27 @@ func New(bus drivers.I2C) Device {
 // It does a "who am I" request and checks the response.
 func (d Device) Connected() bool {
 	data := []byte{0}
-	d.bus.ReadRegister(uint8(d.Address), WHO_AM_I, data)
+	legacy.ReadRegister(d.bus, uint8(d.Address), WHO_AM_I, data)
 	return data[0] == 0x5A
 }
 
 // Configure sets up the device for communication.
 func (d *Device) Configure(speed DataRate, sensitivity Sensitivity) error {
 	// Set mode to STANDBY to be able to change the sensitivity.
-	err := d.bus.WriteRegister(uint8(d.Address), CTRL_REG1, []uint8{0})
+	err := legacy.WriteRegister(d.bus, uint8(d.Address), CTRL_REG1, []uint8{0})
 	if err != nil {
 		return err
 	}
 
 	// Set sensitivity (2G, 4G, 8G).
-	err = d.bus.WriteRegister(uint8(d.Address), XYZ_DATA_CFG, []uint8{uint8(sensitivity)})
+	err = legacy.WriteRegister(d.bus, uint8(d.Address), XYZ_DATA_CFG, []uint8{uint8(sensitivity)})
 	if err != nil {
 		return err
 	}
 	d.sensitivity = sensitivity
 
 	// Set mode to ACTIVE and set the data rate.
-	err = d.bus.WriteRegister(uint8(d.Address), CTRL_REG1, []uint8{(uint8(speed) << 3) | 1})
+	err = legacy.WriteRegister(d.bus, uint8(d.Address), CTRL_REG1, []uint8{(uint8(speed) << 3) | 1})
 	if err != nil {
 		return err
 	}
@@ -59,7 +62,7 @@ func (d *Device) Configure(speed DataRate, sensitivity Sensitivity) error {
 // -1000000.
 func (d Device) ReadAcceleration() (x int32, y int32, z int32, err error) {
 	data := make([]byte, 6)
-	err = d.bus.ReadRegister(uint8(d.Address), OUT_X_MSB, data)
+	err = legacy.ReadRegister(d.bus, uint8(d.Address), OUT_X_MSB, data)
 	shift := uint32(8)
 	switch d.sensitivity {
 	case Sensitivity4G:

--- a/mpu6050/mpu6050.go
+++ b/mpu6050/mpu6050.go
@@ -6,7 +6,10 @@
 // https://www.invensense.com/wp-content/uploads/2015/02/MPU-6000-Register-Map1.pdf
 package mpu6050 // import "tinygo.org/x/drivers/mpu6050"
 
-import "tinygo.org/x/drivers"
+import (
+	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
+)
 
 // Device wraps an I2C connection to a MPU6050 device.
 type Device struct {
@@ -26,7 +29,7 @@ func New(bus drivers.I2C) Device {
 // It does a "who am I" request and checks the response.
 func (d Device) Connected() bool {
 	data := []byte{0}
-	d.bus.ReadRegister(uint8(d.Address), WHO_AM_I, data)
+	legacy.ReadRegister(d.bus, uint8(d.Address), WHO_AM_I, data)
 	return data[0] == 0x68
 }
 
@@ -41,7 +44,7 @@ func (d Device) Configure() error {
 // -1000000.
 func (d Device) ReadAcceleration() (x int32, y int32, z int32) {
 	data := make([]byte, 6)
-	d.bus.ReadRegister(uint8(d.Address), ACCEL_XOUT_H, data)
+	legacy.ReadRegister(d.bus, uint8(d.Address), ACCEL_XOUT_H, data)
 	// Now do two things:
 	// 1. merge the two values to a 16-bit number (and cast to a 32-bit integer)
 	// 2. scale the value to bring it in the -1000000..1000000 range.
@@ -62,7 +65,7 @@ func (d Device) ReadAcceleration() (x int32, y int32, z int32) {
 // you would get a value close to 360000000.
 func (d Device) ReadRotation() (x int32, y int32, z int32) {
 	data := make([]byte, 6)
-	d.bus.ReadRegister(uint8(d.Address), GYRO_XOUT_H, data)
+	legacy.ReadRegister(d.bus, uint8(d.Address), GYRO_XOUT_H, data)
 	// First the value is converted from a pair of bytes to a signed 16-bit
 	// value and then to a signed 32-bit value to avoid integer overflow.
 	// Then the value is scaled to µ°/s (micro-degrees per second).
@@ -81,15 +84,15 @@ func (d Device) ReadRotation() (x int32, y int32, z int32) {
 
 // SetClockSource allows the user to configure the clock source.
 func (d Device) SetClockSource(source uint8) error {
-	return d.bus.WriteRegister(uint8(d.Address), PWR_MGMT_1, []uint8{source})
+	return legacy.WriteRegister(d.bus, uint8(d.Address), PWR_MGMT_1, []uint8{source})
 }
 
 // SetFullScaleGyroRange allows the user to configure the scale range for the gyroscope.
 func (d Device) SetFullScaleGyroRange(rng uint8) error {
-	return d.bus.WriteRegister(uint8(d.Address), GYRO_CONFIG, []uint8{rng})
+	return legacy.WriteRegister(d.bus, uint8(d.Address), GYRO_CONFIG, []uint8{rng})
 }
 
 // SetFullScaleAccelRange allows the user to configure the scale range for the accelerometer.
 func (d Device) SetFullScaleAccelRange(rng uint8) error {
-	return d.bus.WriteRegister(uint8(d.Address), ACCEL_CONFIG, []uint8{rng})
+	return legacy.WriteRegister(d.bus, uint8(d.Address), ACCEL_CONFIG, []uint8{rng})
 }

--- a/pca9685/io.go
+++ b/pca9685/io.go
@@ -1,9 +1,11 @@
 package pca9685
 
+import "tinygo.org/x/drivers/internal/legacy"
+
 func (d *Dev) readReg(reg uint8, data []byte) error {
-	return d.bus.ReadRegister(d.addr, reg, data)
+	return legacy.ReadRegister(d.bus, d.addr, reg, data)
 }
 
 func (d *Dev) writeReg(reg uint8, data []byte) error {
-	return d.bus.WriteRegister(d.addr, reg, data)
+	return legacy.WriteRegister(d.bus, d.addr, reg, data)
 }

--- a/qmi8658c/qmi8658c.go
+++ b/qmi8658c/qmi8658c.go
@@ -5,7 +5,10 @@
 // https://www.qstcorp.com/upload/pdf/202202/%EF%BC%88%E5%B7%B2%E4%BC%A0%EF%BC%89QMI8658C%20datasheet%20rev%200.9.pdf
 package qmi8656c
 
-import "tinygo.org/x/drivers"
+import (
+	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
+)
 
 // Device wraps the I2C connection to the QMIC8658 sensor
 type Device struct {
@@ -179,12 +182,12 @@ func (d *Device) ReadTemperature() (int32, error) {
 
 // Convenience method to read the register and avoid repetition.
 func (d *Device) ReadRegister(reg uint8, buf []byte) error {
-	return d.bus.ReadRegister(uint8(d.Address), reg, buf)
+	return legacy.ReadRegister(d.bus, uint8(d.Address), reg, buf)
 }
 
 // Convenience method to write the register and avoid repetition.
 func (d *Device) WriteRegister(reg uint8, v uint16) error {
 	data := []byte{byte(v)}
-	err := d.bus.WriteRegister(uint8(d.Address), reg, data)
+	err := legacy.WriteRegister(d.bus, uint8(d.Address), reg, data)
 	return err
 }

--- a/tester/device.go
+++ b/tester/device.go
@@ -5,10 +5,10 @@ const MaxRegisters = 255
 
 type I2CDevice interface {
 	// ReadRegister implements I2C.ReadRegister.
-	ReadRegister(r uint8, buf []byte) error
+	readRegister(r uint8, buf []byte) error
 
 	// WriteRegister implements I2C.WriteRegister.
-	WriteRegister(r uint8, buf []byte) error
+	writeRegister(r uint8, buf []byte) error
 
 	// Tx implements I2C.Tx
 	Tx(w, r []byte) error

--- a/tester/device16.go
+++ b/tester/device16.go
@@ -33,7 +33,7 @@ func (d *I2CDevice16) Addr() uint8 {
 }
 
 // ReadRegister implements I2C.ReadRegister.
-func (d *I2CDevice16) ReadRegister(r uint8, buf []byte) error {
+func (d *I2CDevice16) readRegister(r uint8, buf []byte) error {
 	if d.Err != nil {
 		return d.Err
 	}
@@ -54,7 +54,7 @@ func (d *I2CDevice16) ReadRegister(r uint8, buf []byte) error {
 }
 
 // WriteRegister implements I2C.WriteRegister.
-func (d *I2CDevice16) WriteRegister(r uint8, buf []byte) error {
+func (d *I2CDevice16) writeRegister(r uint8, buf []byte) error {
 	if d.Err != nil {
 		return d.Err
 	}
@@ -80,11 +80,11 @@ func (bus *I2CDevice16) Tx(w, r []byte) error {
 		bus.c.Fatalf("i2c mock: need a write byte")
 		return nil
 	case 1:
-		return bus.ReadRegister(w[0], r)
+		return bus.readRegister(w[0], r)
 	default:
 		if len(r) > 0 || len(w) == 1 {
 			bus.c.Fatalf("i2c mock: unsupported lengths in Tx(%d, %d)", len(w), len(r))
 		}
-		return bus.WriteRegister(w[0], w[1:])
+		return bus.writeRegister(w[0], w[1:])
 	}
 }

--- a/tester/device16.go
+++ b/tester/device16.go
@@ -75,6 +75,16 @@ func (d *I2CDevice16) WriteRegister(r uint8, buf []byte) error {
 
 // Tx implements I2C.Tx.
 func (bus *I2CDevice16) Tx(w, r []byte) error {
-	// TODO: implement this
-	return nil
+	switch len(w) {
+	case 0:
+		bus.c.Fatalf("i2c mock: need a write byte")
+		return nil
+	case 1:
+		return bus.ReadRegister(w[0], r)
+	default:
+		if len(r) > 0 || len(w) == 1 {
+			bus.c.Fatalf("i2c mock: unsupported lengths in Tx(%d, %d)", len(w), len(r))
+		}
+		return bus.WriteRegister(w[0], w[1:])
+	}
 }

--- a/tester/device8.go
+++ b/tester/device8.go
@@ -38,6 +38,9 @@ func (d *I2CDevice8) ReadRegister(r uint8, buf []byte) error {
 	if d.Err != nil {
 		return d.Err
 	}
+	if len(buf) == 0 {
+		d.c.Fatalf("no register buffer to read into")
+	}
 	d.assertRegisterRange(r, buf)
 	copy(buf, d.Registers[r:])
 	return nil
@@ -55,8 +58,18 @@ func (d *I2CDevice8) WriteRegister(r uint8, buf []byte) error {
 
 // Tx implements I2C.Tx.
 func (bus *I2CDevice8) Tx(w, r []byte) error {
-	// TODO: implement this
-	return nil
+	switch len(w) {
+	case 0:
+		bus.c.Fatalf("i2c mock: need a write byte")
+		return nil
+	case 1:
+		return bus.ReadRegister(w[0], r)
+	default:
+		if len(r) > 0 || len(w) == 1 {
+			bus.c.Fatalf("i2c mock: unsupported lengths in Tx(%d, %d)", len(w), len(r))
+		}
+		return bus.WriteRegister(w[0], w[1:])
+	}
 }
 
 // assertRegisterRange asserts that reading or writing the given

--- a/tester/device8.go
+++ b/tester/device8.go
@@ -34,7 +34,7 @@ func (d *I2CDevice8) Addr() uint8 {
 }
 
 // ReadRegister implements I2C.ReadRegister.
-func (d *I2CDevice8) ReadRegister(r uint8, buf []byte) error {
+func (d *I2CDevice8) readRegister(r uint8, buf []byte) error {
 	if d.Err != nil {
 		return d.Err
 	}
@@ -47,7 +47,7 @@ func (d *I2CDevice8) ReadRegister(r uint8, buf []byte) error {
 }
 
 // WriteRegister implements I2C.WriteRegister.
-func (d *I2CDevice8) WriteRegister(r uint8, buf []byte) error {
+func (d *I2CDevice8) writeRegister(r uint8, buf []byte) error {
 	if d.Err != nil {
 		return d.Err
 	}
@@ -63,12 +63,12 @@ func (bus *I2CDevice8) Tx(w, r []byte) error {
 		bus.c.Fatalf("i2c mock: need a write byte")
 		return nil
 	case 1:
-		return bus.ReadRegister(w[0], r)
+		return bus.readRegister(w[0], r)
 	default:
 		if len(r) > 0 || len(w) == 1 {
 			bus.c.Fatalf("i2c mock: unsupported lengths in Tx(%d, %d)", len(w), len(r))
 		}
-		return bus.WriteRegister(w[0], w[1:])
+		return bus.writeRegister(w[0], w[1:])
 	}
 }
 

--- a/tester/devicecmd.go
+++ b/tester/devicecmd.go
@@ -50,7 +50,7 @@ func (d *I2CDeviceCmd) Addr() uint8 {
 }
 
 // ReadRegister implements I2C.ReadRegister.
-func (d *I2CDeviceCmd) ReadRegister(r uint8, buf []byte) error {
+func (d *I2CDeviceCmd) readRegister(r uint8, buf []byte) error {
 	if d.Err != nil {
 		return d.Err
 	}
@@ -59,7 +59,7 @@ func (d *I2CDeviceCmd) ReadRegister(r uint8, buf []byte) error {
 }
 
 // WriteRegister implements I2C.WriteRegister.
-func (d *I2CDeviceCmd) WriteRegister(r uint8, buf []byte) error {
+func (d *I2CDeviceCmd) writeRegister(r uint8, buf []byte) error {
 	if d.Err != nil {
 		return d.Err
 	}

--- a/tester/i2c.go
+++ b/tester/i2c.go
@@ -38,12 +38,12 @@ func (bus *I2CBus) NewDevice(addr uint8) *I2CDevice8 {
 
 // ReadRegister implements I2C.ReadRegister.
 func (bus *I2CBus) ReadRegister(addr uint8, r uint8, buf []byte) error {
-	return bus.FindDevice(addr).ReadRegister(r, buf)
+	return bus.FindDevice(addr).readRegister(r, buf)
 }
 
 // WriteRegister implements I2C.WriteRegister.
 func (bus *I2CBus) WriteRegister(addr uint8, r uint8, buf []byte) error {
-	return bus.FindDevice(addr).WriteRegister(r, buf)
+	return bus.FindDevice(addr).writeRegister(r, buf)
 }
 
 // Tx implements I2C.Tx.

--- a/tmp102/tmp102.go
+++ b/tmp102/tmp102.go
@@ -4,7 +4,10 @@
 
 package tmp102 // import "tinygo.org/x/drivers/tmp102"
 
-import "tinygo.org/x/drivers"
+import (
+	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
+)
 
 // Device holds the already configured I2C bus and the address of the sensor.
 type Device struct {
@@ -36,7 +39,7 @@ func (d *Device) Configure(cfg Config) {
 // Connected checks if the config register can be read and that the configuration is correct.
 func (d *Device) Connected() bool {
 	configData := make([]byte, 2)
-	err := d.bus.ReadRegister(d.address, RegConfiguration, configData)
+	err := legacy.ReadRegister(d.bus, d.address, RegConfiguration, configData)
 	// Check the reset configuration values.
 	if err != nil || configData[0] != 0x60 || configData[1] != 0xA0 {
 		return false
@@ -50,7 +53,7 @@ func (d *Device) ReadTemperature() (temperature int32, err error) {
 
 	tmpData := make([]byte, 2)
 
-	err = d.bus.ReadRegister(d.address, RegTemperature, tmpData)
+	err = legacy.ReadRegister(d.bus, d.address, RegTemperature, tmpData)
 
 	if err != nil {
 		return


### PR DESCRIPTION
Resolves #559. So I managed to pull this off because all usages of the I2C type were VERY consistent, so props to the tinygo developers!