### PR TITLE
hub75: fix data buffering

### DIFF
--- a/hub75/hub75.go
+++ b/hub75/hub75.go
@@ -167,7 +167,7 @@ func (d *Device) fillMatrixBuffer(x int16, y int16, r uint8, g uint8, b uint8) {
 		if r > colorTresh {
 			d.buffer[c][offsetR] |= 1 << bitSelect
 		} else {
-			d.buffer[c][offsetR] = d.buffer[c][offsetR] &^ 1 << bitSelect
+			d.buffer[c][offsetR] &^= 1 << bitSelect
 		}
 		if g > colorTresh {
 			d.buffer[(c+d.colorThirdStep)%d.colorDepth][offsetG] |= 1 << bitSelect


### PR DESCRIPTION
I fixed buffering of red data. ( https://github.com/tinygo-org/drivers/issues/691#issue-2386396643 )

The red data seems to be misaligned, so the display position is incorrect;
however, the other colors are fine.
```golang
// Sample code for order of operations
package main

import "fmt"

func main() {
	bitSelect := 2
	data_1 := 0x05
	data_2 := 0x05

	fmt.Println("before")
	fmt.Printf("%08b\n", data_1)
	data_1 = data_1 &^ 1 << bitSelect
	fmt.Printf("%08b\n", data_1)

	fmt.Println("after")
	fmt.Printf("%08b\n", data_2)
	data_2 &^= 1 << bitSelect
	fmt.Printf("%08b\n", data_2)
}
```
```
// before: it setting bits to 1 in unintended positions.
// after: it is clearing the bits in the intended positions.
$ go run .    
before
00000101
00010000
after
00000101
00000001
```