### PR TITLE
remove pico from examples/net/tcpclient

### DIFF
--- a/examples/net/tcpclient/main.go
+++ b/examples/net/tcpclient/main.go
@@ -5,7 +5,7 @@
 //
 // nc -lk 8080
 
-//go:build ninafw || wioterminal || challenger_rp2040 || pico
+//go:build ninafw || wioterminal || challenger_rp2040
 
 package main
 


### PR DESCRIPTION
Not ready for pico yet.  Somehow this slipped in an earlier commit.