### PR TITLE
ssd1306: Add function `SetFlip` and `GetFlip`

### DIFF
--- a/ssd1306/registers.go
+++ b/ssd1306/registers.go
@@ -38,4 +38,7 @@ const (
 
 	EXTERNALVCC  VccMode = 0x1
 	SWITCHCAPVCC VccMode = 0x2
+
+	NO_FLIP = false
+	FLIP    = true
 )

--- a/ssd1306/registers.go
+++ b/ssd1306/registers.go
@@ -1,5 +1,7 @@
 package ssd1306
 
+import "tinygo.org/x/drivers"
+
 // Registers
 const (
 	Address        = 0x3D
@@ -39,6 +41,6 @@ const (
 	EXTERNALVCC  VccMode = 0x1
 	SWITCHCAPVCC VccMode = 0x2
 
-	NO_FLIP = false
-	FLIP    = true
+	NO_ROTATION  = drivers.Rotation0
+	ROTATION_180 = drivers.Rotation180
 )

--- a/ssd1306/ssd1306.go
+++ b/ssd1306/ssd1306.go
@@ -33,6 +33,7 @@ type Device struct {
 	canReset   bool
 	resetCol   ResetValue
 	resetPage  ResetValue
+	isFlip     bool
 }
 
 // Config is the configuration for the display
@@ -48,6 +49,7 @@ type Config struct {
 	// If you're using a different size, you might need to set these values manually.
 	ResetCol  ResetValue
 	ResetPage ResetValue
+	IsFlip    bool
 }
 
 type I2CBus struct {
@@ -149,8 +151,8 @@ func (d *Device) Configure(cfg Config) {
 	}
 	d.Command(MEMORYMODE)
 	d.Command(0x00)
-	d.Command(SEGREMAP | 0x1)
-	d.Command(COMSCANDEC)
+
+	d.SetFlip(cfg.IsFlip)
 
 	if (d.width == 128 && d.height == 64) || (d.width == 64 && d.height == 48) { // 128x64 or 64x48
 		d.Command(SETCOMPINS)
@@ -382,4 +384,23 @@ func (d *Device) Sleep(sleepEnabled bool) error {
 		d.Command(DISPLAYON)
 	}
 	return nil
+}
+
+// GetFlip retrieves the current state of the display's flip orientation.
+// Returns a boolean value indicating whether the display is flipped or not.
+func (d *Device) GetFlip() bool {
+	return d.isFlip
+}
+
+// SetFlip sets the flip orientation of the display.
+// It uses commands SEGREMAP and COMSCANINC to achieve this.
+func (d *Device) SetFlip(flip bool) {
+	d.isFlip = flip
+	if d.isFlip {
+		d.Command(SEGREMAP | 0x1) // Reverse horizontal mapping
+		d.Command(COMSCANDEC)     // Reverse vertical mapping
+	} else {
+		d.Command(SEGREMAP)   // Normal horizontal mapping
+		d.Command(COMSCANINC) // Normal vertical mapping
+	}
 }

--- a/ssd1306/ssd1306.go
+++ b/ssd1306/ssd1306.go
@@ -15,9 +15,8 @@ import (
 )
 
 var (
-	errBufferSize     = errors.New("invalid size buffer")
-	errOutOfRange     = errors.New("out of screen range")
-	errNotImplemented = errors.New("not implemented")
+	errBufferSize = errors.New("invalid size buffer")
+	errOutOfRange = errors.New("out of screen range")
 )
 
 type ResetValue [2]byte
@@ -33,7 +32,7 @@ type Device struct {
 	canReset   bool
 	resetCol   ResetValue
 	resetPage  ResetValue
-	isFlip     bool
+	rotation   drivers.Rotation
 }
 
 // Config is the configuration for the display
@@ -49,7 +48,7 @@ type Config struct {
 	// If you're using a different size, you might need to set these values manually.
 	ResetCol  ResetValue
 	ResetPage ResetValue
-	IsFlip    bool
+	Rotation  drivers.Rotation
 }
 
 type I2CBus struct {
@@ -152,7 +151,7 @@ func (d *Device) Configure(cfg Config) {
 	d.Command(MEMORYMODE)
 	d.Command(0x00)
 
-	d.SetFlip(cfg.IsFlip)
+	d.SetRotation(cfg.Rotation)
 
 	if (d.width == 128 && d.height == 64) || (d.width == 64 && d.height == 48) { // 128x64 or 64x48
 		d.Command(SETCOMPINS)
@@ -365,13 +364,25 @@ func (d *Device) DrawBitmap(x, y int16, bitmap pixel.Image[pixel.Monochrome]) er
 
 // Rotation returns the currently configured rotation.
 func (d *Device) Rotation() drivers.Rotation {
-	return drivers.Rotation0
+	return d.rotation
 }
 
 // SetRotation changes the rotation of the device (clock-wise).
-// Would have to be implemented in software for this device.
 func (d *Device) SetRotation(rotation drivers.Rotation) error {
-	return errNotImplemented
+	d.rotation = rotation
+	switch d.rotation {
+	case drivers.Rotation0:
+		d.Command(SEGREMAP | 0x1) // Reverse horizontal mapping
+		d.Command(COMSCANDEC)     // Reverse vertical mapping
+	case drivers.Rotation180:
+		d.Command(SEGREMAP)   // Normal horizontal mapping
+		d.Command(COMSCANINC) // Normal vertical mapping
+	// nothing to do
+	default:
+		d.Command(SEGREMAP | 0x1) // Reverse horizontal mapping
+		d.Command(COMSCANDEC)     // Reverse vertical mapping
+	}
+	return nil
 }
 
 // Set the sleep mode for this display. When sleeping, the panel uses a lot
@@ -384,23 +395,4 @@ func (d *Device) Sleep(sleepEnabled bool) error {
 		d.Command(DISPLAYON)
 	}
 	return nil
-}
-
-// GetFlip retrieves the current state of the display's flip orientation.
-// Returns a boolean value indicating whether the display is flipped or not.
-func (d *Device) GetFlip() bool {
-	return d.isFlip
-}
-
-// SetFlip sets the flip orientation of the display.
-// It uses commands SEGREMAP and COMSCANINC to achieve this.
-func (d *Device) SetFlip(flip bool) {
-	d.isFlip = flip
-	if d.isFlip {
-		d.Command(SEGREMAP | 0x1) // Reverse horizontal mapping
-		d.Command(COMSCANDEC)     // Reverse vertical mapping
-	} else {
-		d.Command(SEGREMAP)   // Normal horizontal mapping
-		d.Command(COMSCANINC) // Normal vertical mapping
-	}
 }


### PR DESCRIPTION
# Implementation of the Flip Functions

Hello, I am new to contributing to OSS, so I apologize in advance if there are any mistakes.

## What I did
I added a Flip functions to the `ssd1306` driver.

## Background
While playing with `ssd1306`, I wanted to flip the display, but I found that there was no method implemented for it. I had to directly execute commands within the application. Thus, I thought it would be helpful to implement this functionality in the driver itself.

## Why I didn't extend `SetRotation`
Initially, I thought it would be best to integrate the flip functionality into `SetRotation` to align with the other existing implementations. However, I found that implementing 90° and 270° rotations is quite challenging. To help clarify my point, please refer to the images below:

- [0° image](https://pbs.twimg.com/media/GVFnBXoaEAMOFse?format=jpg&name=4096x4096)
- [90°? image](https://pbs.twimg.com/media/GVFnBXob0AAJ7kt?format=jpg&name=4096x4096)
- [180° image](https://pbs.twimg.com/media/GVFnBXraQAEQfHG?format=jpg&name=4096x4096)
- [270°? image](https://pbs.twimg.com/media/GVFnBXqaEAQhlnh?format=jpg&name=4096x4096)

From my current understanding, it seems that the `ssd1306` hardware does not support these kinds of rotation features directly, so a more complex implementation would be required. However, I believe that even just implementing the flip functionality is useful, so I decided to start with this.

Thank you for your time and consideration.
