### PR TITLE
netlink, examples: use 'ninafw' tag instead of individual board tags

### DIFF
--- a/examples/net/http-get/main.go
+++ b/examples/net/http-get/main.go
@@ -9,7 +9,7 @@
 //     examples/net/webclient (for HTTP)
 //     examples/net/tlsclient (for HTTPS)
 
-//go:build pyportal || nano_rp2040 || metro_m4_airlift || arduino_mkrwifi1010 || matrixportal_m4 || wioterminal
+//go:build ninafw || wioterminal
 
 package main
 

--- a/examples/net/http-head/main.go
+++ b/examples/net/http-head/main.go
@@ -9,7 +9,7 @@
 //     examples/net/webclient (for HTTP)
 //     examples/net/tlsclient (for HTTPS)
 
-//go:build pyportal || nano_rp2040 || metro_m4_airlift || arduino_mkrwifi1010 || matrixportal_m4 || wioterminal
+//go:build ninafw || wioterminal
 
 package main
 

--- a/examples/net/http-post/main.go
+++ b/examples/net/http-post/main.go
@@ -9,7 +9,7 @@
 //     examples/net/webclient (for HTTP)
 //     examples/net/tlsclient (for HTTPS)
 
-//go:build pyportal || nano_rp2040 || metro_m4_airlift || arduino_mkrwifi1010 || matrixportal_m4 || wioterminal
+//go:build ninafw || wioterminal
 
 package main
 

--- a/examples/net/http-postform/main.go
+++ b/examples/net/http-postform/main.go
@@ -9,7 +9,7 @@
 //     examples/net/webclient (for HTTP)
 //     examples/net/tlsclient (for HTTPS)
 
-//go:build pyportal || nano_rp2040 || metro_m4_airlift || arduino_mkrwifi1010 || matrixportal_m4 || wioterminal
+//go:build ninafw || wioterminal
 
 package main
 

--- a/examples/net/mqttclient/natiu/main.go
+++ b/examples/net/mqttclient/natiu/main.go
@@ -4,7 +4,7 @@
 // Note: It may be necessary to increase the stack size when using
 // paho.mqtt.golang.  Use the -stack-size=4KB command line option.
 
-//go:build pyportal || nano_rp2040 || metro_m4_airlift || arduino_mkrwifi1010 || matrixportal_m4 || wioterminal || challenger_rp2040
+//go:build ninafw || wioterminal || challenger_rp2040
 
 package main
 

--- a/examples/net/mqttclient/paho/main.go
+++ b/examples/net/mqttclient/paho/main.go
@@ -4,7 +4,7 @@
 // Note: It may be necessary to increase the stack size when using
 // paho.mqtt.golang.  Use the -stack-size=4KB command line option.
 
-//go:build pyportal || nano_rp2040 || metro_m4_airlift || arduino_mkrwifi1010 || matrixportal_m4 || wioterminal || challenger_rp2040
+//go:build ninafw || wioterminal || challenger_rp2040
 
 package main
 

--- a/examples/net/ntpclient/main.go
+++ b/examples/net/ntpclient/main.go
@@ -3,7 +3,7 @@
 // It creates a UDP connection to request the current time and parse the
 // response from a NTP server.  The system time is set to NTP time.
 
-//go:build pyportal || arduino_nano33 || nano_rp2040 || metro_m4_airlift || arduino_mkrwifi1010 || matrixportal_m4 || wioterminal || challenger_rp2040
+//go:build ninafw || wioterminal || challenger_rp2040
 
 package main
 

--- a/examples/net/socket/main.go
+++ b/examples/net/socket/main.go
@@ -4,7 +4,7 @@
 //
 // nc -lk 8080
 
-//go:build pyportal || arduino_nano33 || nano_rp2040 || metro_m4_airlift || arduino_mkrwifi1010 || matrixportal_m4 || wioterminal || challenger_rp2040
+//go:build ninafw || wioterminal || challenger_rp2040
 
 package main
 

--- a/examples/net/tcpclient/main.go
+++ b/examples/net/tcpclient/main.go
@@ -5,7 +5,7 @@
 //
 // nc -lk 8080
 
