### PR TITLE
refactor: add drivers.Pin interface

### DIFF
--- a/apa102/apa102.go
+++ b/apa102/apa102.go
@@ -5,7 +5,6 @@ package apa102 // import "tinygo.org/x/drivers/apa102"
 
 import (
 	"image/color"
-	"machine"
 
 	"tinygo.org/x/drivers"
 )
@@ -37,7 +36,7 @@ func New(b drivers.SPI) *Device {
 
 // NewSoftwareSPI returns a new APA102 driver that will use a software based
 // implementation of the SPI protocol.
-func NewSoftwareSPI(sckPin, sdoPin machine.Pin, delay uint32) *Device {
+func NewSoftwareSPI(sckPin, sdoPin drivers.Pin, delay uint32) *Device {
 	return New(&bbSPI{SCK: sckPin, SDO: sdoPin, Delay: delay})
 }
 

--- a/apa102/softspi.go
+++ b/apa102/softspi.go
@@ -1,6 +1,8 @@
 package apa102
 
-import "machine"
+import (
+	"tinygo.org/x/drivers"
+)
 
 // bbSPI is a dumb bit-bang implementation of SPI protocol that is hardcoded
 // to mode 0 and ignores trying to receive data. Just enough for the APA102.
@@ -8,15 +10,14 @@ import "machine"
 // most purposes other than the APA102 package. It might be desirable to make
 // this more generic and include it in the TinyGo "machine" package instead.
 type bbSPI struct {
-	SCK   machine.Pin
-	SDO   machine.Pin
+	SCK   drivers.Pin
+	SDO   drivers.Pin
 	Delay uint32
 }
 
-// Configure sets up the SCK and SDO pins as outputs and sets them low
+// Configure sets the SCK and SDO pins to low.
+// Note that the SCK and SDO pins must already be configured as outputs.
 func (s *bbSPI) Configure() {
-	s.SCK.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	s.SDO.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	s.SCK.Low()
 	s.SDO.Low()
 	if s.Delay == 0 {

--- a/bmi160/bmi160.go
+++ b/bmi160/bmi160.go
@@ -1,7 +1,6 @@
 package bmi160
 
 import (
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers"
@@ -11,7 +10,7 @@ import (
 // also an I2C interface, but it is not yet supported.
 type DeviceSPI struct {
 	// Chip select pin
-	CSB machine.Pin
+	CSB drivers.Pin
 
 	buf [7]byte
 
@@ -22,18 +21,16 @@ type DeviceSPI struct {
 // NewSPI returns a new device driver. The pin and SPI interface are not
 // touched, provide a fully configured SPI object and call Configure to start
 // using this device.
-func NewSPI(csb machine.Pin, spi drivers.SPI) *DeviceSPI {
+func NewSPI(csb drivers.Pin, spi drivers.SPI) *DeviceSPI {
 	return &DeviceSPI{
 		CSB: csb, // chip select
 		Bus: spi,
 	}
 }
 
-// Configure configures the BMI160 for use. It configures the CSB pin and
-// configures the BMI160, but it does not configure the SPI interface (it is
-// assumed to be up and running).
+// Configure configures the BMI160 for use. The CSB pin  anf the SPI interface
+// should be configured already. This function configures the BMI160 only.
 func (d *DeviceSPI) Configure() error {
-	d.CSB.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	d.CSB.High()
 
 	// The datasheet recommends doing a register read from address 0x7F to get

--- a/buzzer/buzzer.go
+++ b/buzzer/buzzer.go
@@ -2,20 +2,20 @@
 package buzzer // import "tinygo.org/x/drivers/buzzer"
 
 import (
-	"machine"
-
 	"time"
+
+	"tinygo.org/x/drivers"
 )
 
 // Device wraps a GPIO connection to a buzzer.
 type Device struct {
-	pin  machine.Pin
+	pin  drivers.Pin
 	High bool
 	BPM  float64
 }
 
 // New returns a new buzzer driver given which pin to use
-func New(pin machine.Pin) Device {
+func New(pin drivers.Pin) Device {
 	return Device{
 		pin:  pin,
 		High: false,

--- a/easystepper/easystepper.go
+++ b/easystepper/easystepper.go
@@ -3,8 +3,9 @@ package easystepper // import "tinygo.org/x/drivers/easystepper"
 
 import (
 	"errors"
-	"machine"
 	"time"
+
+	"tinygo.org/x/drivers"
 )
 
 // StepMode determines the coil sequence used to perform a single step
@@ -33,7 +34,7 @@ func (sm StepMode) stepCount() uint {
 // DeviceConfig contains the configuration data for a single easystepper driver
 type DeviceConfig struct {
 	// Pin1 ... Pin4 determines the pins to configure and use for the device
-	Pin1, Pin2, Pin3, Pin4 machine.Pin
+	Pin1, Pin2, Pin3, Pin4 drivers.Pin
 	// StepCount is the number of steps required to perform a full revolution of the stepper motor
 	StepCount uint
 	// RPM determines the speed of the stepper motor in 'Revolutions per Minute'
@@ -46,12 +47,12 @@ type DeviceConfig struct {
 type DualDeviceConfig struct {
 	DeviceConfig
 	// Pin5 ... Pin8 determines the pins to configure and use for the second device
-	Pin5, Pin6, Pin7, Pin8 machine.Pin
+	Pin5, Pin6, Pin7, Pin8 drivers.Pin
 }
 
 // Device holds the pins and the delay between steps
 type Device struct {
-	pins       [4]machine.Pin
+	pins       [4]drivers.Pin
 	stepDelay  time.Duration
 	stepNumber uint8
 	stepMode   StepMode
@@ -68,17 +69,15 @@ func New(config DeviceConfig) (*Device, error) {
 		return nil, errors.New("config.StepCount and config.RPM must be > 0")
 	}
 	return &Device{
-		pins:      [4]machine.Pin{config.Pin1, config.Pin2, config.Pin3, config.Pin4},
+		pins:      [4]drivers.Pin{config.Pin1, config.Pin2, config.Pin3, config.Pin4},
 		stepDelay: time.Second * 60 / time.Duration((config.StepCount * config.RPM)),
 		stepMode:  config.Mode,
 	}, nil
 }
 
-// Configure configures the pins of the Device
+// Configure does nothing, as it assumes that the pins of the Device have already
+// been configured by the user as outputs.
 func (d *Device) Configure() {
-	for _, pin := range d.pins {
-		pin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	}
 }
 
 // NewDual returns a new dual easystepper driver given 8 pins, number of steps and rpm

--- a/ft6336/ft6336.go
+++ b/ft6336/ft6336.go
@@ -5,8 +5,6 @@
 package ft6336
 
 import (
-	"machine"
-
 	"tinygo.org/x/drivers"
 	"tinygo.org/x/drivers/internal/legacy"
 	"tinygo.org/x/drivers/touch"
@@ -17,11 +15,11 @@ type Device struct {
 	bus     drivers.I2C
 	buf     []byte
 	Address uint8
-	intPin  machine.Pin
+	intPin  drivers.Pin
 }
 
 // New returns FT6336 device for the provided I2C bus using default address.
-func New(i2c drivers.I2C, intPin machine.Pin) *Device {
+func New(i2c drivers.I2C, intPin drivers.Pin) *Device {
 	return &Device{
 		bus:     i2c,
 		buf:     make([]byte, 11),
@@ -34,10 +32,10 @@ func New(i2c drivers.I2C, intPin machine.Pin) *Device {
 type Config struct {
 }
 
-// Configure the FT6336 device.
+// Configure the FT6336 device. Note that the interrupt pin must be configured
+// separately as an input.
 func (d *Device) Configure(config Config) error {
 	d.write1Byte(0xA4, 0x00)
-	d.intPin.Configure(machine.PinConfig{Mode: machine.PinInputPulldown})
 	return nil
 }
 

--- a/gc9a01/gc9a01.go
+++ b/gc9a01/gc9a01.go
@@ -5,7 +5,6 @@ package gc9a01 // import "tinygo.org/x/drivers/gc9a01"
 
 import (
 	"image/color"
-	"machine"
 	"time"
 
 	"errors"
@@ -22,10 +21,10 @@ type FrameRate uint8
 // Device wraps an SPI connection.
 type Device struct {
 	bus             drivers.SPI
-	dcPin           machine.Pin
-	resetPin        machine.Pin
-	csPin           machine.Pin
-	blPin           machine.Pin
+	dcPin           drivers.Pin
+	resetPin        drivers.Pin
+	csPin           drivers.Pin
+	blPin           drivers.Pin
 	width           int16
 	height          int16
 	columnOffsetCfg int16
@@ -51,12 +50,9 @@ type Config struct {
 	Height       int16
 }
 
-// New creates a new ST7789 connection. The SPI wire must already be configured.
-func New(bus drivers.SPI, resetPin, dcPin, csPin, blPin machine.Pin) Device {
-	resetPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	blPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+// New creates a new ST7789 connection. The SPI wire must already be configured, along with the
+// data/command and reset pins as outputs.
+func New(bus drivers.SPI, resetPin, dcPin, csPin, blPin drivers.Pin) Device {
 	return Device{
 		bus:      bus,
 		resetPin: resetPin,

--- a/hcsr04/hcsr04.go
+++ b/hcsr04/hcsr04.go
@@ -5,30 +5,31 @@
 package hcsr04
 
 import (
-	"machine"
 	"time"
+
+	"tinygo.org/x/drivers"
 )
 
 const TIMEOUT = 23324 // max sensing distance (4m)
 
 // Device holds the pins
 type Device struct {
-	trigger machine.Pin
-	echo    machine.Pin
+	trigger drivers.Pin
+	echo    drivers.Pin
 }
 
 // New returns a new ultrasonic driver given 2 pins
-func New(trigger, echo machine.Pin) Device {
+func New(trigger, echo drivers.Pin) Device {
 	return Device{
 		trigger: trigger,
 		echo:    echo,
 	}
 }
 
-// Configure configures the pins of the Device
+// Configure expects that the pins of the Device have already
+// been configured by the user. Trigger pin should be an output
+// and echo pin should be an input.
 func (d *Device) Configure() {
-	d.trigger.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.echo.Configure(machine.PinConfig{Mode: machine.PinInput})
 }
 
 // ReadDistance returns the distance of the object in mm

--- a/max6675/max6675.go
+++ b/max6675/max6675.go
@@ -3,7 +3,6 @@ package max6675
 
 import (
 	"errors"
-	"machine"
 
 	"tinygo.org/x/drivers"
 )
@@ -14,13 +13,13 @@ var ErrThermocoupleOpen = errors.New("thermocouple input open")
 
 type Device struct {
 	bus drivers.SPI
-	cs  machine.Pin
+	cs  drivers.Pin
 }
 
 // Create a new Device to read from a MAX6675 thermocouple.
 // Pins must be configured before use.  Frequency for SPI
 // should be 4.3MHz maximum.
-func NewDevice(bus drivers.SPI, cs machine.Pin) *Device {
+func NewDevice(bus drivers.SPI, cs drivers.Pin) *Device {
 	return &Device{
 		bus: bus,
 		cs:  cs,

--- a/max72xx/max72xx.go
+++ b/max72xx/max72xx.go
@@ -3,31 +3,26 @@
 package max72xx
 
 import (
-	"machine"
-
 	"tinygo.org/x/drivers"
 )
 
 type Device struct {
 	bus drivers.SPI
-	cs  machine.Pin
+	cs  drivers.Pin
 }
 
 // NewDriver creates a new max7219 connection. The SPI wire must already be configured
 // The SPI frequency must not be higher than 10MHz.
 // parameter cs: the datasheet also refers to this pin as "load" pin.
-func NewDevice(bus drivers.SPI, cs machine.Pin) *Device {
+func NewDevice(bus drivers.SPI, cs drivers.Pin) *Device {
 	return &Device{
 		bus: bus,
 		cs:  cs,
 	}
 }
 
-// Configure setups the pins.
+// Configure expects that the pin of the Device has already been configured by the user as output.
 func (driver *Device) Configure() {
-	outPutConfig := machine.PinConfig{Mode: machine.PinOutput}
-
-	driver.cs.Configure(outPutConfig)
 }
 
 // SetScanLimit sets the scan limit. Maximum is 8.

--- a/mcp2515/mcp2515.go
+++ b/mcp2515/mcp2515.go
@@ -8,7 +8,6 @@ package mcp2515 // import "tinygo.org/x/drivers/mcp2515"
 import (
 	"errors"
 	"fmt"
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers"
@@ -17,7 +16,7 @@ import (
 // Device wraps MCP2515 SPI CAN Module.
 type Device struct {
 	spi     SPI
-	cs      machine.Pin
+	cs      drivers.Pin
 	msg     *CANMsg
 	mcpMode byte
 }
@@ -36,7 +35,7 @@ const (
 )
 
 // New returns a new MCP2515 driver. Pass in a fully configured SPI bus.
-func New(b drivers.SPI, csPin machine.Pin) *Device {
+func New(b drivers.SPI, csPin drivers.Pin) *Device {
 	d := &Device{
 		spi: SPI{
 			bus: b,
@@ -50,9 +49,9 @@ func New(b drivers.SPI, csPin machine.Pin) *Device {
 	return d
 }
 
-// Configure sets up the device for communication.
+// Configure sets up the device for communication. It expects the SPI interface to be already
+// configured, and the CS configured as output.
 func (d *Device) Configure() {
-	d.cs.Configure(machine.PinConfig{Mode: machine.PinOutput})
 }
 
 const beginTimeoutValue int = 10

--- a/pcd8544/pcd8544.go
+++ b/pcd8544/pcd8544.go
@@ -6,7 +6,6 @@ package pcd8544 // import "tinygo.org/x/drivers/pcd8544"
 import (
 	"errors"
 	"image/color"
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers"
@@ -15,9 +14,9 @@ import (
 // Device wraps an SPI connection.
 type Device struct {
 	bus        drivers.SPI
-	dcPin      machine.Pin
-	rstPin     machine.Pin
-	scePin     machine.Pin
+	dcPin      drivers.Pin
+	rstPin     drivers.Pin
+	scePin     drivers.Pin
 	buffer     []byte
 	width      int16
 	height     int16
@@ -29,8 +28,8 @@ type Config struct {
 	Height int16
 }
 
-// New creates a new PCD8544 connection. The SPI bus must already be configured.
-func New(bus drivers.SPI, dcPin, rstPin, scePin machine.Pin) *Device {
+// New creates a new PCD8544 connection. The SPI bus and pins must already be configured.
+func New(bus drivers.SPI, dcPin, rstPin, scePin drivers.Pin) *Device {
 	return &Device{
 		bus:    bus,
 		dcPin:  dcPin,

--- a/pin.go
+++ b/pin.go
@@ -1,0 +1,10 @@
+package drivers
+
+// Pin is a digital pin interface. It is notably implemented by the
+// machine.Pin type.
+type Pin interface {
+	Get() bool
+	High()
+	Low()
+	Set(high bool)
+}

--- a/shiftregister/shiftregister.go
+++ b/shiftregister/shiftregister.go
@@ -2,7 +2,7 @@
 package shiftregister
 
 import (
-	"machine"
+	"tinygo.org/x/drivers"
 )
 
 type NumberBit int8
@@ -16,20 +16,20 @@ const (
 
 // Device holds pin number
 type Device struct {
-	latch, clock, out machine.Pin // IC wiring
+	latch, clock, out drivers.Pin // IC wiring
 	bits              NumberBit   // Pin number
 	mask              uint32      // keep all pins state
 }
 
 // ShiftPin is the implementation of the ShiftPin interface.
-// ShiftPin provide an interface like regular machine.Pin
+// ShiftPin provide an interface like regular drivers.Pin
 type ShiftPin struct {
 	mask uint32  // Bit representing the pin
 	d    *Device // Reference to the register
 }
 
 // New returns a new shift output register device
-func New(Bits NumberBit, Latch, Clock, Out machine.Pin) *Device {
+func New(Bits NumberBit, Latch, Clock, Out drivers.Pin) *Device {
 	return &Device{
 		latch: Latch,
 		clock: Clock,
@@ -38,11 +38,9 @@ func New(Bits NumberBit, Latch, Clock, Out machine.Pin) *Device {
 	}
 }
 
-// Configure set hardware configuration
+// Configure set hardware configuration. Make sure that the pins are already configured
+// as output.
 func (d *Device) Configure() {
-	d.latch.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.clock.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.out.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	d.latch.High()
 }
 

--- a/ssd1289/ssd1289.go
+++ b/ssd1289/ssd1289.go
@@ -5,8 +5,9 @@ package ssd1289
 
 import (
 	"image/color"
-	"machine"
 	"time"
+
+	"tinygo.org/x/drivers"
 )
 
 type Bus interface {
@@ -14,17 +15,17 @@ type Bus interface {
 }
 
 type Device struct {
-	rs  machine.Pin
-	wr  machine.Pin
-	cs  machine.Pin
-	rst machine.Pin
+	rs  drivers.Pin
+	wr  drivers.Pin
+	cs  drivers.Pin
+	rst drivers.Pin
 	bus Bus
 }
 
 const width = int16(240)
 const height = int16(320)
 
-func New(rs machine.Pin, wr machine.Pin, cs machine.Pin, rst machine.Pin, bus Bus) Device {
+func New(rs drivers.Pin, wr drivers.Pin, cs drivers.Pin, rst drivers.Pin, bus Bus) Device {
 	d := Device{
 		rs:  rs,
 		wr:  wr,
@@ -32,11 +33,6 @@ func New(rs machine.Pin, wr machine.Pin, cs machine.Pin, rst machine.Pin, bus Bu
 		rst: rst,
 		bus: bus,
 	}
-
-	rs.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	wr.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	cs.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	rst.Configure(machine.PinConfig{Mode: machine.PinOutput})
 
 	cs.High()
 	rst.High()

--- a/ssd1306/ssd1306.go
+++ b/ssd1306/ssd1306.go
@@ -6,7 +6,6 @@ package ssd1306 // import "tinygo.org/x/drivers/ssd1306"
 import (
 	"errors"
 	"image/color"
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers"
@@ -58,9 +57,9 @@ type I2CBus struct {
 
 type SPIBus struct {
 	wire     drivers.SPI
-	dcPin    machine.Pin
-	resetPin machine.Pin
-	csPin    machine.Pin
+	dcPin    drivers.Pin
+	resetPin drivers.Pin
+	csPin    drivers.Pin
 }
 
 type Buser interface {
@@ -81,11 +80,8 @@ func NewI2C(bus drivers.I2C) Device {
 	}
 }
 
-// NewSPI creates a new SSD1306 connection. The SPI wire must already be configured.
-func NewSPI(bus drivers.SPI, dcPin, resetPin, csPin machine.Pin) Device {
-	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	resetPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+// NewSPI creates a new SSD1306 connection. The SPI wire and pins must already be configured.
+func NewSPI(bus drivers.SPI, dcPin, resetPin, csPin drivers.Pin) Device {
 	return Device{
 		bus: &SPIBus{
 			wire:     bus,

--- a/ssd1331/ssd1331.go
+++ b/ssd1331/ssd1331.go
@@ -5,7 +5,6 @@ package ssd1331 // import "tinygo.org/x/drivers/ssd1331"
 
 import (
 	"image/color"
-	"machine"
 
 	"errors"
 	"time"
@@ -19,9 +18,9 @@ type Rotation uint8
 // Device wraps an SPI connection.
 type Device struct {
 	bus         drivers.SPI
-	dcPin       machine.Pin
-	resetPin    machine.Pin
-	csPin       machine.Pin
+	dcPin       drivers.Pin
+	resetPin    drivers.Pin
+	csPin       drivers.Pin
 	width       int16
 	height      int16
 	batchLength int16
@@ -35,11 +34,8 @@ type Config struct {
 	Height int16
 }
 
-// New creates a new SSD1331 connection. The SPI wire must already be configured.
-func New(bus drivers.SPI, resetPin, dcPin, csPin machine.Pin) Device {
-	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	resetPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+// New creates a new SSD1331 connection. The SPI wire and pins must already be configured.
+func New(bus drivers.SPI, resetPin, dcPin, csPin drivers.Pin) Device {
 	return Device{
 		bus:      bus,
 		dcPin:    dcPin,

--- a/ssd1351/ssd1351.go
+++ b/ssd1351/ssd1351.go
@@ -6,7 +6,6 @@ package ssd1351 // import "tinygo.org/x/drivers/ssd1351"
 import (
 	"errors"
 	"image/color"
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers"
@@ -20,11 +19,11 @@ var (
 // Device wraps an SPI connection.
 type Device struct {
 	bus          drivers.SPI
-	dcPin        machine.Pin
-	resetPin     machine.Pin
-	csPin        machine.Pin
-	enPin        machine.Pin
-	rwPin        machine.Pin
+	dcPin        drivers.Pin
+	resetPin     drivers.Pin
+	csPin        drivers.Pin
+	enPin        drivers.Pin
+	rwPin        drivers.Pin
 	width        int16
 	height       int16
 	rowOffset    int16
@@ -41,7 +40,7 @@ type Config struct {
 }
 
 // New creates a new SSD1351 connection. The SPI wire must already be configured.
-func New(bus drivers.SPI, resetPin, dcPin, csPin, enPin, rwPin machine.Pin) Device {
+func New(bus drivers.SPI, resetPin, dcPin, csPin, enPin, rwPin drivers.Pin) Device {
 	return Device{
 		bus:      bus,
 		dcPin:    dcPin,
@@ -71,13 +70,6 @@ func (d *Device) Configure(cfg Config) {
 	if d.height > d.width {
 		d.bufferLength = d.height
 	}
-
-	// configure GPIO pins
-	d.dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.resetPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.enPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.rwPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
 
 	// reset the device
 	d.resetPin.High()

--- a/st7735/st7735.go
+++ b/st7735/st7735.go
@@ -5,7 +5,6 @@ package st7735 // import "tinygo.org/x/drivers/st7735"
 
 import (
 	"image/color"
-	"machine"
 	"time"
 
 	"errors"
@@ -39,10 +38,10 @@ type Device = DeviceOf[pixel.RGB565BE]
 // formats.
 type DeviceOf[T Color] struct {
 	bus          drivers.SPI
-	dcPin        machine.Pin
-	resetPin     machine.Pin
-	csPin        machine.Pin
-	blPin        machine.Pin
+	dcPin        drivers.Pin
+	resetPin     drivers.Pin
+	csPin        drivers.Pin
+	blPin        drivers.Pin
 	width        int16
 	height       int16
 	columnOffset int16
@@ -65,17 +64,13 @@ type Config struct {
 }
 
 // New creates a new ST7735 connection. The SPI wire must already be configured.
-func New(bus drivers.SPI, resetPin, dcPin, csPin, blPin machine.Pin) Device {
+func New(bus drivers.SPI, resetPin, dcPin, csPin, blPin drivers.Pin) Device {
 	return NewOf[pixel.RGB565BE](bus, resetPin, dcPin, csPin, blPin)
 }
 
 // NewOf creates a new ST7735 connection with a particular pixel format. The SPI
-// wire must already be configured.
-func NewOf[T Color](bus drivers.SPI, resetPin, dcPin, csPin, blPin machine.Pin) DeviceOf[T] {
-	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	resetPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	blPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+// wire and pins must already be configured.
+func NewOf[T Color](bus drivers.SPI, resetPin, dcPin, csPin, blPin drivers.Pin) DeviceOf[T] {
 	return DeviceOf[T]{
 		bus:      bus,
 		dcPin:    dcPin,

--- a/st7789/st7789.go
+++ b/st7789/st7789.go
@@ -46,10 +46,10 @@ type Device = DeviceOf[pixel.RGB565BE]
 // formats.
 type DeviceOf[T Color] struct {
 	bus             drivers.SPI
-	dcPin           machine.Pin
-	resetPin        machine.Pin
-	csPin           machine.Pin
-	blPin           machine.Pin
+	dcPin           drivers.Pin
+	resetPin        drivers.Pin
+	csPin           drivers.Pin
+	blPin           drivers.Pin
 	width           int16
 	height          int16
 	columnOffsetCfg int16
@@ -83,17 +83,13 @@ type Config struct {
 }
 
 // New creates a new ST7789 connection. The SPI wire must already be configured.
-func New(bus drivers.SPI, resetPin, dcPin, csPin, blPin machine.Pin) Device {
+func New(bus drivers.SPI, resetPin, dcPin, csPin, blPin drivers.Pin) Device {
 	return NewOf[pixel.RGB565BE](bus, resetPin, dcPin, csPin, blPin)
 }
 
 // NewOf creates a new ST7789 connection with a particular pixel format. The SPI
-// wire must already be configured.
-func NewOf[T Color](bus drivers.SPI, resetPin, dcPin, csPin, blPin machine.Pin) DeviceOf[T] {
-	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	resetPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	blPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+// wire and pins must already be configured.
+func NewOf[T Color](bus drivers.SPI, resetPin, dcPin, csPin, blPin drivers.Pin) DeviceOf[T] {
 	return DeviceOf[T]{
 		bus:      bus,
 		dcPin:    dcPin,

--- a/sx127x/sx127x.go
+++ b/sx127x/sx127x.go
@@ -6,7 +6,6 @@ package sx127x
 
 import (
 	"errors"
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers"
@@ -22,7 +21,7 @@ const (
 // Device wraps an SPI connection to a SX127x device.
 type Device struct {
 	spi            drivers.SPI          // SPI bus for module communication
-	rstPin         machine.Pin          // GPIO for reset
+	rstPin         drivers.Pin          // GPIO for reset
 	radioEventChan chan lora.RadioEvent // Channel for Receiving events
 	loraConf       lora.Config          // Current Lora configuration
 	controller     RadioController      // to manage interactions with the radio
@@ -43,7 +42,7 @@ func (d *Device) GetRadioEventChan() chan lora.RadioEvent {
 }
 
 // New creates a new SX127x connection. The SPI bus must already be configured.
-func New(spi drivers.SPI, rstPin machine.Pin) *Device {
+func New(spi drivers.SPI, rstPin drivers.Pin) *Device {
 	k := Device{
 		spi:            spi,
 		rstPin:         rstPin,

--- a/uc8151/uc8151.go
+++ b/uc8151/uc8151.go
@@ -8,7 +8,6 @@ package uc8151 // import "tinygo.org/x/drivers/uc8151"
 import (
 	"errors"
 	"image/color"
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers"
@@ -31,10 +30,10 @@ type Config struct {
 
 type Device struct {
 	bus                      drivers.SPI
-	cs                       machine.Pin
-	dc                       machine.Pin
-	rst                      machine.Pin
-	busy                     machine.Pin
+	cs                       drivers.Pin
+	dc                       drivers.Pin
+	rst                      drivers.Pin
+	busy                     drivers.Pin
 	width                    int16
 	height                   int16
 	buffer                   []uint8
@@ -48,12 +47,9 @@ type Device struct {
 
 type Speed uint8
 
-// New returns a new uc8151 driver. Pass in a fully configured SPI bus.
-func New(bus drivers.SPI, csPin, dcPin, rstPin, busyPin machine.Pin) Device {
-	csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	rstPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	busyPin.Configure(machine.PinConfig{Mode: machine.PinInput})
+// New returns a new uc8151 driver. Pass in a fully configured SPI bus and pins.
+// busyPin should be set and input, the others as outputs.
+func New(bus drivers.SPI, csPin, dcPin, rstPin, busyPin drivers.Pin) Device {
 	return Device{
 		bus:  bus,
 		cs:   csPin,

--- a/waveshare-epd/epd1in54/epd1in54.go
+++ b/waveshare-epd/epd1in54/epd1in54.go
@@ -12,6 +12,8 @@ import (
 	"image/color"
 	"machine"
 	"time"
+
+	"tinygo.org/x/drivers"
 )
 
 type Config struct {
@@ -23,10 +25,10 @@ type Config struct {
 
 type Device struct {
 	bus  *machine.SPI
-	cs   machine.Pin
-	dc   machine.Pin
-	rst  machine.Pin
-	busy machine.Pin
+	cs   drivers.Pin
+	dc   drivers.Pin
+	rst  drivers.Pin
+	busy drivers.Pin
 
 	buffer   []uint8
 	rotation Rotation
@@ -79,7 +81,7 @@ var partialRefresh = [159]uint8{
 }
 
 // New returns a new epd1in54 driver. Pass in a fully configured SPI bus.
-func New(bus *machine.SPI, csPin, dcPin, rstPin, busyPin machine.Pin) Device {
+func New(bus *machine.SPI, csPin, dcPin, rstPin, busyPin drivers.Pin) Device {
 	return Device{
 		buffer: make([]uint8, (uint32(Width)*uint32(Height))/8),
 		bus:    bus,
@@ -91,11 +93,6 @@ func New(bus *machine.SPI, csPin, dcPin, rstPin, busyPin machine.Pin) Device {
 }
 
 func (d *Device) LDirInit(cfg Config) {
-	d.cs.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.rst.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.dc.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.busy.Configure(machine.PinConfig{Mode: machine.PinInput})
-
 	d.bus.Configure(machine.SPIConfig{
 		Frequency: 2000000,
 		Mode:      0,
@@ -150,11 +147,6 @@ func (d *Device) LDirInit(cfg Config) {
 }
 
 func (d *Device) HDirInit(cfg Config) {
-	d.cs.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.rst.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.dc.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.busy.Configure(machine.PinConfig{Mode: machine.PinInput})
-
 	d.bus.Configure(machine.SPIConfig{
 		Frequency: 2000000,
 		Mode:      0,

--- a/waveshare-epd/epd2in13/epd2in13.go
+++ b/waveshare-epd/epd2in13/epd2in13.go
@@ -6,7 +6,6 @@ package epd2in13 // import "tinygo.org/x/drivers/waveshare-epd/epd2in13"
 import (
 	"errors"
 	"image/color"
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers"
@@ -21,10 +20,10 @@ type Config struct {
 
 type Device struct {
 	bus          drivers.SPI
-	cs           machine.Pin
-	dc           machine.Pin
-	rst          machine.Pin
-	busy         machine.Pin
+	cs           drivers.Pin
+	dc           drivers.Pin
+	rst          drivers.Pin
+	busy         drivers.Pin
 	logicalWidth int16
 	width        int16
 	height       int16
@@ -52,12 +51,9 @@ var lutPartialUpdate = [30]uint8{
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 }
 
-// New returns a new epd2in13x driver. Pass in a fully configured SPI bus.
-func New(bus drivers.SPI, csPin, dcPin, rstPin, busyPin machine.Pin) Device {
-	csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	rstPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	busyPin.Configure(machine.PinConfig{Mode: machine.PinInput})
+// New returns a new epd2in13x driver. Pass in a fully configured SPI bus and pins.
+// Busy pin should input, the rest should be output.
+func New(bus drivers.SPI, csPin, dcPin, rstPin, busyPin drivers.Pin) Device {
 	return Device{
 		bus:  bus,
 		cs:   csPin,

--- a/waveshare-epd/epd2in13x/epd2in13x.go
+++ b/waveshare-epd/epd2in13x/epd2in13x.go
@@ -6,7 +6,6 @@ package epd2in13x // import "tinygo.org/x/drivers/waveshare-epd/epd2in13x"
 import (
 	"errors"
 	"image/color"
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers"
@@ -20,10 +19,10 @@ type Config struct {
 
 type Device struct {
 	bus          drivers.SPI
-	cs           machine.Pin
-	dc           machine.Pin
-	rst          machine.Pin
-	busy         machine.Pin
+	cs           drivers.Pin
+	dc           drivers.Pin
+	rst          drivers.Pin
+	busy         drivers.Pin
 	width        int16
 	height       int16
 	buffer       [][]uint8
@@ -32,12 +31,9 @@ type Device struct {
 
 type Color uint8
 
-// New returns a new epd2in13x driver. Pass in a fully configured SPI bus.
-func New(bus drivers.SPI, csPin, dcPin, rstPin, busyPin machine.Pin) Device {
-	csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	rstPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	busyPin.Configure(machine.PinConfig{Mode: machine.PinInput})
+// New returns a new epd2in13x driver. Pass in a fully configured SPI bus and pins.
+// Busy pin should input, the rest should be output.
+func New(bus drivers.SPI, csPin, dcPin, rstPin, busyPin drivers.Pin) Device {
 	return Device{
 		bus:  bus,
 		cs:   csPin,

--- a/waveshare-epd/epd2in66b/dev.go
+++ b/waveshare-epd/epd2in66b/dev.go
@@ -5,7 +5,6 @@ package epd2in66b
 
 import (
 	"image/color"
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers"
@@ -19,18 +18,18 @@ const (
 const Baudrate = 4_000_000 // 4 MHz
 
 type Config struct {
-	ResetPin      machine.Pin
-	DataPin       machine.Pin
-	ChipSelectPin machine.Pin
-	BusyPin       machine.Pin
+	ResetPin      drivers.Pin
+	DataPin       drivers.Pin
+	ChipSelectPin drivers.Pin
+	BusyPin       drivers.Pin
 }
 
 type Device struct {
 	bus  drivers.SPI
-	cs   machine.Pin
-	dc   machine.Pin
-	rst  machine.Pin
-	busy machine.Pin
+	cs   drivers.Pin
+	dc   drivers.Pin
+	rst  drivers.Pin
+	busy drivers.Pin
 
 	blackBuffer []byte
 	redBuffer   []byte
@@ -50,17 +49,13 @@ func New(bus drivers.SPI) Device {
 	}
 }
 
-// Configure configures the device and its pins.
+// Configure configures the device. Note that pins should already
+// be configured. Busy pin should be input, the rest should be output.
 func (d *Device) Configure(c Config) error {
 	d.cs = c.ChipSelectPin
 	d.dc = c.DataPin
 	d.rst = c.ResetPin
 	d.busy = c.BusyPin
-
-	d.cs.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.dc.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.rst.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.busy.Configure(machine.PinConfig{Mode: machine.PinInput})
 
 	return nil
 }

--- a/waveshare-epd/epd2in9/epd2in9.go
+++ b/waveshare-epd/epd2in9/epd2in9.go
@@ -13,7 +13,6 @@ package epd2in9 // import "tinygo.org/x/drivers/waveshare-epd/epd2in9"
 
 import (
 	"image/color"
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers"
@@ -28,10 +27,10 @@ type Config struct {
 
 type Device struct {
 	bus          drivers.SPI
-	cs           machine.Pin
-	dc           machine.Pin
-	rst          machine.Pin
-	busy         machine.Pin
+	cs           drivers.Pin
+	dc           drivers.Pin
+	rst          drivers.Pin
+	busy         drivers.Pin
 	logicalWidth int16
 	width        int16
 	height       int16
@@ -60,12 +59,9 @@ var lutPartialUpdate = [30]uint8{
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 }
 
-// New returns a new epd2in9 driver. Pass in a fully configured SPI bus.
-func New(bus drivers.SPI, csPin, dcPin, rstPin, busyPin machine.Pin) Device {
-	csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	rstPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	busyPin.Configure(machine.PinConfig{Mode: machine.PinInput})
+// New returns a new epd2in9 driver. Pass in a fully configured SPI bus and pins.
+// Busy pin should input, the rest should be output.
+func New(bus drivers.SPI, csPin, dcPin, rstPin, busyPin drivers.Pin) Device {
 	return Device{
 		bus:  bus,
 		cs:   csPin,

--- a/waveshare-epd/epd4in2/epd4in2.go
+++ b/waveshare-epd/epd4in2/epd4in2.go
@@ -10,7 +10,6 @@ package epd4in2
 
 import (
 	"image/color"
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers"
@@ -25,10 +24,10 @@ type Config struct {
 
 type Device struct {
 	bus          drivers.SPI
-	cs           machine.Pin
-	dc           machine.Pin
-	rst          machine.Pin
-	busy         machine.Pin
+	cs           drivers.Pin
+	dc           drivers.Pin
+	rst          drivers.Pin
+	busy         drivers.Pin
 	logicalWidth int16
 	width        int16
 	height       int16
@@ -39,12 +38,9 @@ type Device struct {
 
 type Rotation uint8
 
-// New returns a new epd4in2 driver. Pass in a fully configured SPI bus.
-func New(bus drivers.SPI, csPin, dcPin, rstPin, busyPin machine.Pin) Device {
-	csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	rstPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	busyPin.Configure(machine.PinConfig{Mode: machine.PinInput})
+// New returns a new epd4in2 driver. Pass in a fully configured SPI bus and pins.
+// Busy pin should input, the rest should be output.
+func New(bus drivers.SPI, csPin, dcPin, rstPin, busyPin drivers.Pin) Device {
 	return Device{
 		bus:  bus,
 		cs:   csPin,


### PR DESCRIPTION
This PR is to add a `drivers.Pin` interface and use it everywhere that is easy to do so.

Related to work in PR #742 this is intended to help disconnect the drivers repo even more from the `machine` package.

The remaining drivers that use `machine.Pin` directly have various complications such as changing the pin config from input to output and back, which will have to be addressed in some different way.