### PR TITLE
Add MAX6675 Cold-Junction-Compensated K-Thermocouple-to-Digital Converter 

### DIFF
--- a/examples/max6675/main.go
+++ b/examples/max6675/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"machine"
+	"time"
+
+	"tinygo.org/x/drivers/max6675"
+)
+
+// example for reading temperature from a thermocouple
+func main() {
+	// Pins are for an Adafruit Feather nRF52840 Express
+	machine.D5.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.D5.High()
+
+	machine.SPI0.Configure(machine.SPIConfig{
+		Frequency: 1_000_000,
+		SCK:       machine.SPI0_SCK_PIN,
+		SDI:       machine.SPI0_SDI_PIN,
+	})
+
+	thermocouple := max6675.NewDevice(machine.SPI0, machine.D5)
+
+	for {
+		temp, err := thermocouple.Read()
+		if err != nil {
+			println(err)
+			return
+		}
+		fmt.Printf("%0.02f C : %0.02f F\n", temp, (temp*9/5)+32)
+		time.Sleep(time.Second)
+	}
+}

--- a/max6675/max6675.go
+++ b/max6675/max6675.go
@@ -1,0 +1,51 @@
+// Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/max6675.pdf
+package max6675
+
+import (
+	"errors"
+	"machine"
+)
+
+// ErrThermocoupleOpen is returned when the thermocouple input is open.
+// i.e. not attached  or faulty
+var ErrThermocoupleOpen = errors.New("thermocouple input open")
+
+type Device struct {
+	bus machine.SPI
+	cs  machine.Pin
+}
+
+// Create a new Device to read from a MAX6675 thermocouple.
+// Pins must be configured before use.  Frequency for SPI
+// should be 4.3MHz maximum.
+func NewDevice(bus machine.SPI, cs machine.Pin) *Device {
+	return &Device{
+		bus: bus,
+		cs:  cs,
+	}
+}
+
+// Read and return the temperature in celsius
+func (d *Device) Read() (float32, error) {
+	var (
+		read  []byte = []byte{0, 0}
+		value uint16
+	)
+
+	d.cs.Low()
+	if err := d.bus.Tx([]byte{0, 0}, read); err != nil {
+		return 0, err
+	}
+	d.cs.High()
+
+	// datasheet: Bit D2 is normally low and goes high if the thermocouple input is open.
+	if read[1]&0x04 == 0x04 {
+		return 0, ErrThermocoupleOpen
+	}
+
+	// data is 12 bits, split across the two bytes
+	// -XXXXXXX XXXXX---
+	value = (uint16(read[0]) << 5) | (uint16(read[1]) >> 3)
+
+	return float32(value) * 0.25, nil
+}

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -139,6 +139,7 @@ tinygo build -size short -o ./build/test.uf2 -target=pico ./examples/mcp9808/mai
 tinygo build -size short -o ./build/test.uf2 -target=pico ./examples/tmc2209/main.go
 tinygo build -size short -o ./build/test.hex -target=pico ./examples/tmc5160/main.go
 tinygo build -size short -o ./build/test.uf2 -target=nicenano ./examples/sharpmem/main.go
+tinygo build -size short -o ./build/test.hex -target=feather-nrf52840 ./examples/max6675/main.go
 # network examples (espat)
 tinygo build -size short -o ./build/test.hex -target=challenger-rp2040 ./examples/net/ntpclient/
 # network examples (wifinina)


### PR DESCRIPTION
Small SPI device for reading temperatures from a probe.

Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/max6675.pdf

Tested with feather-nrf52840 and a generic breakout board.

Happy to make any changes to match conventions, I looked at some of the other devices in here and tried to conform to the style.  I did not see a test framework for SPI so did not end up writing any tests.

Thanks! 