### PR TITLE
i2clegacy: avoid heap allocations in i2c legacy helper functions

### DIFF
--- a/internal/legacy/i2clegacy.go
+++ b/internal/legacy/i2clegacy.go
@@ -2,13 +2,18 @@ package legacy
 
 import "tinygo.org/x/drivers"
 
+var i2cBuf []uint8 = make([]uint8, 1)
+
 func ReadRegister(bus drivers.I2C, addr uint8, reg uint8, data []byte) error {
-	return bus.Tx(uint16(addr), []byte{reg}, data)
+	i2cBuf[0] = reg
+	return bus.Tx(uint16(addr), i2cBuf[:1], data)
 }
 
 func WriteRegister(bus drivers.I2C, addr uint8, reg uint8, data []byte) error {
-	buf := make([]uint8, len(data)+1)
-	buf[0] = reg
-	copy(buf[1:], data)
-	return bus.Tx(uint16(addr), buf, nil)
+	if len(i2cBuf) < 1+len(data) {
+		i2cBuf = make([]uint8, 1+len(data))
+	}
+	i2cBuf[0] = reg
+	copy(i2cBuf[1:], data)
+	return bus.Tx(uint16(addr), i2cBuf[:1+len(data)], nil)
 }


### PR DESCRIPTION
This theoretically shall instantly improve memory usage in majority of older drivers.
The buffer grows adapting for the need.

This is just a low hanging best-effort patch until we come around end erradicate legacy way of calling I2C in all the drivers.

What do you think?