### PR TITLE
tmc2209 bug fixes

### DIFF
--- a/tmc2209/uartcomm.go
+++ b/tmc2209/uartcomm.go
@@ -60,12 +60,7 @@ func (comm *UARTComm) WriteRegister(register uint8, value uint32, driverIndex ui
 		0,                          // CRC
 	}
 
-	// Calculate checksum by XORing all bytes
-	checksum := byte(0)
-	for _, b := range buffer[:7] {
-		checksum ^= b
-	}
-	buffer[7] = checksum // Set checksum byte
+	buffer[7] = comm.crc(buffer[:7])
 
 	// Write the data to the TMC2209
 	done := make(chan error, 1)
@@ -84,13 +79,29 @@ func (comm *UARTComm) WriteRegister(register uint8, value uint32, driverIndex ui
 	}
 }
 
+func (comm *UARTComm) crc(buf []byte) byte {
+	crc := byte(0)
+	for i := range buf {
+		currentByte := buf[i]
+		for j := 0; j < 8; j++ {
+			if (crc>>7)^(currentByte&0x01) > 0 {
+				crc = (crc << 1) ^ 0x07
+			} else {
+				crc = crc << 1
+			}
+			currentByte = currentByte >> 1
+		}
+	}
+	return crc
+}
+
 // ReadRegister sends a register read command to the TMC2209 with a timeout.
 func (comm *UARTComm) ReadRegister(register uint8, driverIndex uint8) (uint32, error) {
 	var writeBuffer [4]byte
-	writeBuffer[0] = 0x05                                             // Sync byte
-	writeBuffer[1] = 0x00                                             // Slave address
-	writeBuffer[2] = register & 0x7F                                  // Read command (MSB clear for read)
-	writeBuffer[3] = writeBuffer[0] ^ writeBuffer[1] ^ writeBuffer[2] // Checksum
+	writeBuffer[0] = 0x05            // Sync byte
+	writeBuffer[1] = 0x00            // Slave address
+	writeBuffer[2] = register & 0x7F // Read command (MSB clear for read)
+	writeBuffer[3] = comm.crc(writeBuffer[:3])
 
 	// Send the read command
 	done := make(chan []byte, 1)
@@ -104,11 +115,7 @@ func (comm *UARTComm) ReadRegister(register uint8, driverIndex uint8) (uint32, e
 	// Implementing timeout using a 100ms timer
 	select {
 	case readBuffer := <-done:
-		// Validate checksum
-		checksum := byte(0)
-		for i := 0; i < 7; i++ {
-			checksum ^= readBuffer[i]
-		}
+		checksum = comm.crc(readBuffer[:7])
 		if checksum != readBuffer[7] {
 			return 0, CustomError("checksum error")
 		}

--- a/tmc2209/uartcomm.go
+++ b/tmc2209/uartcomm.go
@@ -57,6 +57,7 @@ func (comm *UARTComm) WriteRegister(register uint8, value uint32, driverIndex ui
 		byte((value >> 16) & 0xFF), // Middle byte
 		byte((value >> 8) & 0xFF),  // Next byte
 		byte(value & 0xFF),         // LSB of value
+		0,                          // CRC
 	}
 
 	// Calculate checksum by XORing all bytes

--- a/tmc2209/uartcomm.go
+++ b/tmc2209/uartcomm.go
@@ -60,7 +60,7 @@ func (comm *UARTComm) WriteRegister(register uint8, value uint32, driverIndex ui
 		0,                          // CRC
 	}
 
-	buffer[7] = comm.crc(buffer[:7])
+	buffer[7] = CalculateCRC(buffer[:7])
 
 	// Write the data to the TMC2209
 	done := make(chan error, 1)
@@ -79,29 +79,13 @@ func (comm *UARTComm) WriteRegister(register uint8, value uint32, driverIndex ui
 	}
 }
 
-func (comm *UARTComm) crc(buf []byte) byte {
-	crc := byte(0)
-	for i := range buf {
-		currentByte := buf[i]
-		for j := 0; j < 8; j++ {
-			if (crc>>7)^(currentByte&0x01) > 0 {
-				crc = (crc << 1) ^ 0x07
-			} else {
-				crc = crc << 1
-			}
-			currentByte = currentByte >> 1
-		}
-	}
-	return crc
-}
-
 // ReadRegister sends a register read command to the TMC2209 with a timeout.
 func (comm *UARTComm) ReadRegister(register uint8, driverIndex uint8) (uint32, error) {
 	var writeBuffer [4]byte
 	writeBuffer[0] = 0x05            // Sync byte
 	writeBuffer[1] = 0x00            // Slave address
 	writeBuffer[2] = register & 0x7F // Read command (MSB clear for read)
-	writeBuffer[3] = comm.crc(writeBuffer[:3])
+	writeBuffer[3] = CalculateCRC(writeBuffer[:3])
 
 	// Send the read command
 	done := make(chan []byte, 1)
@@ -115,7 +99,7 @@ func (comm *UARTComm) ReadRegister(register uint8, driverIndex uint8) (uint32, e
 	// Implementing timeout using a 100ms timer
 	select {
 	case readBuffer := <-done:
-		checksum := comm.crc(readBuffer[:7])
+		checksum := CalculateCRC(readBuffer[:7])
 		if checksum != readBuffer[7] {
 			return 0, CustomError("checksum error")
 		}

--- a/tmc2209/uartcomm.go
+++ b/tmc2209/uartcomm.go
@@ -115,7 +115,7 @@ func (comm *UARTComm) ReadRegister(register uint8, driverIndex uint8) (uint32, e
 	// Implementing timeout using a 100ms timer
 	select {
 	case readBuffer := <-done:
-		checksum = comm.crc(readBuffer[:7])
+		checksum := comm.crc(readBuffer[:7])
 		if checksum != readBuffer[7] {
 			return 0, CustomError("checksum error")
 		}


### PR DESCRIPTION
I guess this means nobody has ever used this driver for controlling a TMC2209 via uart because it panics because the buffer is too small.

Even with this fix I'm unable to turn the motor via uart, but I'm not sure why.  If this PR piques someones interest in making a working example I'd be very grateful.  

EDIT:  I got the motor to turn.  The reason turned out to be due to calculating the crc incorrectly.  I pushed another commit that calculates crc according to the datasheet.