### PR TITLE
release: prepare for 0.33.0 drivers release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+0.33.0
+---
+- **new devices**
+    - **ens160**
+        - Add ens160 i2c driver
+    - **lsm303dlhc**
+        - added support for LSM303DLHC e-Compass; (#783)
+    - **seesaw**
+        - add support for Adafruit Seesaw encoders
+
+- **enhancements**
+    - **ws2812**
+        - add RP2350 support
+    - **ssd1306**
+        - avoid unnecessary heap allocations (#767)
+    - **gps**
+        - allow gps init with address
+    - **lsm6ds3tr**
+        - avoid unnecessary heap allocations (#766)
+
+- **bugfixes**
+    - **gps**
+        - Fix gps time calculation (#785)
+
+
 0.32.0
 ---
 - **enhancements**

--- a/version.go
+++ b/version.go
@@ -2,4 +2,4 @@ package drivers
 
 // Version returns a user-readable string showing the version of the drivers package for support purposes.
 // Update this value before release of new version of software.
-const Version = "0.32.0"
+const Version = "0.33.0"


### PR DESCRIPTION
This PR is to prepare for `v0.33.0` TinyGo drivers release.