### PR TITLE
Reduced pinhal port - "1-to-1 Ports"

### DIFF
--- a/apa102/apa102.go
+++ b/apa102/apa102.go
@@ -5,9 +5,10 @@ package apa102 // import "tinygo.org/x/drivers/apa102"
 
 import (
 	"image/color"
-	"machine"
 
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
+	"tinygo.org/x/drivers/internal/pin"
 )
 
 const (
@@ -37,8 +38,11 @@ func New(b drivers.SPI) *Device {
 
 // NewSoftwareSPI returns a new APA102 driver that will use a software based
 // implementation of the SPI protocol.
-func NewSoftwareSPI(sckPin, sdoPin machine.Pin, delay uint32) *Device {
-	return New(&bbSPI{SCK: sckPin, SDO: sdoPin, Delay: delay})
+func NewSoftwareSPI(sckPin, sdoPin pin.Output, delay uint32) *Device {
+	return New(&bbSPI{SCK: sckPin.Set, SDO: sdoPin.Set, Delay: delay, configurePins: func() {
+		legacy.ConfigurePinOut(sckPin)
+		legacy.ConfigurePinOut(sdoPin)
+	}})
 }
 
 // WriteColors writes the given RGBA color slice out using the APA102 protocol.

--- a/apa102/softspi.go
+++ b/apa102/softspi.go
@@ -1,6 +1,9 @@
 package apa102
 
-import "machine"
+import (
+	"tinygo.org/x/drivers/internal/legacy"
+	"tinygo.org/x/drivers/internal/pin"
+)
 
 // bbSPI is a dumb bit-bang implementation of SPI protocol that is hardcoded
 // to mode 0 and ignores trying to receive data. Just enough for the APA102.
@@ -8,15 +11,18 @@ import "machine"
 // most purposes other than the APA102 package. It might be desirable to make
 // this more generic and include it in the TinyGo "machine" package instead.
 type bbSPI struct {
-	SCK   machine.Pin
-	SDO   machine.Pin
-	Delay uint32
+	SCK           pin.OutputFunc
+	SDO           pin.OutputFunc
+	Delay         uint32
+	configurePins func()
 }
 
 // Configure sets up the SCK and SDO pins as outputs and sets them low
 func (s *bbSPI) Configure() {
-	s.SCK.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	s.SDO.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	if s.configurePins == nil {
+		panic(legacy.ErrConfigBeforeInstantiated)
+	}
+	s.configurePins()
 	s.SCK.Low()
 	s.SDO.Low()
 	if s.Delay == 0 {

--- a/bmi160/bmi160.go
+++ b/bmi160/bmi160.go
@@ -1,31 +1,36 @@
 package bmi160
 
 import (
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
+	"tinygo.org/x/drivers/internal/pin"
 )
 
 // DeviceSPI is the SPI interface to a BMI160 accelerometer/gyroscope. There is
 // also an I2C interface, but it is not yet supported.
 type DeviceSPI struct {
 	// Chip select pin
-	CSB machine.Pin
+	csb pin.OutputFunc
 
 	buf [7]byte
 
 	// SPI bus (requires chip select to be usable).
-	Bus drivers.SPI
+	bus           drivers.SPI
+	configurePins func()
 }
 
 // NewSPI returns a new device driver. The pin and SPI interface are not
 // touched, provide a fully configured SPI object and call Configure to start
 // using this device.
-func NewSPI(csb machine.Pin, spi drivers.SPI) *DeviceSPI {
+func NewSPI(csb pin.Output, spi drivers.SPI) *DeviceSPI {
 	return &DeviceSPI{
-		CSB: csb, // chip select
-		Bus: spi,
+		csb: csb.Set, // chip select
+		bus: spi,
+		configurePins: func() {
+			legacy.ConfigurePinOut(csb)
+		},
 	}
 }
 
@@ -33,9 +38,11 @@ func NewSPI(csb machine.Pin, spi drivers.SPI) *DeviceSPI {
 // configures the BMI160, but it does not configure the SPI interface (it is
 // assumed to be up and running).
 func (d *DeviceSPI) Configure() error {
-	d.CSB.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	d.CSB.High()
-
+	if d.configurePins == nil {
+		return legacy.ErrConfigBeforeInstantiated
+	}
+	d.configurePins()
+	d.csb.High()
 	// The datasheet recommends doing a register read from address 0x7F to get
 	// SPI communication going:
 	// > If CSB sees a rising edge after power-up, the BMI160 interface switches
@@ -86,9 +93,9 @@ func (d *DeviceSPI) ReadTemperature() (temperature int32, err error) {
 	data[0] = 0x80 | reg_TEMPERATURE_0
 	data[1] = 0
 	data[2] = 0
-	d.CSB.Low()
-	err = d.Bus.Tx(data, data)
-	d.CSB.High()
+	d.csb.Low()
+	err = d.bus.Tx(data, data)
+	d.csb.High()
 	if err != nil {
 		return
 	}
@@ -123,9 +130,9 @@ func (d *DeviceSPI) ReadAcceleration() (x int32, y int32, z int32, err error) {
 	for i := 1; i < len(data); i++ {
 		data[i] = 0
 	}
-	d.CSB.Low()
-	err = d.Bus.Tx(data, data)
-	d.CSB.High()
+	d.csb.Low()
+	err = d.bus.Tx(data, data)
+	d.csb.High()
 	if err != nil {
 		return
 	}
@@ -153,9 +160,9 @@ func (d *DeviceSPI) ReadRotation() (x int32, y int32, z int32, err error) {
 	for i := 1; i < len(data); i++ {
 		data[i] = 0
 	}
-	d.CSB.Low()
-	err = d.Bus.Tx(data, data)
-	d.CSB.High()
+	d.csb.Low()
+	err = d.bus.Tx(data, data)
+	d.csb.High()
 	if err != nil {
 		return
 	}
@@ -201,9 +208,9 @@ func (d *DeviceSPI) readRegister(address uint8) uint8 {
 	data := d.buf[:2]
 	data[0] = 0x80 | address
 	data[1] = 0
-	d.CSB.Low()
-	d.Bus.Tx(data, data)
-	d.CSB.High()
+	d.csb.Low()
+	d.bus.Tx(data, data)
+	d.csb.High()
 	return data[1]
 }
 
@@ -217,7 +224,7 @@ func (d *DeviceSPI) writeRegister(address, data uint8) {
 	buf[0] = address
 	buf[1] = data
 
-	d.CSB.Low()
-	d.Bus.Tx(buf, buf)
-	d.CSB.High()
+	d.csb.Low()
+	d.bus.Tx(buf, buf)
+	d.csb.High()
 }

--- a/buzzer/buzzer.go
+++ b/buzzer/buzzer.go
@@ -2,22 +2,22 @@
 package buzzer // import "tinygo.org/x/drivers/buzzer"
 
 import (
-	"machine"
-
 	"time"
+
+	"tinygo.org/x/drivers/internal/pin"
 )
 
 // Device wraps a GPIO connection to a buzzer.
 type Device struct {
-	pin  machine.Pin
+	pin  pin.OutputFunc
 	High bool
 	BPM  float64
 }
 
 // New returns a new buzzer driver given which pin to use
-func New(pin machine.Pin) Device {
+func New(pin pin.Output) Device {
 	return Device{
-		pin:  pin,
+		pin:  pin.Set,
 		High: false,
 		BPM:  96.0,
 	}
@@ -25,14 +25,14 @@ func New(pin machine.Pin) Device {
 
 // On sets the buzzer to a high state.
 func (l *Device) On() (err error) {
-	l.pin.Set(true)
+	l.pin.High()
 	l.High = true
 	return
 }
 
 // Off sets the buzzer to a low state.
 func (l *Device) Off() (err error) {
-	l.pin.Set(false)
+	l.pin.Low()
 	l.High = false
 	return
 }

--- a/ft6336/ft6336.go
+++ b/ft6336/ft6336.go
@@ -1,3 +1,6 @@
+// Guarded because still unsure of how to deal with interrupt drivers.
+//go:build tinygo
+
 // Package ft6336 provides a driver for the FT6336 I2C Self-Capacitive touch
 // panel controller.
 //

--- a/hd44780/hd44780.go
+++ b/hd44780/hd44780.go
@@ -210,7 +210,7 @@ func (d *Device) SendCommand(command byte) {
 	d.bus.SetCommandMode(true)
 	d.bus.Write([]byte{command})
 
-	for d.busy(command == DISPLAY_CLEAR || command == CURSOR_HOME) {
+	for d.isBusy(command == DISPLAY_CLEAR || command == CURSOR_HOME) {
 	}
 }
 
@@ -219,7 +219,7 @@ func (d *Device) sendData(data byte) {
 	d.bus.SetCommandMode(false)
 	d.bus.Write([]byte{data})
 
-	for d.busy(false) {
+	for d.isBusy(false) {
 	}
 }
 
@@ -231,9 +231,9 @@ func (d *Device) CreateCharacter(cgramAddr uint8, data []byte) {
 	}
 }
 
-// busy returns true when hd447890 is busy
+// isBusy returns true when hd447890 is isBusy
 // or after the timeout specified
-func (d *Device) busy(longDelay bool) bool {
+func (d *Device) isBusy(longDelay bool) bool {
 	if d.bus.WriteOnly() {
 		// Can't read busy flag if write only, so sleep a bit then return
 		if longDelay {
@@ -261,7 +261,7 @@ func (d *Device) busy(longDelay bool) bool {
 
 // Busy returns true when hd447890 is busy
 func (d *Device) Busy() bool {
-	return d.busy(false)
+	return d.isBusy(false)
 }
 
 // Size returns the current size of the display.

--- a/max6675/max6675.go
+++ b/max6675/max6675.go
@@ -3,9 +3,9 @@ package max6675
 
 import (
 	"errors"
-	"machine"
 
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/pin"
 )
 
 // ErrThermocoupleOpen is returned when the thermocouple input is open.
@@ -14,16 +14,16 @@ var ErrThermocoupleOpen = errors.New("thermocouple input open")
 
 type Device struct {
 	bus drivers.SPI
-	cs  machine.Pin
+	cs  pin.OutputFunc
 }
 
 // Create a new Device to read from a MAX6675 thermocouple.
 // Pins must be configured before use.  Frequency for SPI
 // should be 4.3MHz maximum.
-func NewDevice(bus drivers.SPI, cs machine.Pin) *Device {
+func NewDevice(bus drivers.SPI, cs pin.Output) *Device {
 	return &Device{
 		bus: bus,
-		cs:  cs,
+		cs:  cs.Set,
 	}
 }
 

--- a/max72xx/max72xx.go
+++ b/max72xx/max72xx.go
@@ -3,31 +3,36 @@
 package max72xx
 
 import (
-	"machine"
-
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
+	"tinygo.org/x/drivers/internal/pin"
 )
 
 type Device struct {
-	bus drivers.SPI
-	cs  machine.Pin
+	bus           drivers.SPI
+	cs            pin.OutputFunc
+	configurePins func()
 }
 
 // NewDriver creates a new max7219 connection. The SPI wire must already be configured
 // The SPI frequency must not be higher than 10MHz.
 // parameter cs: the datasheet also refers to this pin as "load" pin.
-func NewDevice(bus drivers.SPI, cs machine.Pin) *Device {
+func NewDevice(bus drivers.SPI, cs pin.Output) *Device {
 	return &Device{
 		bus: bus,
-		cs:  cs,
+		cs:  cs.Set,
+		configurePins: func() {
+			legacy.ConfigurePinOut(cs)
+		},
 	}
 }
 
 // Configure setups the pins.
 func (driver *Device) Configure() {
-	outPutConfig := machine.PinConfig{Mode: machine.PinOutput}
-
-	driver.cs.Configure(outPutConfig)
+	if driver.configurePins == nil {
+		panic(legacy.ErrConfigBeforeInstantiated)
+	}
+	driver.configurePins()
 }
 
 // SetScanLimit sets the scan limit. Maximum is 8.

--- a/mcp2515/mcp2515.go
+++ b/mcp2515/mcp2515.go
@@ -8,18 +8,20 @@ package mcp2515 // import "tinygo.org/x/drivers/mcp2515"
 import (
 	"errors"
 	"fmt"
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/legacy"
+	"tinygo.org/x/drivers/internal/pin"
 )
 
 // Device wraps MCP2515 SPI CAN Module.
 type Device struct {
-	spi     SPI
-	cs      machine.Pin
-	msg     *CANMsg
-	mcpMode byte
+	spi           SPI
+	cs            pin.OutputFunc
+	msg           *CANMsg
+	mcpMode       byte
+	configurePins func()
 }
 
 // CANMsg stores CAN message fields.
@@ -36,15 +38,18 @@ const (
 )
 
 // New returns a new MCP2515 driver. Pass in a fully configured SPI bus.
-func New(b drivers.SPI, csPin machine.Pin) *Device {
+func New(b drivers.SPI, csPin pin.Output) *Device {
 	d := &Device{
 		spi: SPI{
 			bus: b,
 			tx:  make([]byte, 0, bufferSize),
 			rx:  make([]byte, 0, bufferSize),
 		},
-		cs:  csPin,
+		cs:  csPin.Set,
 		msg: &CANMsg{},
+		configurePins: func() {
+			legacy.ConfigurePinOut(csPin)
+		},
 	}
 
 	return d
@@ -52,7 +57,10 @@ func New(b drivers.SPI, csPin machine.Pin) *Device {
 
 // Configure sets up the device for communication.
 func (d *Device) Configure() {
-	d.cs.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	if d.configurePins == nil {
+		panic(legacy.ErrConfigBeforeInstantiated)
+	}
+	d.configurePins()
 }
 
 const beginTimeoutValue int = 10

--- a/pcd8544/pcd8544.go
+++ b/pcd8544/pcd8544.go
@@ -6,18 +6,18 @@ package pcd8544 // import "tinygo.org/x/drivers/pcd8544"
 import (
 	"errors"
 	"image/color"
-	"machine"
 	"time"
 
 	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/internal/pin"
 )
 
 // Device wraps an SPI connection.
 type Device struct {
 	bus        drivers.SPI
-	dcPin      machine.Pin
-	rstPin     machine.Pin
-	scePin     machine.Pin
+	dcPin      pin.OutputFunc
+	rstPin     pin.OutputFunc
+	scePin     pin.OutputFunc
 	buffer     []byte
 	width      int16
 	height     int16
@@ -30,12 +30,12 @@ type Config struct {
 }
 
 // New creates a new PCD8544 connection. The SPI bus must already be configured.
-func New(bus drivers.SPI, dcPin, rstPin, scePin machine.Pin) *Device {
+func New(bus drivers.SPI, dcPin, rstPin, scePin pin.Output) *Device {
 	return &Device{
 		bus:    bus,
-		dcPin:  dcPin,
-		rstPin: rstPin,
-		scePin: scePin,
+		dcPin:  dcPin.Set,
+		rstPin: rstPin.Set,
+		scePin: scePin.Set,
 	}
 }
 


### PR DESCRIPTION
Is #814 but reduced in scope. I only added drivers which are simple to verify due to 1-to-1 porting logic because I imagine we won't be testing each driver individually- it should be enough to trust the compiler and several eyes.