### PR TITLE
all: prepare for CGo changes in TinyGo

### DIFF
--- a/delay/sleep.go
+++ b/delay/sleep.go
@@ -49,7 +49,7 @@ func Sleep(duration time.Duration) {
 	//   * The CPU frequency is lower than 256MHz. If it is higher, long sleep
 	//     times (1-16ms) may not work correctly.
 	cycles := uint32(duration) * (machine.CPUFrequency() / 1000_000) / 1000
-	slept := C.tinygo_drivers_sleep(cycles)
+	slept := C.tinygo_drivers_sleep(C.uint32_t(cycles))
 	if !slept {
 		// Fallback for platforms without inline assembly support.
 		time.Sleep(duration)

--- a/ws2812/gen-ws2812.go
+++ b/ws2812/gen-ws2812.go
@@ -251,7 +251,7 @@ func writeGoWrapper(f *os.File, arch string, megahertz int) error {
 	fmt.Fprintf(buf, "	portClear, maskClear := d.Pin.PortMaskClear()\n")
 	fmt.Fprintf(buf, "\n")
 	fmt.Fprintf(buf, "	mask := interrupt.Disable()\n")
-	fmt.Fprintf(buf, "	C.ws2812_writeByte%d(C.char(c), (*uint32)(unsafe.Pointer(portSet)), (*uint32)(unsafe.Pointer(portClear)), maskSet, maskClear)\n", megahertz)
+	fmt.Fprintf(buf, "	C.ws2812_writeByte%d(C.char(c), (*C.uint32_t)(unsafe.Pointer(portSet)), (*C.uint32_t)(unsafe.Pointer(portClear)), C.uint32_t(maskSet), C.uint32_t(maskClear))\n", megahertz)
 	buf.WriteString(`
 	interrupt.Restore(mask)
 }

--- a/ws2812/ws2812-asm_cortexm.go
+++ b/ws2812/ws2812-asm_cortexm.go
@@ -1328,7 +1328,7 @@ func (d Device) writeByte16(c byte) {
 	portClear, maskClear := d.Pin.PortMaskClear()
 
 	mask := interrupt.Disable()
-	C.ws2812_writeByte16(C.char(c), (*uint32)(unsafe.Pointer(portSet)), (*uint32)(unsafe.Pointer(portClear)), maskSet, maskClear)
+	C.ws2812_writeByte16(C.char(c), (*C.uint32_t)(unsafe.Pointer(portSet)), (*C.uint32_t)(unsafe.Pointer(portClear)), C.uint32_t(maskSet), C.uint32_t(maskClear))
 
 	interrupt.Restore(mask)
 }
@@ -1338,7 +1338,7 @@ func (d Device) writeByte48(c byte) {
 	portClear, maskClear := d.Pin.PortMaskClear()
 
 	mask := interrupt.Disable()
-	C.ws2812_writeByte48(C.char(c), (*uint32)(unsafe.Pointer(portSet)), (*uint32)(unsafe.Pointer(portClear)), maskSet, maskClear)
+	C.ws2812_writeByte48(C.char(c), (*C.uint32_t)(unsafe.Pointer(portSet)), (*C.uint32_t)(unsafe.Pointer(portClear)), C.uint32_t(maskSet), C.uint32_t(maskClear))
 
 	interrupt.Restore(mask)
 }
@@ -1348,7 +1348,7 @@ func (d Device) writeByte64(c byte) {
 	portClear, maskClear := d.Pin.PortMaskClear()
 
 	mask := interrupt.Disable()
-	C.ws2812_writeByte64(C.char(c), (*uint32)(unsafe.Pointer(portSet)), (*uint32)(unsafe.Pointer(portClear)), maskSet, maskClear)
+	C.ws2812_writeByte64(C.char(c), (*C.uint32_t)(unsafe.Pointer(portSet)), (*C.uint32_t)(unsafe.Pointer(portClear)), C.uint32_t(maskSet), C.uint32_t(maskClear))
 
 	interrupt.Restore(mask)
 }
@@ -1358,7 +1358,7 @@ func (d Device) writeByte120(c byte) {
 	portClear, maskClear := d.Pin.PortMaskClear()
 
 	mask := interrupt.Disable()
-	C.ws2812_writeByte120(C.char(c), (*uint32)(unsafe.Pointer(portSet)), (*uint32)(unsafe.Pointer(portClear)), maskSet, maskClear)
+	C.ws2812_writeByte120(C.char(c), (*C.uint32_t)(unsafe.Pointer(portSet)), (*C.uint32_t)(unsafe.Pointer(portClear)), C.uint32_t(maskSet), C.uint32_t(maskClear))
 
 	interrupt.Restore(mask)
 }
@@ -1368,7 +1368,7 @@ func (d Device) writeByte125(c byte) {
 	portClear, maskClear := d.Pin.PortMaskClear()
 
 	mask := interrupt.Disable()
-	C.ws2812_writeByte125(C.char(c), (*uint32)(unsafe.Pointer(portSet)), (*uint32)(unsafe.Pointer(portClear)), maskSet, maskClear)
+	C.ws2812_writeByte125(C.char(c), (*C.uint32_t)(unsafe.Pointer(portSet)), (*C.uint32_t)(unsafe.Pointer(portClear)), C.uint32_t(maskSet), C.uint32_t(maskClear))
 
 	interrupt.Restore(mask)
 }
@@ -1378,7 +1378,7 @@ func (d Device) writeByte168(c byte) {
 	portClear, maskClear := d.Pin.PortMaskClear()
 
 	mask := interrupt.Disable()
-	C.ws2812_writeByte168(C.char(c), (*uint32)(unsafe.Pointer(portSet)), (*uint32)(unsafe.Pointer(portClear)), maskSet, maskClear)
+	C.ws2812_writeByte168(C.char(c), (*C.uint32_t)(unsafe.Pointer(portSet)), (*C.uint32_t)(unsafe.Pointer(portClear)), C.uint32_t(maskSet), C.uint32_t(maskClear))
 
 	interrupt.Restore(mask)
 }

--- a/ws2812/ws2812-asm_tinygoriscv.go
+++ b/ws2812/ws2812-asm_tinygoriscv.go
@@ -1114,7 +1114,7 @@ func (d Device) writeByte160(c byte) {
 	portClear, maskClear := d.Pin.PortMaskClear()
 
 	mask := interrupt.Disable()
-	C.ws2812_writeByte160(C.char(c), (*uint32)(unsafe.Pointer(portSet)), (*uint32)(unsafe.Pointer(portClear)), maskSet, maskClear)
+	C.ws2812_writeByte160(C.char(c), (*C.uint32_t)(unsafe.Pointer(portSet)), (*C.uint32_t)(unsafe.Pointer(portClear)), C.uint32_t(maskSet), C.uint32_t(maskClear))
 
 	interrupt.Restore(mask)
 }
@@ -1124,7 +1124,7 @@ func (d Device) writeByte320(c byte) {
 	portClear, maskClear := d.Pin.PortMaskClear()
 
 	mask := interrupt.Disable()
-	C.ws2812_writeByte320(C.char(c), (*uint32)(unsafe.Pointer(portSet)), (*uint32)(unsafe.Pointer(portClear)), maskSet, maskClear)
+	C.ws2812_writeByte320(C.char(c), (*C.uint32_t)(unsafe.Pointer(portSet)), (*C.uint32_t)(unsafe.Pointer(portClear)), C.uint32_t(maskSet), C.uint32_t(maskClear))
 
 	interrupt.Restore(mask)
 }

--- a/ws2812/ws2812_avr.go
+++ b/ws2812/ws2812_avr.go
@@ -60,7 +60,7 @@ func (d Device) WriteByte(c byte) error {
 
 	switch machine.CPUFrequency() {
 	case 16e6: // 16MHz
-		C.ws2812_writeByte16(C.char(c), (*uint8)(unsafe.Pointer(port)), maskSet, maskClear)
+		C.ws2812_writeByte16(C.char(c), (*C.uint8_t)(unsafe.Pointer(port)), C.uint8_t(maskSet), C.uint8_t(maskClear))
 		interrupt.Restore(mask)
 		return nil
 	default:


### PR DESCRIPTION
For details, see: https://github.com/tinygo-org/tinygo/pull/3927

This change just means we need to be more careful to use the right type, when types like C.uint32_t won't match to the Go equivalent (like uint32).