### PR TITLE
build: use latest tag of tinygo-dev container for running tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ghcr.io/tinygo-org/tinygo-dev
+    container: ghcr.io/tinygo-org/tinygo-dev:latest
     steps:
       - name: Work around CVE-2022-24765
         # We're not on a multi-user machine, so this is safe.


### PR DESCRIPTION
This PR specifies the `latest` tag of the `tinygo-dev` container image for running tests.