### PR TITLE
ssd1306: add Rotation(), SetRotation() and Sleep() functions to complete Displayer interface

### DIFF
--- a/ssd1306/ssd1306.go
+++ b/ssd1306/ssd1306.go
@@ -15,8 +15,9 @@ import (
 )
 
 var (
-	errBufferSize = errors.New("invalid size buffer")
-	errOutOfRange = errors.New("out of screen range")
+	errBufferSize     = errors.New("invalid size buffer")
+	errOutOfRange     = errors.New("out of screen range")
+	errNotImplemented = errors.New("not implemented")
 )
 
 type ResetValue [2]byte
@@ -358,4 +359,15 @@ func (d *Device) DrawBitmap(x, y int16, bitmap pixel.Image[pixel.Monochrome]) er
 	}
 
 	return nil
+}
+
+// Rotation returns the currently configured rotation.
+func (d *Device) Rotation() drivers.Rotation {
+	return drivers.Rotation0
+}
+
+// SetRotation changes the rotation of the device (clock-wise).
+// Would have to be implemented in software for this device.
+func (d *Device) SetRotation(rotation drivers.Rotation) error {
+	return errNotImplemented
 }

--- a/ssd1306/ssd1306.go
+++ b/ssd1306/ssd1306.go
@@ -371,3 +371,15 @@ func (d *Device) Rotation() drivers.Rotation {
 func (d *Device) SetRotation(rotation drivers.Rotation) error {
 	return errNotImplemented
 }
+
+// Set the sleep mode for this display. When sleeping, the panel uses a lot
+// less power. The display won't show an image anymore, but the memory contents
+// should be kept.
+func (d *Device) Sleep(sleepEnabled bool) error {
+	if sleepEnabled {
+		d.Command(DISPLAYOFF)
+	} else {
+		d.Command(DISPLAYON)
+	}
+	return nil
+}


### PR DESCRIPTION
This PR extends the `ssd1306` to add `Rotation()`, `SetRotation()`, and `Sleep()` functions to complete the `Displayer` interface implementation.