### PR TITLE
rtl8720dn, wifinina: implement netlink.ConnectModeAP

### DIFF
--- a/netdev/netdev.go
+++ b/netdev/netdev.go
@@ -36,6 +36,7 @@ var (
 	ErrFamilyNotSupported   = errors.New("Address family not supported")
 	ErrProtocolNotSupported = errors.New("Socket protocol/type not supported")
 	ErrStartingDHCPClient   = errors.New("Error starting DHPC client")
+	ErrStartingDHCPServer   = errors.New("Error starting DHPC server")
 	ErrNoMoreSockets        = errors.New("No more sockets")
 	ErrClosingSocket        = errors.New("Error closing socket")
 	ErrNotSupported         = errors.New("Not supported")


### PR DESCRIPTION
This PR extends the `rtl8720dn` and `wifinina` drivers to implement `ConnectMode` using `netlink.ConnectModeAP`.

```go
link.NetConnect(&netlink.ConnectParams{
	ConnectMode: netlink.ConnectModeAP,
	Ssid:        ssid,
	Passphrase:  pass,
})
```