### PR TITLE
smoketest: allow stack-size flag as it is needed for net examples

### DIFF
--- a/smoketest.go
+++ b/smoketest.go
@@ -96,6 +96,7 @@ func runSmokeTest(filename string) error {
 		flagSet := flag.NewFlagSet(fields[0], flag.ContinueOnError)
 		_ = flagSet.String("size", "", "")
 		_ = flagSet.String("o", "", "")
+		_ = flagSet.String("stack-size", "", "")
 		targetFlag := flagSet.String("target", "", "")
 		err = flagSet.Parse(fields[2:])
 		if err != nil {


### PR DESCRIPTION
This PR modifies the smoketest to allow the `stack-size` flag as it is needed for the changes to the `net` package.