-//go:build pyportal || arduino_nano33 || nano_rp2040 || metro_m4_airlift || arduino_mkrwifi1010 || matrixportal_m4 || wioterminal || challenger_rp2040 || pico
+//go:build ninafw || wioterminal || challenger_rp2040 || pico
 
 package main
 

--- a/examples/net/tcpecho/main.go
+++ b/examples/net/tcpecho/main.go
@@ -7,7 +7,7 @@
 //
 // $ nc 10.0.0.2 8080 <file >copy ; cmp file copy
 
-//go:build pyportal || arduino_nano33 || nano_rp2040 || metro_m4_airlift || arduino_mkrwifi1010 || matrixportal_m4 || wioterminal
+//go:build ninafw || wioterminal
 
 package main
 

--- a/examples/net/tlsclient/main.go
+++ b/examples/net/tlsclient/main.go
@@ -5,7 +5,7 @@
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
 
-//go:build pyportal || nano_rp2040 || metro_m4_airlift || arduino_mkrwifi1010 || matrixportal_m4 || wioterminal
+//go:build ninafw || wioterminal
 
 package main
 

--- a/examples/net/webclient/main.go
+++ b/examples/net/webclient/main.go
@@ -17,7 +17,7 @@
 // }
 // ---------------------------------------------------------------------------
 
-//go:build pyportal || arduino_nano33 || nano_rp2040 || metro_m4_airlift || arduino_mkrwifi1010 || matrixportal_m4 || wioterminal
+//go:build ninafw || wioterminal
 
 package main
 

--- a/examples/net/webserver/main.go
+++ b/examples/net/webserver/main.go
@@ -6,7 +6,7 @@
 // Note: It may be necessary to increase the stack size when using "net/http".
 // Use the -stack-size=4KB command line option.
 
-//go:build pyportal || nano_rp2040 || metro_m4_airlift || arduino_mkrwifi1010 || matrixportal_m4 || wioterminal
+//go:build ninafw || wioterminal
 
 package main
 

--- a/examples/net/websocket/dial/main.go
+++ b/examples/net/websocket/dial/main.go
@@ -6,7 +6,7 @@
 // Note: It may be necessary to increase the stack size when using
 // "golang.org/x/net/websocket".  Use the -stack-size=4KB command line option.
 
-//go:build pyportal || nano_rp2040 || metro_m4_airlift || arduino_mkrwifi1010 || matrixportal_m4 || wioterminal
+//go:build ninafw || wioterminal
 
 package main
 

--- a/examples/net/websocket/handler/main.go
+++ b/examples/net/websocket/handler/main.go
@@ -6,7 +6,7 @@
 // Note: It may be necessary to increase the stack size when using
 // "golang.org/x/net/websocket".  Use the -stack-size=4KB command line option.
 
-//go:build pyportal || nano_rp2040 || metro_m4_airlift || arduino_mkrwifi1010 || matrixportal_m4 || wioterminal
+//go:build ninafw || wioterminal
 
 package main
 

--- a/examples/net/webstatic/main.go
+++ b/examples/net/webstatic/main.go
@@ -3,7 +3,7 @@
 // Note: It may be necessary to increase the stack size when using "net/http".
 // Use the -stack-size=4KB command line option.
 
-//go:build pyportal || nano_rp2040 || metro_m4_airlift || arduino_mkrwifi1010 || matrixportal_m4 || wioterminal
+//go:build ninafw || wioterminal
 
 package main
 

--- a/netlink/probe/wifinina.go
+++ b/netlink/probe/wifinina.go
@@ -1,4 +1,4 @@
-//go:build pyportal || arduino_nano33 || nano_rp2040 || metro_m4_airlift || matrixportal_m4
+//go:build ninafw && !arduino_mkrwifi1010
 
 package probe
 


### PR DESCRIPTION
This PR modifies `netlink` and also the associated examples to use the 'ninafw' tag instead of individual board tags to simplify maintenance. Also see [PR #4085](https://github.com/tinygo-org/tinygo/pull/4085) in the main TinyGo repo.