### PR TITLE
Fixes to the ./pixel tests and corrections to pixel.RGB555

### DIFF
--- a/pixel/image_test.go
+++ b/pixel/image_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestImageRGB565BE(t *testing.T) {
 	image := pixel.NewImage[pixel.RGB565BE](5, 3)
-	if width, height := image.Size(); width != 5 && height != 3 {
+	if width, height := image.Size(); width != 5 || height != 3 {
 		t.Errorf("image.Size(): expected 5, 3 but got %d, %d", width, height)
 	}
 	for _, c := range []color.RGBA{
@@ -32,7 +32,7 @@ func TestImageRGB565BE(t *testing.T) {
 
 func TestImageRGB444BE(t *testing.T) {
 	image := pixel.NewImage[pixel.RGB444BE](5, 3)
-	if width, height := image.Size(); width != 5 && height != 3 {
+	if width, height := image.Size(); width != 5 || height != 3 {
 		t.Errorf("image.Size(): expected 5, 3 but got %d, %d", width, height)
 	}
 	for _, c := range []color.RGBA{

--- a/pixel/image_test.go
+++ b/pixel/image_test.go
@@ -109,7 +109,7 @@ func TestImageRGB444BE(t *testing.T) {
 
 func TestImageMonochrome(t *testing.T) {
 	image := pixel.NewImage[pixel.Monochrome](128, 64)
-	if width, height := image.Size(); width != 128 && height != 64 {
+	if width, height := image.Size(); width != 128 || height != 64 {
 		t.Errorf("image.Size(): expected 128, 64 but got %d, %d", width, height)
 	}
 	for _, expected := range []color.RGBA{

--- a/pixel/image_test.go
+++ b/pixel/image_test.go
@@ -9,6 +9,27 @@ import (
 	"tinygo.org/x/drivers/pixel"
 )
 
+func TestImageRGB888(t *testing.T) {
+	image := pixel.NewImage[pixel.RGB888](5, 3)
+	if width, height := image.Size(); width != 5 || height != 3 {
+		t.Errorf("image.Size(): expected 5, 3 but got %d, %d", width, height)
+	}
+	for _, c := range []color.RGBA{
+		{R: 0xff, A: 0xff},
+		{G: 0xff, A: 0xff},
+		{B: 0xff, A: 0xff},
+		{R: 0x10, A: 0xff},
+		{G: 0x10, A: 0xff},
+		{B: 0x10, A: 0xff},
+	} {
+		image.Set(4, 2, pixel.NewColor[pixel.RGB888](c.R, c.G, c.B))
+		c2 := image.Get(4, 2).RGBA()
+		if c2 != c {
+			t.Errorf("failed to roundtrip color: expected %v but got %v", c, c2)
+		}
+	}
+}
+
 func TestImageRGB565BE(t *testing.T) {
 	image := pixel.NewImage[pixel.RGB565BE](5, 3)
 	if width, height := image.Size(); width != 5 || height != 3 {
@@ -23,6 +44,27 @@ func TestImageRGB565BE(t *testing.T) {
 		{B: 0x10, A: 0xff},
 	} {
 		image.Set(4, 2, pixel.NewColor[pixel.RGB565BE](c.R, c.G, c.B))
+		c2 := image.Get(4, 2).RGBA()
+		if c2 != c {
+			t.Errorf("failed to roundtrip color: expected %v but got %v", c, c2)
+		}
+	}
+}
+
+func TestImageRGB555(t *testing.T) {
+	image := pixel.NewImage[pixel.RGB555](5, 3)
+	if width, height := image.Size(); width != 5 || height != 3 {
+		t.Errorf("image.Size(): expected 5, 3 but got %d, %d", width, height)
+	}
+	for _, c := range []color.RGBA{
+		{R: 0xff, A: 0xff},
+		{G: 0xff, A: 0xff},
+		{B: 0xff, A: 0xff},
+		{R: 0x10, A: 0xff},
+		{G: 0x10, A: 0xff},
+		{B: 0x10, A: 0xff},
+	} {
+		image.Set(4, 2, pixel.NewColor[pixel.RGB555](c.R, c.G, c.B))
 		c2 := image.Get(4, 2).RGBA()
 		if c2 != c {
 			t.Errorf("failed to roundtrip color: expected %v but got %v", c, c2)

--- a/pixel/pixel.go
+++ b/pixel/pixel.go
@@ -161,9 +161,9 @@ func (c RGB555) BitsPerPixel() int {
 
 func (c RGB555) RGBA() color.RGBA {
 	color := color.RGBA{
-		R: uint8(c>>10) << 3,
-		G: uint8(c>>5) << 3,
-		B: uint8(c) << 3,
+		R: (uint8(c) & 0x1F) << 3,
+		G: (uint8(c>>5) & 0x1F) << 3,
+		B: (uint8(c>>10) & 0x1F) << 3,
 		A: 255,
 	}
 	// Correct color rounding, so that 0xff roundtrips back to 0xff.


### PR DESCRIPTION
I noticed a mistake in RGB555 during the work.
Also, I realized there were no tests, so I’ve added them.

In RGB555, red and blue are reversed. So, for example, if you set an image on the left using `pixel.RGB565BE` and then read it out as `pixel.RGB555`, the color will appear as shown on the right.

before:
<img width="330" height="280" alt="image" src="https://github.com/user-attachments/assets/9d17a511-997d-4dee-9872-a366905ef156" />

after:
<img width="330" height="280" alt="image" src="https://github.com/user-attachments/assets/06ff6d59-5a13-406a-af6a-cb1da79675be" />


Here is the source code:

```go
package main

import (
	"bytes"
	_ "embed"
	"image/color"
	"log"
	"time"

	"github.com/sago35/tinydisplay/examples/initdisplay"
	"tinygo.org/x/drivers"
	"tinygo.org/x/drivers/image/png"
	"tinygo.org/x/drivers/pixel"
)

func main() {
	err := run()
	for err != nil {
		log.Fatal(err)
		time.Sleep(1 * time.Second)
	}
}

var (
	target      = pixel.NewImage[pixel.RGB555](150, 128)
	imgRGB565BE = pixel.NewImage[pixel.RGB565BE](150, 128)
)

func run() error {
	display := initdisplay.InitDisplay()
	display.FillScreen(color.RGBA{0, 0, 0, 255})

	drawPngToPixel(target)
	drawPngToPixel(imgRGB565BE)

	drawPixelToDisplayer(display, 0, 0, imgRGB565BE)
	drawPixelToDisplayer(display, 160, 0, target)

	select {}

	return nil
}

func drawPixelToDisplayer[T pixel.Color](display drivers.Displayer, x, y int16, img pixel.Image[T]) error {
	w, h := img.Size()
	for yy := int16(0); yy < int16(h); yy++ {
		for xx := int16(0); xx < int16(w); xx++ {
			p := img.Get(int(xx), int(yy))
			display.SetPixel(x+xx, y+yy, p.RGBA())
		}
	}
	return nil
}

func drawPngToPixel[T pixel.Color](img pixel.Image[T]) error {
	p := bytes.NewReader(pngImage)
	png.SetCallback(buffer[:], func(data []uint16, x, y, w, h, width, height int16) {
		idx := 0
		for yy := y; yy < y+h; yy++ {
			for xx := x; xx < x+w; xx++ {
				r, g, b, _ := RGB565ToRGBA(data[idx])
				img.Set(int(xx), int(yy), pixel.NewColor[T](r, g, b))
				idx++
			}
		}
	})

	_, err := png.Decode(p)
	return err
}

func RGB565ToRGBA(c uint16) (byte, byte, byte, byte) {
	r5 := uint8((c >> 11) & 0x1F) // 0x1F is 0b11111
	r8 := (r5 << 3) | (r5 >> 2)
	g6 := uint8((c >> 5) & 0x3F) // 0x3F is 0b111111
	g8 := (g6 << 2) | (g6 >> 4)
	b5 := uint8(c & 0x1F) // 0x1F is 0b11111
	b8 := (b5 << 3) | (b5 >> 2)
	return r8, g8, b8, 0xFF
}

// Define the buffer required for the callback. In most cases, this setting
// should be sufficient.  For jpeg, the callback will always be called every
// 3*8*8*4 pix. png will be called every line, i.e. every width pix.
var buffer [3 * 8 * 8 * 4]uint16

//go:embed tinygo-logo.png
var pngImage []byte
```

tinygo-log.png (24bpp)
<img width="150" height="128" alt="tinygo-logo" src="https://github.com/user-attachments/assets/8f932207-9ebc-40bd-9d45-944ed33d08a8" />

