### PR TITLE
build: free space before build and use latest checkout action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,11 +13,22 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/tinygo-org/tinygo-dev:latest
     steps:
+      - name: Free Disk space
+        shell: bash
+        run: |
+          df -h
+          rm -rf /opt/hostedtoolcache
+          rm -rf /usr/local/lib/android
+          rm -rf /usr/share/dotnet
+          rm -rf /opt/ghc
+          rm -rf /usr/local/graalvm
+          rm -rf /usr/local/share/boost
+          df -h
       - name: Work around CVE-2022-24765
         # We're not on a multi-user machine, so this is safe.
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: TinyGo version check
         run: tinygo version
       - name: Enforce Go Formatted Code


### PR DESCRIPTION
This PR modifies the build to free space on the runner drive before build. It also updates to use the latest GH checkout action.