### PR TITLE
scd4x: add support for SCD41 single-shot measurements

### DIFF
--- a/scd4x/registers.go
+++ b/scd4x/registers.go
@@ -22,4 +22,5 @@ const (
 	CmdStartLowPowerPeriodicMeasurement = 0x21AC
 	CmdStartPeriodicMeasurement         = 0x21B1
 	CmdStopPeriodicMeasurement          = 0x3F86
+	CmdMeasureSingleShot                = 0x219D
 )

--- a/scd4x/scd4x.go
+++ b/scd4x/scd4x.go
@@ -82,6 +82,13 @@ func (d *Device) StartLowPowerPeriodicMeasurement() error {
 	return d.sendCommand(CmdStartLowPowerPeriodicMeasurement)
 }
 
+// MeasureSingleShot starts a single measurement cycle (SCD41 only). After this
+// command is complete, the caller should wait for 5000ms before trying to read
+// the result.
+func (d *Device) MeasureSingleShot() error {
+	return d.sendCommand(CmdMeasureSingleShot)
+}
+
 // ReadData reads the data from the sensor and caches it.
 func (d *Device) ReadData() error {
 	if err := d.sendCommandWithResult(CmdReadMeasurement, d.rx[0:9]); err != nil {


### PR DESCRIPTION
I have a SCD41, and would like to use it for single shot measurements instead of "low power periodic" measurements to achieve much lower average current consumption.