### PR TITLE
correct netdever Accept() prototype

### DIFF
--- a/espat/espat.go
+++ b/espat/espat.go
@@ -218,8 +218,8 @@ func (d *Device) Listen(sockfd int, backlog int) error {
 	return nil
 }
 
-func (d *Device) Accept(sockfd int, ip netip.AddrPort) (int, error) {
-	return -1, netdev.ErrNotSupported
+func (d *Device) Accept(sockfd int) (int, netip.AddrPort, error) {
+	return -1, netip.AddrPort{}, netdev.ErrNotSupported
 }
 
 func (d *Device) sendChunk(sockfd int, buf []byte, deadline time.Time) (int, error) {

--- a/examples/net/tcpecho/main.go
+++ b/examples/net/tcpecho/main.go
@@ -30,16 +30,18 @@ var (
 var buf [1024]byte
 
 func echo(conn net.Conn) {
+	println("Client", conn.RemoteAddr(), "connected")
 	defer conn.Close()
 	_, err := io.CopyBuffer(conn, conn, buf[:])
 	if err != nil && err != io.EOF {
 		log.Fatal(err.Error())
 	}
+	println("Client", conn.RemoteAddr(), "closed")
 }
 
 func main() {
 
-	time.Sleep(time.Second)
+	time.Sleep(2 * time.Second)
 
 	link, _ := probe.Probe()
 
@@ -51,6 +53,7 @@ func main() {
 		log.Fatal(err)
 	}
 
+	println("Starting TCP server listening on", port)
 	l, err := net.Listen("tcp", port)
 	if err != nil {
 		log.Fatal(err.Error())

--- a/netdev/netdev.go
+++ b/netdev/netdev.go
@@ -82,7 +82,7 @@ type Netdever interface {
 	Bind(sockfd int, ip netip.AddrPort) error
 	Connect(sockfd int, host string, ip netip.AddrPort) error
 	Listen(sockfd int, backlog int) error
-	Accept(sockfd int, ip netip.AddrPort) (int, error)
+	Accept(sockfd int) (int, netip.AddrPort, error)
 	Send(sockfd int, buf []byte, flags int, deadline time.Time) (int, error)
 	Recv(sockfd int, buf []byte, flags int, deadline time.Time) (int, error)
 	Close(sockfd int) error


### PR DESCRIPTION
According to man page accept(2), accept returns new client sockfd and remote peer ip:port.  This patch corrects the Accept() prototype in the netdever interface to not take in an ip:port arg, but rather return an ip:port for remote peer.

Tested with examples/net/tcpecho on wioterminal and nano-rp2040.  Here's a run with wioterminal:

```
SERVER
============
sfeldma@nuc:~/work/drivers$ tinygo flash -monitor -target wioterminal -size short -stack-size=8kb ./examples/net/tcpecho
code    data     bss |   flash     ram
110876    2552   11212 |  113428   13764
Connected to /dev/ttyACM2. Press Ctrl-C to exit.

Realtek rtl8720dn Wifi network device driver (rtl8720dn)

Driver version           : 0.0.1
RTL8720 firmware version : 2.1.2
MAC address              : 2c:f7:f1:1c:9b:2f

Connecting to Wifi SSID 'test'...CONNECTED

DHCP-assigned IP         : 10.0.0.140
DHCP-assigned subnet     : 255.255.255.0
DHCP-assigned gateway    : 10.0.0.1

Starting TCP server listening on :8080
Client 10.0.0.190:50000 connected
Client 10.0.0.190:50000 closed

CLIENT
=============
nc -p 50000 10.0.0.140 8080
```