### PR TITLE
make: add tasks to count and list drivers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,17 @@ unit-test:
 	@go test -v $(addprefix ./,$(TESTS))
 
 test: clean fmt-check unit-test smoke-test
+
+EXCLUDE_DIRS = build cmd examples internal lora ndir netdev netlink tester
+
+drivers-count:
+	@root_count=$$(find . -mindepth 1 -maxdepth 1 -type d | grep -vE '^\./($(subst $(space),|,$(EXCLUDE_DIRS)))$$' | wc -l); \
+	epd_count=$$(find ./waveshare-epd -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l); \
+	total=$$((root_count + epd_count)); \
+	echo "Total drivers: $$total (root: $$root_count, waveshare-epd: $$epd_count)"
+
+drivers-list:
+	@{ \
+		find . -mindepth 1 -maxdepth 1 -type d | grep -vE '^\./($(subst $(space),|,$(EXCLUDE_DIRS)))$$'; \
+		if [ -d ./waveshare-epd ]; then find ./waveshare-epd -mindepth 1 -maxdepth 1 -type d; fi; \
+	} | sed 's|^\./||' | sort

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PkgGoDev](https://pkg.go.dev/badge/tinygo.org/x/drivers)](https://pkg.go.dev/tinygo.org/x/drivers) [![Build](https://github.com/tinygo-org/drivers/actions/workflows/build.yml/badge.svg?branch=dev)](https://github.com/tinygo-org/drivers/actions/workflows/build.yml)
 
 
-This package provides a collection of over 130 different hardware drivers for devices such as sensors, displays, wireless adaptors, and actuators, that can be used together with [TinyGo](https://tinygo.org).
+This package provides a collection of 139 different hardware drivers for devices such as sensors, displays, wireless adaptors, and actuators, that can be used together with [TinyGo](https://tinygo.org).
 
 For the complete list, please see:
 https://tinygo.org/docs/reference/devices/


### PR DESCRIPTION
This PR is to add make tasks to count and list drivers. Should be helpful to keep the docs up to date.

```shell
$ make drivers-count 
Total drivers: 140 (root: 134, waveshare-epd: 6)
```