### PR TITLE
wioterminal: fix check for bad Wifi connect

### DIFF
--- a/netlink/netlink.go
+++ b/netlink/netlink.go
@@ -13,6 +13,7 @@ var (
 	ErrConnectFailed     = errors.New("Connect failed")
 	ErrConnectTimeout    = errors.New("Connect timed out")
 	ErrMissingSSID       = errors.New("Missing WiFi SSID")
+	ErrShortPassphrase   = errors.New("Invalid Wifi Passphrase < 8 chars")
 	ErrAuthFailure       = errors.New("Wifi authentication failure")
 	ErrAuthTypeNoGood    = errors.New("Wifi authorization type not supported")
 	ErrConnectModeNoGood = errors.New("Connect mode not supported")

--- a/rtl8720dn/rtl8720dn.go
+++ b/rtl8720dn/rtl8720dn.go
@@ -102,6 +102,10 @@ func (r *rtl8720dn) connectToAP() error {
 		return netlink.ErrMissingSSID
 	}
 
+	if len(r.params.Passphrase) != 0 && len(r.params.Passphrase) < 8 {
+		return netlink.ErrShortPassphrase
+	}
+
 	if debugging(debugBasic) {
 		fmt.Printf("Connecting to Wifi SSID '%s'...", r.params.Ssid)
 	}
@@ -109,7 +113,7 @@ func (r *rtl8720dn) connectToAP() error {
 	// Start the connection process
 	securityType := uint32(0x00400004)
 	result := r.rpc_wifi_connect(r.params.Ssid, r.params.Passphrase, securityType, -1, 0)
-	if result == -1 {
+	if result != 0 {
 		if debugging(debugBasic) {
 			fmt.Printf("FAILED\r\n")
 		}


### PR DESCRIPTION
rpc_wifi_connect() will return 0 on successful connection, so check for that.  Also, check that if passphrase is given, that it's the minimum 8 chars per WPA Wifi.