### PR TITLE
Fix gps time calculation

### DIFF
--- a/gps/gpsparser.go
+++ b/gps/gpsparser.go
@@ -96,7 +96,10 @@ func (parser *Parser) Parse(sentence string) (Fix, error) {
 		fix.Speed = findSpeed(fields[7])
 		fix.Heading = findHeading(fields[8])
 		date := findDate(fields[9])
-		fix.Time = fix.Time.AddDate(date.Year(), int(date.Month()), date.Day())
+		fix.Time = date.Add(time.Duration(fix.Time.Hour())*time.Hour +
+			time.Duration(fix.Time.Minute())*time.Minute +
+			time.Duration(fix.Time.Second())*time.Second +
+			time.Duration(fix.Time.Nanosecond())*time.Nanosecond)
 
 		return fix, nil
 	}

--- a/gps/gpsparser_test.go
+++ b/gps/gpsparser_test.go
@@ -70,15 +70,15 @@ func TestParseRMC(t *testing.T) {
 		t.Error("should have errInvalidRMCSentence error")
 	}
 
-	val = "$GPRMC,203522.00,A,5109.0262308,N,11401.8407342,W,0.004,133.4,130522,0.0,E,D*2B"
+	val = "$GPRMC,203522.00,A,5109.0262308,N,11401.8407342,W,0.004,133.4,010622,0.0,E,D*2B"
 	fix, err := p.Parse(val)
 	if err != nil {
 		t.Error("should have parsed")
 	}
 
 	c.Assert(fix.Time.Year(), qt.Equals, 2022)
-	c.Assert(fix.Time.Month(), qt.Equals, time.May)
-	c.Assert(fix.Time.Day(), qt.Equals, 13)
+	c.Assert(fix.Time.Month(), qt.Equals, time.June)
+	c.Assert(fix.Time.Day(), qt.Equals, 1)
 	c.Assert(fix.Time.Hour(), qt.Equals, 20)
 	c.Assert(fix.Time.Minute(), qt.Equals, 35)
 	c.Assert(fix.Time.Second(), qt.Equals, 22)


### PR DESCRIPTION
fix #784 

The Parse() function in the gps package incorrectly calculates dates on or after June 1st, resulting in a timestamp that is one day earlier than the correct date.