### PR TITLE
uc8151: add FillRectangle() and SetScroll() functions to satisfy tinyterm.Displayer interface

### DIFF
--- a/uc8151/uc8151.go
+++ b/uc8151/uc8151.go
@@ -478,3 +478,31 @@ func (d *Device) SetLUT(speed Speed, flickerFree bool) error {
 
 	return nil
 }
+
+// FillRectangle fills a rectangle at a given coordinates with a color
+func (d *Device) FillRectangle(x, y, width, height int16, c color.RGBA) error {
+	dw, dh := d.Size()
+
+	if x < 0 || y < 0 || width <= 0 || height <= 0 ||
+		x >= d.width || (x+width) > dw || y >= dh || (y+height) > dh {
+		return errOutOfRange
+	}
+
+	if x+width == dw && y+height == dh && c.R == 0 && c.G == 0 && c.B == 0 {
+		d.ClearDisplay()
+		return nil
+	}
+
+	for i := x; i < x+width; i++ {
+		for j := y; j < y+height; j++ {
+			d.SetPixel(i, j, c)
+		}
+	}
+
+	return nil
+}
+
+// SetScroll sets the vertical scrolling for the display, which is a NOP for this display.
+func (d *Device) SetScroll(line int16) {
+	return
+}


### PR DESCRIPTION
This PR adds to the `uc8151` display by implementing the `FillRectangle()` and `SetScroll()` functions in order to satisfy the `tinyterm.Displayer` interface.