### PR TITLE
Use int16 for ADXL345 readings

### DIFF
--- a/adxl345/adxl345.go
+++ b/adxl345/adxl345.go
@@ -92,12 +92,12 @@ func (d *Device) Restart() {
 // it in µg (micro-gravity). When one of the axes is pointing straight to Earth
 // and the sensor is not moving the returned value will be around 1000000 or
 // -1000000.
-func (d *Device) ReadAcceleration() (x int16, y int16, z int16, err error) {
+func (d *Device) ReadAcceleration() (x int32, y int32, z int32, err error) {
 	rx, ry, rz := d.ReadRawAcceleration()
 
-	x = d.dataFormat.convertToIS(rx)
-	y = d.dataFormat.convertToIS(ry)
-	z = d.dataFormat.convertToIS(rz)
+	x = int32(d.dataFormat.convertToIS(rx))
+	y = int32(d.dataFormat.convertToIS(ry))
+	z = int32(d.dataFormat.convertToIS(rz))
 
 	return
 }

--- a/adxl345/adxl345.go
+++ b/adxl345/adxl345.go
@@ -92,7 +92,7 @@ func (d *Device) Restart() {
 // it in µg (micro-gravity). When one of the axes is pointing straight to Earth
 // and the sensor is not moving the returned value will be around 1000000 or
 // -1000000.
-func (d *Device) ReadAcceleration() (x int32, y int32, z int32, err error) {
+func (d *Device) ReadAcceleration() (x int16, y int16, z int16, err error) {
 	rx, ry, rz := d.ReadRawAcceleration()
 
 	x = d.dataFormat.convertToIS(rx)
@@ -104,7 +104,7 @@ func (d *Device) ReadAcceleration() (x int32, y int32, z int32, err error) {
 
 // ReadRawAcceleration reads the sensor values and returns the raw x, y and z axis
 // from the adxl345.
-func (d *Device) ReadRawAcceleration() (x int32, y int32, z int32) {
+func (d *Device) ReadRawAcceleration() (x int16, y int16, z int16) {
 	data := []byte{0, 0, 0, 0, 0, 0}
 	legacy.ReadRegister(d.bus, uint8(d.Address), REG_DATAX0, data)
 
@@ -140,7 +140,7 @@ func (d *Device) SetRange(sensorRange Range) bool {
 }
 
 // convertToIS adjusts the raw values from the adxl345 with the range configuration
-func (d *dataFormat) convertToIS(rawValue int32) int32 {
+func (d *dataFormat) convertToIS(rawValue int16) int16 {
 	switch d.sensorRange {
 	case RANGE_2G:
 		return rawValue * 4 // rawValue * 2 * 1000 / 512
@@ -190,6 +190,6 @@ func (b *bwRate) toByte() (bits uint8) {
 }
 
 // readInt converts two bytes to int16
-func readIntLE(msb byte, lsb byte) int32 {
-	return int32(uint16(msb) | uint16(lsb)<<8)
+func readIntLE(msb byte, lsb byte) int16 {
+	return int16(uint16(msb) | uint16(lsb)<<8)
 }


### PR DESCRIPTION
The ADXL345 accelerometer outputs readings as 16-bit integers (see [the first page of its datasheet][datasheet]), and thus parsing them as 32-bit ones skews the results.

Here is [the example code][example] running on an RP2040 with the [current implementation][current] and giving out of range readings (the sensor is sitting facing downwards and slightly tilted towards the Y axis):
```
X: 20 Y: 448 Z: 261212
X (raw): 5 Y (raw): 112 Z (raw): 65303
```

And here with proper typecasting, with higher values now in the expected µg (micro-gravity) range:
```
X: 12 Y: 432 Z: -940
X (raw): 3 Y (raw): 108 Z (raw): -235
```

Given the comments in the source code itself, I guess that this driver porting error was previously masked by the limited bitness of other microcontrollers?

~~While I was at it I deleted the error return param from ReadAcceleration since I didn't see anything prone to throwing in its codepath, but I'm wondering if https://github.com/tinygo-org/drivers/pull/46#issue-437786421 is still applicable and it should be kept instead.~~ CI gave me the answer :)

[datasheet]: https://www.sparkfun.com/datasheets/Sensors/Accelerometer/ADXL345.pdf
[example]: https://github.com/tinygo-org/drivers/blob/308763f5007acbf05ba7dd147082ad962ba006bb/examples/adxl345/main.go
[current]: https://github.com/tinygo-org/drivers/blob/308763f5007acbf05ba7dd147082ad962ba006bb/adxl345/adxl345.go#L192