### PR TITLE
rtl8720dn: allow connecting to open wifi access points

### DIFF
--- a/rtl8720dn/rtl8720dn.go
+++ b/rtl8720dn/rtl8720dn.go
@@ -111,7 +111,11 @@ func (r *rtl8720dn) connectToAP() error {
 	}
 
 	// Start the connection process
-	securityType := uint32(0x00400004)
+	securityType := uint32(0) // RTW_SECURITY_OPEN
+	if len(r.params.Passphrase) != 0 {
+		securityType = 0x00400004 // RTW_SECURITY_WPA2_AES_PSK
+	}
+
 	result := r.rpc_wifi_connect(r.params.Ssid, r.params.Passphrase, securityType, -1, 0)
 	if result != 0 {
 		if debugging(debugBasic) {


### PR DESCRIPTION
This PR modifies the `rtl8720dn` driver to allow connecting to open wifi access points.