### PR TITLE
Fix `make smoke-test` tests & runner

### DIFF
--- a/sh1106/sh1106.go
+++ b/sh1106/sh1106.go
@@ -285,7 +285,6 @@ func (d *Device) Tx(data []byte, isCommand bool) {
 func (b *I2CBus) tx(data []byte, isCommand bool) {
 	if isCommand {
 		legacy.WriteRegister(b.wire, uint8(b.Address), 0x00, data)
-		b.wire.WriteRegister(uint8(b.Address), 0x00, data)
 	} else {
 		legacy.WriteRegister(b.wire, uint8(b.Address), 0x40, data)
 	}

--- a/smoketest.go
+++ b/smoketest.go
@@ -133,7 +133,7 @@ func runSmokeTest(filename string) error {
 		result := <-job.resultChan
 		os.Stdout.Write(job.output.Bytes())
 		if result != nil {
-			return err
+			return result
 		}
 	}
 


### PR DESCRIPTION
- It seems that one usage of `i2c.WireRegister(...)` was missed, breaking `make smoke-test`.
- The testrunner did not propagate the error properly, so the CI action never failed.

Came across this trying to fix my environment in #612 :)

Now though the CI action fails:
```
...
tinygo build -size short -o ./build/test.uf2 -target=pico ./examples/xpt2046/main.go
   code    data     bss |   flash     ram
   8808     108    3152 |    8916    3260
22814d5dc2ec7af38c49bbb0686e1e1b  ./build/test.uf2
exit status 1
tinygo build -size short -o ./build/test.elf -target=m5stack-core2 ./examples/ft6336/basic/
usage: go run ./smoketest.go smoketest.txt
# tinygo.org/x/drivers/delay
  -xtensa
    	Enable Xtensa tests (default true)
delay/sleep.go:10:10: fatal: 'stdbool.h' file not found
exit status 1
make: *** [Makefile:13: smoke-test] Error 1
```

So far I couldn't reproduce that locally and the tinygo docker images also seams to have the necessary dependencies at a quick glance.