### PR TITLE
Remove unnecessary delays from SSD1306 SPI transfer code

### DIFF
--- a/ssd1306/ssd1306.go
+++ b/ssd1306/ssd1306.go
@@ -322,7 +322,6 @@ func (b *SPIBus) tx(data []byte, isCommand bool) error {
 
 	if isCommand {
 		b.csPin.High()
-		time.Sleep(1 * time.Millisecond)
 		b.dcPin.Low()
 		b.csPin.Low()
 
@@ -330,7 +329,6 @@ func (b *SPIBus) tx(data []byte, isCommand bool) error {
 		b.csPin.High()
 	} else {
 		b.csPin.High()
-		time.Sleep(1 * time.Millisecond)
 		b.dcPin.High()
 		b.csPin.Low()
 


### PR DESCRIPTION
Hello,

for my recent project I'm using a small SSD1306 display, 128x32, over SPI.

I've noticed that the SPI communication code - the tx function - has 1ms delay for each SPI transfer, which is quite a lot even if considered a "safety margin". There's 7ms of total delay introduced each time new screen contents are sent (set column address, set page address, then send buffer data). Actually, on lower performance microcontrollers this can be as much as 10ms, as tested with custom SAMD21 board. This makes it impossible to create an application that tries to target 60fps - games, smooth UI, etc.

This behaviour was introduced with the very first version of SSD1306 driver. I guess this went unnoticed because most of the time 128x64 displays are used, and registers are not updated in that case. The delay of 1.5ms was simply less of a problem than 10ms.

As an example, MicroPython SSD1306 library does not have any delay before each transaction. TinyGo SH1106 driver has 1µs (not 1ms), but based on comments even such tiny delay may be unnecessary.

I also fail to see why CS pin needs to be pulled high before DC pin is changed, but since other implementations have this logic let's keep it as is.
