### PR TITLE
Onewire improvements

### DIFF
--- a/ds18b20/ds18b20.go
+++ b/ds18b20/ds18b20.go
@@ -19,7 +19,7 @@ type OneWireDevice interface {
 	Write(uint8)
 	Read() uint8
 	Select([]uint8) error
-	Сrc8([]uint8, int) uint8
+	Сrc8([]uint8) uint8
 }
 
 // Device wraps a connection to an 1-Wire devices.
@@ -69,7 +69,7 @@ func (d Device) ReadTemperatureRaw(romid []uint8) ([]uint8, error) {
 	for i := 0; i < 9; i++ {
 		spb[i] = d.owd.Read()
 	}
-	if d.owd.Сrc8(spb, 8) != spb[8] {
+	if d.owd.Сrc8(spb) != 0 {
 		return nil, errReadTemperature
 	}
 	return spb[:2:2], nil


### PR DESCRIPTION
Some improvements to OneWire/DS18B20 driver.

Although external pull-up resistor for DS18B20 is recommended, internal pull-up is good enough in some cases (for example for single sensor on a short bus), so low level functions are changed to enable internal pull-up for high state. 

While testing DS18B20 sensor without internal or external pull-up, I got panic because OneWire `Search` function "found" more than 32 devices and overflowed the array. To prevent this, the check is added to stop the search (and return an error) when more than 32 devices are found. Also, CRC check was added to prevent adding invalid devices during search. 

Additionally PR contains suggestion for changing `Crc8` method and in turn `OneWireDevice` interface (which is a breaking change) to be a bit more idiomatic Go. This is only a suggestion and I would like to get other opinions on it.