### PR TITLE
Add RP2350 to encoders/quadrature_interrupt.go

### DIFF
--- a/encoders/quadrature_interrupt.go
+++ b/encoders/quadrature_interrupt.go
@@ -1,4 +1,4 @@
-//go:build tinygo && (rp2040 || stm32 || k210 || esp32c3 || nrf || sam || (avr && (atmega328p || atmega328pb)))
+//go:build tinygo && (rp2040 || rp2350 || stm32 || k210 || esp32c3 || nrf || sam || (avr && (atmega328p || atmega328pb)))
 
 // Implementation based on:
 // https://gist.github.com/aykevl/3fc1683ed77bb0a9c07559dfe857304a


### PR DESCRIPTION
Same as the rp2040, the rp2350 does support machine.PinToggle. I've tested it with a sensor as well and it all works as expected.