### PR TITLE
bugfix: correct pcf8591 casting of return value from adc

### DIFF
--- a/pcf8591/pcf8591.go
+++ b/pcf8591/pcf8591.go
@@ -76,7 +76,7 @@ func (p ADCPin) Get() uint16 {
 	p.d.bus.Tx(p.d.Address, tx, rx)
 
 	// scale result to 16bit value like other ADCs
-	return uint16(rx[1] << 8)
+	return uint16(rx[1]) << 8
 }
 
 // Configure here just for interface compatibility.


### PR DESCRIPTION
This PR corrects the `pcf8591` driver, by correcting the casting of return value from adc as it was overflowing the 8 bit result.