### PR TITLE
st7789: fix incorrect Rotation configuration

### DIFF
--- a/st7789/st7789.go
+++ b/st7789/st7789.go
@@ -474,20 +474,20 @@ func (d *Device) setRotation(rotation Rotation) error {
 	madctl := uint8(0)
 	switch rotation % 4 {
 	case drivers.Rotation0:
-		madctl = MADCTL_MX | MADCTL_MY
-		d.rowOffset = d.rowOffsetCfg
-		d.columnOffset = d.columnOffsetCfg
-	case drivers.Rotation90:
-		madctl = MADCTL_MY | MADCTL_MV
-		d.rowOffset = d.columnOffsetCfg
-		d.columnOffset = d.rowOffsetCfg
-	case drivers.Rotation180:
 		d.rowOffset = 0
 		d.columnOffset = 0
-	case drivers.Rotation270:
+	case drivers.Rotation90:
 		madctl = MADCTL_MX | MADCTL_MV
 		d.rowOffset = 0
 		d.columnOffset = 0
+	case drivers.Rotation180:
+		madctl = MADCTL_MX | MADCTL_MY
+		d.rowOffset = d.rowOffsetCfg
+		d.columnOffset = d.columnOffsetCfg
+	case drivers.Rotation270:
+		madctl = MADCTL_MY | MADCTL_MV
+		d.rowOffset = d.columnOffsetCfg
+		d.columnOffset = d.rowOffsetCfg
 	}
 	if d.isBGR {
 		madctl |= MADCTL_BGR


### PR DESCRIPTION
The rotation as configured using st7789.Config was rotated 180°: 0° was configured as 180°, 90° was configured as 270°, etc. Presumably with the original test display, the ribbon cable was seen as the top of the screen while if you look at product photos it is usually at the bottom.
Example: https://www.buydisplay.com/wide-angle-1-3-inch-240x240-color-ips-tft-display-st7789-controller
Only Adafruit seems to sell these displays with the ribbon at the top: https://www.adafruit.com/product/3787

This patch fixes this mistake. It should be noted that this is backwards incompatible: all code that uses a st7789 will have to be modified to use the correct rotation instead of the previous incorrect rotation.

If this is too big of a change, we could just keep things as-is and pretend that all displays are upside down.

Also see: https://github.com/tinygo-org/drivers/issues/573#issuecomment-1593446268