### PR TITLE
Fix i2c legacy calls

### DIFF
--- a/as560x/i2c_register.go
+++ b/as560x/i2c_register.go
@@ -159,7 +159,7 @@ func (r *i2cRegister) write(bus drivers.I2C, deviceAddress uint8, value uint16) 
 	}
 
 	// Write the register from the buffer over I2C
-	err := bus.WriteRegister(deviceAddress, r.host.address, buf)
+	err := legacy.WriteRegister(bus, deviceAddress, r.host.address, buf)
 	// after successful I2C write, cache this value if the host register (if also readable)
 	// Note we cache the entire buffer without applying shift/mask
 	if nil == err && r.host.attributes&reg_read != 0 {

--- a/lps22hb/lps22hb_nano_33_ble.go
+++ b/lps22hb/lps22hb_nano_33_ble.go
@@ -5,6 +5,8 @@ package lps22hb
 import (
 	"machine"
 	"time"
+
+	"tinygo.org/x/drivers/internal/legacy"
 )
 
 // Configure sets up the LPS22HB device for communication.

--- a/ssd1306/ssd1306.go
+++ b/ssd1306/ssd1306.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
 )
 
 // Device wraps I2C or SPI connection.
@@ -277,9 +278,9 @@ func (d *Device) Tx(data []byte, isCommand bool) {
 // tx sends data to the display (I2CBus implementation)
 func (b *I2CBus) tx(data []byte, isCommand bool) {
 	if isCommand {
-		b.wire.WriteRegister(uint8(b.Address), 0x00, data)
+		legacy.WriteRegister(b.wire, uint8(b.Address), 0x00, data)
 	} else {
-		b.wire.WriteRegister(uint8(b.Address), 0x40, data)
+		legacy.WriteRegister(b.wire, uint8(b.Address), 0x40, data)
 	}
 }
 


### PR DESCRIPTION
Fix some uses of I2C WriteRegister that were causing `make test` to fail.  (Side note: looks like CI isn't running `make test`)