### PR TITLE
added support for SK6812 to WS2812 device

### DIFF
--- a/examples/ws2812/main.go
+++ b/examples/ws2812/main.go
@@ -19,7 +19,7 @@ func main() {
 
 	neo.Configure(machine.PinConfig{Mode: machine.PinOutput})
 
-	ws := ws2812.New(neo)
+	ws := ws2812.New(neo, ws2812.WS2812)
 	rg := false
 
 	for {

--- a/examples/ws2812/main.go
+++ b/examples/ws2812/main.go
@@ -19,7 +19,7 @@ func main() {
 
 	neo.Configure(machine.PinConfig{Mode: machine.PinOutput})
 
-	ws := ws2812.New(neo, ws2812.WS2812)
+	ws := ws2812.NewWS2812(neo)
 	rg := false
 
 	for {

--- a/ws2812/ws2812.go
+++ b/ws2812/ws2812.go
@@ -26,7 +26,7 @@ type Device struct {
 }
 
 // deprecated, use NewWS2812 or NewSK6812 depending on which device you want.
-// calls NewWS2812() to avoid breaking everyone's existing code. 
+// calls NewWS2812() to avoid breaking everyone's existing code.
 func New(pin machine.Pin) Device {
 	return NewWS2812(pin)
 }

--- a/ws2812/ws2812.go
+++ b/ws2812/ws2812.go
@@ -12,15 +12,27 @@ import (
 
 var errUnknownClockSpeed = errors.New("ws2812: unknown CPU clock speed")
 
+type DeviceType uint8
+
+const (
+	WS2812 DeviceType = iota // RGB
+	SK6812                   // RGBA / RGBW
+)
+
 // Device wraps a pin object for an easy driver interface.
 type Device struct {
-	Pin machine.Pin
+	Pin        machine.Pin
+	DeviceType DeviceType
 }
 
 // New returns a new WS2812 driver. It does not touch the pin object: you have
 // to configure it as an output pin before calling New.
-func New(pin machine.Pin) Device {
-	return Device{pin}
+// WS2812 is for RGB, SK6812 is for RGBA
+func New(pin machine.Pin, deviceType DeviceType) Device {
+	return Device{
+		Pin:        pin,
+		DeviceType: deviceType,
+	}
 }
 
 // Write the raw bitstring out using the WS2812 protocol.
@@ -32,12 +44,32 @@ func (d Device) Write(buf []byte) (n int, err error) {
 }
 
 // Write the given color slice out using the WS2812 protocol.
-// Colors are sent out in the usual GRB format.
-func (d Device) WriteColors(buf []color.RGBA) error {
-	for _, color := range buf {
-		d.WriteByte(color.G) // green
-		d.WriteByte(color.R) // red
-		d.WriteByte(color.B) // blue
+// Colors are sent out in the usual GRB(A) format.
+func (d Device) WriteColors(buf []color.RGBA) (err error) {
+	switch d.DeviceType {
+	case WS2812:
+		err = d.writeColorsRGB(buf)
+	case SK6812:
+		err = d.writeColorsRGBA(buf)
 	}
-	return nil
+	return
+}
+
+func (d Device) writeColorsRGB(buf []color.RGBA) (err error) {
+	for _, color := range buf {
+		d.WriteByte(color.G)       // green
+		d.WriteByte(color.R)       // red
+		err = d.WriteByte(color.B) // blue
+	}
+	return
+}
+
+func (d Device) writeColorsRGBA(buf []color.RGBA) (err error) {
+	for _, color := range buf {
+		d.WriteByte(color.G)       // green
+		d.WriteByte(color.R)       // red
+		d.WriteByte(color.B)       // blue
+		err = d.WriteByte(color.A) // alpha
+	}
+	return
 }


### PR DESCRIPTION
Adds support for SK6812 (RGBA) LEDs to WS2812 device.

PR for issue: https://github.com/tinygo-org/drivers/issues/608