### PR TITLE
chore: update all SPI usage to use either *machine.SPI or drivers.SPI

### DIFF
--- a/examples/flash/console/spi/main.go
+++ b/examples/flash/console/spi/main.go
@@ -10,7 +10,7 @@ import (
 func main() {
 	console_example.RunFor(
 		flash.NewSPI(
-			&machine.SPI1,
+			machine.SPI1,
 			machine.SPI1_SDO_PIN,
 			machine.SPI1_SDI_PIN,
 			machine.SPI1_SCK_PIN,

--- a/examples/sdcard/console/feather-m4.go
+++ b/examples/sdcard/console/feather-m4.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	spi = &machine.SPI0
+	spi = machine.SPI0
 	sckPin = machine.SPI0_SCK_PIN
 	sdoPin = machine.SPI0_SDO_PIN
 	sdiPin = machine.SPI0_SDI_PIN

--- a/examples/sdcard/console/grandcentral-m4.go
+++ b/examples/sdcard/console/grandcentral-m4.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	spi = &machine.SPI1
+	spi = machine.SPI1
 	sckPin = machine.SDCARD_SCK_PIN
 	sdoPin = machine.SDCARD_SDO_PIN
 	sdiPin = machine.SDCARD_SDI_PIN

--- a/examples/sdcard/console/m0.go
+++ b/examples/sdcard/console/m0.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	spi = &machine.SPI0
+	spi = machine.SPI0
 	sckPin = machine.SPI0_SCK_PIN
 	sdoPin = machine.SPI0_SDO_PIN
 	sdiPin = machine.SPI0_SDI_PIN

--- a/examples/sdcard/console/p1am-100.go
+++ b/examples/sdcard/console/p1am-100.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	spi = &machine.SDCARD_SPI
+	spi = machine.SDCARD_SPI
 	sckPin = machine.SDCARD_SCK_PIN
 	sdoPin = machine.SDCARD_SDO_PIN
 	sdiPin = machine.SDCARD_SDI_PIN

--- a/examples/sdcard/console/pygamer.go
+++ b/examples/sdcard/console/pygamer.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	spi = &machine.SPI0
+	spi = machine.SPI0
 	sckPin = machine.SPI0_SCK_PIN
 	sdoPin = machine.SPI0_SDO_PIN
 	sdiPin = machine.SPI0_SDI_PIN

--- a/examples/sdcard/console/pyportal.go
+++ b/examples/sdcard/console/pyportal.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	spi = &machine.SPI0
+	spi = machine.SPI0
 	sckPin = machine.SPI0_SCK_PIN
 	sdoPin = machine.SPI0_SDO_PIN
 	sdiPin = machine.SPI0_SDI_PIN

--- a/examples/sdcard/console/wioterminal.go
+++ b/examples/sdcard/console/wioterminal.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	spi = &machine.SPI2
+	spi = machine.SPI2
 	sckPin = machine.SCK2
 	sdoPin = machine.SDO2
 	sdiPin = machine.SDI2

--- a/examples/tmc5160/main.go
+++ b/examples/tmc5160/main.go
@@ -27,7 +27,7 @@ func main() {
 	//bind csPin to driverAdddress
 	driverAddress := uint8(0) // Let's assume we are working with driver at address 0x01
 	// Step 3. Bind the communication interface to the protocol
-	comm := tmc5160.NewSPIComm(*spi, csPins)
+	comm := tmc5160.NewSPIComm(spi, csPins)
 	// Step 4. Define your stepper like this below
 	//stepper := tmc5160.NewStepper(angle , gearRatio  vSupply  rCoil , lCoil , iPeak , rSense , mSteps, fclk )
 	stepper := tmc5160.NewDefaultStepper() // Default Stepper should be used only for testing.

--- a/ili9341/spi_atsamd21.go
+++ b/ili9341/spi_atsamd21.go
@@ -8,10 +8,10 @@ import (
 )
 
 type spiDriver struct {
-	bus machine.SPI
+	bus *machine.SPI
 }
 
-func NewSPI(bus machine.SPI, dc, cs, rst machine.Pin) *Device {
+func NewSPI(bus *machine.SPI, dc, cs, rst machine.Pin) *Device {
 	return &Device{
 		dc:  dc,
 		cs:  cs,

--- a/ili9341/spi_atsamd51.go
+++ b/ili9341/spi_atsamd51.go
@@ -8,10 +8,10 @@ import (
 )
 
 type spiDriver struct {
-	bus machine.SPI
+	bus *machine.SPI
 }
 
-func NewSPI(bus machine.SPI, dc, cs, rst machine.Pin) *Device {
+func NewSPI(bus *machine.SPI, dc, cs, rst machine.Pin) *Device {
 	return &Device{
 		dc:  dc,
 		cs:  cs,

--- a/max6675/max6675.go
+++ b/max6675/max6675.go
@@ -4,6 +4,8 @@ package max6675
 import (
 	"errors"
 	"machine"
+
+	"tinygo.org/x/drivers"
 )
 
 // ErrThermocoupleOpen is returned when the thermocouple input is open.
@@ -11,14 +13,14 @@ import (
 var ErrThermocoupleOpen = errors.New("thermocouple input open")
 
 type Device struct {
-	bus machine.SPI
+	bus drivers.SPI
 	cs  machine.Pin
 }
 
 // Create a new Device to read from a MAX6675 thermocouple.
 // Pins must be configured before use.  Frequency for SPI
 // should be 4.3MHz maximum.
-func NewDevice(bus machine.SPI, cs machine.Pin) *Device {
+func NewDevice(bus drivers.SPI, cs machine.Pin) *Device {
 	return &Device{
 		bus: bus,
 		cs:  cs,

--- a/max72xx/max72xx.go
+++ b/max72xx/max72xx.go
@@ -4,17 +4,19 @@ package max72xx
 
 import (
 	"machine"
+
+	"tinygo.org/x/drivers"
 )
 
 type Device struct {
-	bus machine.SPI
+	bus drivers.SPI
 	cs  machine.Pin
 }
 
 // NewDriver creates a new max7219 connection. The SPI wire must already be configured
 // The SPI frequency must not be higher than 10MHz.
 // parameter cs: the datasheet also refers to this pin as "load" pin.
-func NewDevice(bus machine.SPI, cs machine.Pin) *Device {
+func NewDevice(bus drivers.SPI, cs machine.Pin) *Device {
 	return &Device{
 		bus: bus,
 		cs:  cs,

--- a/p1am/p1am.go
+++ b/p1am/p1am.go
@@ -14,7 +14,8 @@ import (
 )
 
 type P1AM struct {
-	bus                                        machine.SPI
+	bus *machine.SPI
+
 	slaveSelectPin, slaveAckPin, baseEnablePin machine.Pin
 
 	// SkipAutoConfig will skip loading a default configuration into each module.

--- a/sx127x/sx127x.go
+++ b/sx127x/sx127x.go
@@ -43,7 +43,7 @@ func (d *Device) GetRadioEventChan() chan lora.RadioEvent {
 }
 
 // New creates a new SX127x connection. The SPI bus must already be configured.
-func New(spi machine.SPI, rstPin machine.Pin) *Device {
+func New(spi drivers.SPI, rstPin machine.Pin) *Device {
 	k := Device{
 		spi:            spi,
 		rstPin:         rstPin,

--- a/tmc5160/README.MD
+++ b/tmc5160/README.MD
@@ -183,7 +183,7 @@ if err != nil {
 
 ## API Reference
 
-    NewSPIComm(spi machine.SPI, csPins map[uint8]machine.Pin) *SPIComm
+    NewSPIComm(spi *machine.SPI, csPins map[uint8]machine.Pin) *SPIComm
 
 Creates a new SPI communication interface for the TMC5160.
 

--- a/waveshare-epd/epd1in54/epd1in54.go
+++ b/waveshare-epd/epd1in54/epd1in54.go
@@ -22,7 +22,7 @@ type Config struct {
 }
 
 type Device struct {
-	bus  machine.SPI
+	bus  *machine.SPI
 	cs   machine.Pin
 	dc   machine.Pin
 	rst  machine.Pin
@@ -79,7 +79,7 @@ var partialRefresh = [159]uint8{
 }
 
 // New returns a new epd1in54 driver. Pass in a fully configured SPI bus.
-func New(bus machine.SPI, csPin, dcPin, rstPin, busyPin machine.Pin) Device {
+func New(bus *machine.SPI, csPin, dcPin, rstPin, busyPin machine.Pin) Device {
 	return Device{
 		buffer: make([]uint8, (uint32(Width)*uint32(Height))/8),
 		bus:    bus,


### PR DESCRIPTION
This PR is to update all SPI usage to use either `*machine.SPI` or `drivers.SPI` to accommodate recent switch in machine package to always use `*machine.SPI`.