### PR TITLE
Sensirion Sht4x Support 

### DIFF
--- a/examples/sht4x/main.go
+++ b/examples/sht4x/main.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	machine.I2C0.Configure(machine.I2CConfig{})
-	sensor := sht4x.New(machine.I2C0, sht4x.DefaultAddress)
+	sensor := sht4x.New(machine.I2C0)
 
 	for {
 		temp, humidity, _ := sensor.ReadTemperatureHumidity()

--- a/examples/sht4x/main.go
+++ b/examples/sht4x/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"machine"
+	"time"
+
+	"tinygo.org/x/drivers/sht4x"
+)
+
+func main() {
+	machine.I2C0.Configure(machine.I2CConfig{})
+	sensor := sht4x.New(machine.I2C0, sht4x.DefaultAddress)
+
+	for {
+		temp, humidity, _ := sensor.ReadTemperatureHumidity()
+		t := fmt.Sprintf("%.2f", float32(temp)/1000)
+		h := fmt.Sprintf("%.2f", float32(humidity)/100)
+		println("Temperature: ", t, "°C")
+		println("Humidity:    ", h, "%")
+		time.Sleep(2 * time.Second)
+	}
+}

--- a/sht4x/sht4x.go
+++ b/sht4x/sht4x.go
@@ -1,0 +1,79 @@
+// Package sht4x provides a driver for the SHT4x digital humidity sensor series by Sensirion.
+// Datasheet: https://www.sensirion.com/media/documents/33FD6951/64D3B030/Sensirion_Datasheet_SHT4x.pdf
+package sht4x
+
+import (
+	"time"
+
+	"tinygo.org/x/drivers"
+)
+
+const DefaultAddress = 0x44
+
+const (
+	// single-shot, high-repeatability measurement
+	commandMeasurement = 0xfd
+)
+
+// Device represents a SHT4x sensor
+type Device struct {
+	bus     drivers.I2C
+	address uint8
+}
+
+// New creates a new SHT4x connection. The I2C bus must already be
+// configured.
+func New(bus drivers.I2C, addr uint8) Device {
+	if addr == 0 {
+		addr = DefaultAddress
+	}
+	return Device{
+		bus:     bus,
+		address: addr,
+	}
+}
+
+// ReadTemperatureHumidity starts a measurement and then reads out the results. This function blocks
+// while the measurement is in progress.
+//
+// Temperature is returned in [degree Celsius], multiplied by 1000,
+// and relative humidity in [percent relative humidity], multiplied by 1000.
+func (d *Device) ReadTemperatureHumidity() (temperatureMilliCelsius int32, relativeHumidityMilliPercent int32, err error) {
+	rawTemp, rawHum, err := d.rawReadings()
+	if err != nil {
+		return 0, 0, err
+	}
+
+	// from the reference driver: https://github.com/Sensirion/embedded-sht/blob/fcc8a523210cc1241a2750899ff6b0f68f3ed212/sht4x/sht4x.c#L81
+	temperatureMilliCelsius = ((21875 * int32(rawTemp)) >> 13) - 45000
+	relativeHumidityMilliPercent = ((15625 * int32(rawHum)) >> 13) - 6000
+
+	return temperatureMilliCelsius, relativeHumidityMilliPercent, err
+}
+
+// rawReadings returns the sensor's raw values of the temperature and humidity
+func (d *Device) rawReadings() (uint16, uint16, error) {
+	err := d.bus.Tx(uint16(d.address), []byte{commandMeasurement}, nil)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	// max time for measurement according to datasheet
+	time.Sleep(10 * time.Millisecond)
+
+	var data [6]byte
+	err = d.bus.Tx(uint16(d.address), nil, data[:])
+	if err != nil {
+		return 0, 0, err
+	}
+
+	tTicks := readUint(data[0], data[1])
+	rhTicks := readUint(data[3], data[4])
+
+	return tTicks, rhTicks, nil
+}
+
+// readUint converts two bytes to uint16
+func readUint(msb byte, lsb byte) uint16 {
+	return (uint16(msb) << 8) | uint16(lsb)
+}

--- a/sht4x/sht4x.go
+++ b/sht4x/sht4x.go
@@ -18,18 +18,15 @@ const (
 // Device represents a SHT4x sensor
 type Device struct {
 	bus     drivers.I2C
-	address uint8
+	Address uint8
 }
 
 // New creates a new SHT4x connection. The I2C bus must already be
 // configured.
-func New(bus drivers.I2C, addr uint8) Device {
-	if addr == 0 {
-		addr = DefaultAddress
-	}
+func New(bus drivers.I2C) Device {
 	return Device{
 		bus:     bus,
-		address: addr,
+		Address: DefaultAddress,
 	}
 }
 
@@ -53,7 +50,7 @@ func (d *Device) ReadTemperatureHumidity() (temperatureMilliCelsius int32, relat
 
 // rawReadings returns the sensor's raw values of the temperature and humidity
 func (d *Device) rawReadings() (uint16, uint16, error) {
-	err := d.bus.Tx(uint16(d.address), []byte{commandMeasurement}, nil)
+	err := d.bus.Tx(uint16(d.Address), []byte{commandMeasurement}, nil)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -62,7 +59,7 @@ func (d *Device) rawReadings() (uint16, uint16, error) {
 	time.Sleep(10 * time.Millisecond)
 
 	var data [6]byte
-	err = d.bus.Tx(uint16(d.address), nil, data[:])
+	err = d.bus.Tx(uint16(d.Address), nil, data[:])
 	if err != nil {
 		return 0, 0, err
 	}

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -63,6 +63,7 @@ tinygo build -size short -o ./build/test.hex -target=microbit ./examples/pcd8544
 tinygo build -size short -o ./build/test.hex -target=arduino ./examples/servo
 tinygo build -size short -o ./build/test.hex -target=pybadge ./examples/shifter/main.go
 tinygo build -size short -o ./build/test.hex -target=microbit ./examples/sht3x/main.go
+tinygo build -size short -o ./build/test.hex -target=microbit ./examples/sht4x/main.go
 tinygo build -size short -o ./build/test.hex -target=microbit ./examples/shtc3/main.go
 tinygo build -size short -o ./build/test.hex -target=microbit ./examples/ssd1306/i2c_128x32/main.go
 tinygo build -size short -o ./build/test.hex -target=microbit ./examples/ssd1306/spi_128x64/main.go


### PR DESCRIPTION
Support for the SHT4x family of humidity & temperature sensors from Sensirion.

I've tried to keep the interface aligned with the existing SHT3x driver where it made sense but kept it
simple.