### PR TITLE
drivers.Pin with function pointers example

### DIFF
--- a/apa102/apa102.go
+++ b/apa102/apa102.go
@@ -36,8 +36,8 @@ func New(b drivers.SPI) *Device {
 
 // NewSoftwareSPI returns a new APA102 driver that will use a software based
 // implementation of the SPI protocol.
-func NewSoftwareSPI(sckPin, sdoPin drivers.Pin, delay uint32) *Device {
-	return New(&bbSPI{SCK: sckPin, SDO: sdoPin, Delay: delay})
+func NewSoftwareSPI(sckPin, sdoPin drivers.PinOut, delay uint32) *Device {
+	return New(&bbSPI{SCK: sckPin.Set, SDO: sdoPin.Set, Delay: delay})
 }
 
 // WriteColors writes the given RGBA color slice out using the APA102 protocol.

--- a/apa102/softspi.go
+++ b/apa102/softspi.go
@@ -1,25 +1,21 @@
 package apa102
 
-import (
-	"tinygo.org/x/drivers"
-)
-
 // bbSPI is a dumb bit-bang implementation of SPI protocol that is hardcoded
 // to mode 0 and ignores trying to receive data. Just enough for the APA102.
 // Note: making this unexported for now because it is probable not suitable
 // most purposes other than the APA102 package. It might be desirable to make
 // this more generic and include it in the TinyGo "machine" package instead.
 type bbSPI struct {
-	SCK   drivers.Pin
-	SDO   drivers.Pin
+	SCK   func(bool)
+	SDO   func(bool)
 	Delay uint32
 }
 
 // Configure sets the SCK and SDO pins to low.
 // Note that the SCK and SDO pins must already be configured as outputs.
 func (s *bbSPI) Configure() {
-	s.SCK.Low()
-	s.SDO.Low()
+	s.SCK(false) // SCK is low
+	s.SDO(false) // SDO is low
 	if s.Delay == 0 {
 		s.Delay = 1
 	}
@@ -48,19 +44,19 @@ func (s *bbSPI) Transfer(b byte) (byte, error) {
 	for i := uint8(0); i < 8; i++ {
 
 		// half clock cycle high to start
-		s.SCK.High()
+		s.SCK(true)
 		s.delay()
 
 		// write the value to SDO (MSB first)
 		if b&(1<<(7-i)) == 0 {
-			s.SDO.Low()
+			s.SDO(false)
 		} else {
-			s.SDO.High()
+			s.SDO(true)
 		}
 		s.delay()
 
 		// half clock cycle low
-		s.SCK.Low()
+		s.SCK(false)
 		s.delay()
 
 		// for actual SPI would try to read the SDI value here

--- a/pin.go
+++ b/pin.go
@@ -1,10 +1,18 @@
 package drivers
 
-// Pin is a digital pin interface. It is notably implemented by the
-// machine.Pin type.
+// Pin is a digital pin interface.
+// It is notably implemented by the machine.Pin type.
 type Pin interface {
+	PinIn
+	PinOut
+}
+
+type PinIn interface {
 	Get() bool
-	High()
-	Low()
+}
+
+type PinOut interface {
+	High() // deprecated: use Set(true)
+	Low()  // deprecated: use Set(false)
 	Set(high bool)
 }

--- a/waveshare-epd/epd2in66b/dev.go
+++ b/waveshare-epd/epd2in66b/dev.go
@@ -18,18 +18,18 @@ const (
 const Baudrate = 4_000_000 // 4 MHz
 
 type Config struct {
-	ResetPin      drivers.Pin
-	DataPin       drivers.Pin
-	ChipSelectPin drivers.Pin
-	BusyPin       drivers.Pin
+	ResetPin      drivers.PinOut
+	DataPin       drivers.PinOut
+	ChipSelectPin drivers.PinOut
+	BusyPin       drivers.PinIn
 }
 
 type Device struct {
 	bus  drivers.SPI
-	cs   drivers.Pin
-	dc   drivers.Pin
-	rst  drivers.Pin
-	busy drivers.Pin
+	cs   drivers.PinOut
+	dc   drivers.PinOut
+	rst  drivers.PinOut
+	busy drivers.PinIn
 
 	blackBuffer []byte
 	redBuffer   []byte


### PR DESCRIPTION
This showcases how we can split `drivers.Pin` to smaller `drivers.PinIn` and `drivers.PinOut` interfaces AND use function pointer to `.Set(bool)` function in performance critical places, like `softspi` implementation.

This still breaks users though, as it is based on a PR #749  that mandates pins to be configured outside the drivers.