### PR TITLE
Fixing issue #417: avoid panic in GPS Parser

### DIFF
--- a/gps/gpsparser.go
+++ b/gps/gpsparser.go
@@ -116,7 +116,7 @@ func findTime(val string) time.Time {
 	s, _ := strconv.ParseInt(val[4:6], 10, 8)
 	ms := int64(0)
 	if len(val) > 6 {
-		ms, _ = strconv.ParseInt(val[7:], 10, 16)
+		ms, _ = strconv.ParseInt(val[7:9], 10, 16)
 	}
 	t := time.Date(0, 0, 0, int(h), int(m), int(s), int(ms), time.UTC)
 


### PR DESCRIPTION
Fix #417 

In its current shape, the driver would panic due to index being out of range.
@ipsusila is perfectly correct. 

I ran into the same problem, I am doing the PR myself since it has not been done before. 
We need to ensure that the parsing is only until 9 bytes, 
since the length of NMEA time field (hhmmss.ss) is 9 bytes.