### PR TITLE
ft6336: ignore bogus touch events

### DIFF
--- a/ft6336/ft6336.go
+++ b/ft6336/ft6336.go
@@ -80,7 +80,8 @@ func (d *Device) Read() []byte {
 func (d *Device) ReadTouchPoint() touch.Point {
 	d.Read()
 	z := 0xFFFFF
-	if d.buf[0] == 0 {
+	switch d.buf[0] {
+	case 0, 255:
 		z = 0
 	}
 


### PR DESCRIPTION
At least one ft6336 device reports all 255 values from the first read after reset or poweron, even after waiting the specified 300ms reset delay.