### PR TITLE
pixel: fix Monochrome setPixel 

### DIFF
--- a/pixel/image.go
+++ b/pixel/image.go
@@ -138,14 +138,14 @@ func (img Image[T]) setPixel(index int, c T) {
 	switch {
 	case zeroColor.BitsPerPixel() == 1:
 		// Monochrome.
-		x := index % int(img.width)
 		offset := index / 8
+		bits := index % 8
 
 		ptr := (*byte)(unsafe.Add(img.data, offset))
 		if c != zeroColor {
-			*((*byte)(ptr)) |= (1 << (7 - uint8(x%8)))
+			*((*byte)(ptr)) |= (1 << (7 - uint8(bits)))
 		} else {
-			*((*byte)(ptr)) &^= (1 << (7 - uint8(x%8)))
+			*((*byte)(ptr)) &^= (1 << (7 - uint8(bits)))
 		}
 
 		return
@@ -202,7 +202,7 @@ func (img Image[T]) Get(x, y int) T {
 		// Monochrome.
 		var c Monochrome
 		offset := index / 8
-		bits := index - (offset * 8)
+		bits := index % 8
 		ptr := (*byte)(unsafe.Add(img.data, offset))
 		c = ((*ptr >> (7 - uint8(bits))) & 0x1) > 0
 		return any(c).(T)

--- a/pixel/image_test.go
+++ b/pixel/image_test.go
@@ -194,6 +194,9 @@ func TestImageNoise(t *testing.T) {
 	t.Run("RGB444BE", func(t *testing.T) {
 		testImageNoise[pixel.RGB444BE](t)
 	})
+	t.Run("Monochrome", func(t *testing.T) {
+		testImageNoise[pixel.Monochrome](t)
+	})
 }
 
 func testImageNoise[T pixel.Color](t *testing.T) {

--- a/pixel/image_test.go
+++ b/pixel/image_test.go
@@ -183,20 +183,28 @@ func TestImageFromBytesMonochrome(t *testing.T) {
 // contain the same data afterwards.
 func TestImageNoise(t *testing.T) {
 	t.Run("RGB888", func(t *testing.T) {
-		testImageNoise[pixel.RGB888](t)
+		testImageNoiseN[pixel.RGB888](t)
 	})
 	t.Run("RGB565BE", func(t *testing.T) {
-		testImageNoise[pixel.RGB565BE](t)
+		testImageNoiseN[pixel.RGB565BE](t)
 	})
 	t.Run("RGB555", func(t *testing.T) {
-		testImageNoise[pixel.RGB555](t)
+		testImageNoiseN[pixel.RGB555](t)
 	})
 	t.Run("RGB444BE", func(t *testing.T) {
-		testImageNoise[pixel.RGB444BE](t)
+		testImageNoiseN[pixel.RGB444BE](t)
 	})
 	t.Run("Monochrome", func(t *testing.T) {
-		testImageNoise[pixel.Monochrome](t)
+		testImageNoiseN[pixel.Monochrome](t)
 	})
+}
+
+// Run the testImageNoise multiple times, because a single test might not catch
+// all bugs (since the test uses random data).
+func testImageNoiseN[T pixel.Color](t *testing.T) {
+	for i := 0; i < 10; i++ {
+		testImageNoise[T](t)
+	}
 }
 
 func testImageNoise[T pixel.Color](t *testing.T) {


### PR DESCRIPTION
Set/setPixel and Get weren't using the same indices. I've taken the ones used in Get and applied them to setPixel too.
This fixes testImageNoise for the monochrome image.

I don't know which of the two behaviors was correct, but the one in `Get` certainly is simpler and more efficient.
@deadprogram do you have a specification of the format somewhere?