### PR TITLE
removed what seems like an accidental home directory replace in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module tinygo.org/x/drivers
 
 go 1.18
 
-replace tinygo.org/x/drivers/mcp9808 => /home/kasterby/Documents/drivers/mcp9808
-
 require (
 	github.com/eclipse/paho.mqtt.golang v1.2.0
 	github.com/frankban/quicktest v1.10.2


### PR DESCRIPTION
in go.mod was this line that I propose removing:

replace tinygo.org/x/drivers/mcp9808 => /home/kasterby/Documents/drivers/mcp9808

Looks like an accidental commit of a development local "replace" - probably should not be in the mainline.