### PR TITLE
Add sponsor button to key repositories

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# These are supported funding model platforms
+open_collective: tinygo


### PR DESCRIPTION
Add the sponsor button linking to open collective in the repository.

Needs to be enable ( https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository )