### PR TITLE
Allow GPS with any i2c address (support PA1010D)

### DIFF
--- a/examples/gps/i2c/main.go
+++ b/examples/gps/i2c/main.go
@@ -10,7 +10,7 @@ import (
 func main() {
 	println("GPS I2C Example")
 	machine.I2C0.Configure(machine.I2CConfig{})
-	ublox := gps.NewI2C(machine.I2C0)
+	ublox := gps.NewI2CWithAddress(machine.I2C0, gps.UBLOX_I2C_ADDRESS)
 	parser := gps.NewParser()
 	var fix gps.Fix
 	for {

--- a/gps/gps.go
+++ b/gps/gps.go
@@ -69,10 +69,16 @@ func NewUART(uart drivers.UART) Device {
 }
 
 // NewI2C creates a new I2C GPS connection.
+// Uses the default i2c address (0x42) for backward compatibility reasons.
 func NewI2C(bus drivers.I2C) Device {
+	return NewI2CWithAddress(bus, I2C_ADDRESS)
+}
+
+// NewI2CWithAddress creates a new I2C GPS connection on the provided address
+func NewI2CWithAddress(bus drivers.I2C, i2cAddress uint16) Device {
 	return Device{
 		bus:      bus,
-		address:  I2C_ADDRESS,
+		address:  i2cAddress,
 		buffer:   make([]byte, bufferSize),
 		bufIdx:   bufferSize,
 		sentence: strings.Builder{},

--- a/gps/registers.go
+++ b/gps/registers.go
@@ -4,7 +4,11 @@ package gps
 
 // The I2C address which this device listens to.
 const (
-	I2C_ADDRESS = 0x42
+	// To ensure backward compatibility
+	I2C_ADDRESS = UBLOX_I2C_ADDRESS
+
+	UBLOX_I2C_ADDRESS   = 0x42
+	PA1010D_I2C_ADDRESS = 0x10
 )
 
 const (


### PR DESCRIPTION
[Adafruit's Mini GPS PA1010D Module](https://learn.adafruit.com/adafruit-mini-gps-pa1010d-module) works with this device driver (personally confirmed), but requires `0x10` as the i2c address, rather than `0x42`.

This change allows the device to be initialised with whatever i2c address is needed, while maintaining backward compatibility.

(If backward compatibility isn't needed, please let me know, and I'll remove the function that assumes a default, and force the use of an i2c address to initialise!)

Also adds new constants to allow easy configuration of both the ublox device and the PA1010D.