### PR TITLE
fix(dhcp): fix typo in DHCP error message

### DIFF
--- a/netdev/netdev.go
+++ b/netdev/netdev.go
@@ -35,8 +35,8 @@ var (
 var (
 	ErrFamilyNotSupported   = errors.New("Address family not supported")
 	ErrProtocolNotSupported = errors.New("Socket protocol/type not supported")
-	ErrStartingDHCPClient   = errors.New("Error starting DHPC client")
-	ErrStartingDHCPServer   = errors.New("Error starting DHPC server")
+	ErrStartingDHCPClient   = errors.New("Error starting DHCP client")
+	ErrStartingDHCPServer   = errors.New("Error starting DHCP server")
 	ErrNoMoreSockets        = errors.New("No more sockets")
 	ErrClosingSocket        = errors.New("Error closing socket")
 	ErrNotSupported         = errors.New("Not supported")


### PR DESCRIPTION
While reviewing the `netdev` package I noticed the DHCP error messages both have DHCP misspelled.