### PR TITLE
st7789: fix scrolling when rotated by 180°

### DIFF
--- a/st7789/st7789.go
+++ b/st7789/st7789.go
@@ -558,7 +558,13 @@ func (d *Device) SetScrollArea(topFixedArea, bottomFixedArea int16) {
 		// The screen doesn't use the full 320 pixel height.
 		// Enlarge the bottom fixed area to fill the 320 pixel height, so that
 		// bottomFixedArea starts from the visible bottom of the screen.
-		bottomFixedArea += 320 - d.height
+		topFixedArea += d.rowOffset
+		bottomFixedArea += (320 - d.height) - d.rowOffset
+	}
+	if d.rotation == drivers.Rotation180 {
+		// The screen is rotated by 180°, so we have to switch the top and
+		// bottom fixed area.
+		topFixedArea, bottomFixedArea = bottomFixedArea, topFixedArea
 	}
 	verticalScrollArea := 320 - topFixedArea - bottomFixedArea
 	copy(d.buf[:6], []uint8{
@@ -572,6 +578,11 @@ func (d *Device) SetScrollArea(topFixedArea, bottomFixedArea int16) {
 
 // SetScroll sets the vertical scroll address of the display.
 func (d *Device) SetScroll(line int16) {
+	if d.rotation == drivers.Rotation180 {
+		// The screen is rotated by 180°, so we have to invert the scroll line
+		// (taking care of the RowOffset).
+		line = (319 - d.rowOffset) - line
+	}
 	d.buf[0] = uint8(line >> 8)
 	d.buf[1] = uint8(line)
 	d.startWrite()


### PR DESCRIPTION
This fixes https://github.com/tinygo-org/drivers/issues/573.
It doesn't handle 90° or 270°, I guess it needs a fix for 270° but I haven't tested that so didn't include it in the patch.

Tested on my PineTime on top of the current dev branch and it works in both 0° and 180° while previously it would only work with 180°.

Note that with this patch, the behavior matches the ili9341 driver, which appears to do exactly this in hardware (but the st7789 apparently doesn't).