### PR TITLE
ws2812: use PIO on RP2040/RP2350 transparently via build tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,8 @@
 module tinygo.org/x/drivers
 
-
 go 1.22.1
 
 toolchain go1.23.1
-
 
 require (
 	github.com/eclipse/paho.mqtt.golang v1.2.0
@@ -12,6 +10,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/orsinium-labs/tinymath v1.1.0
 	github.com/soypat/natiu-mqtt v0.5.1
+	github.com/tinygo-org/pio v0.3.0
 	golang.org/x/exp v0.0.0-20241204233417-43b7b7cde48d
 	golang.org/x/net v0.33.0
 	tinygo.org/x/tinyfont v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/orsinium-labs/tinymath v1.1.0 h1:KomdsyLHB7vE3f1nRAJF2dyf1m/gnM2HxfTe
 github.com/orsinium-labs/tinymath v1.1.0/go.mod h1:WPXX6ei3KSXG7JfA03a+ekCYaY9SWN4I+JRl2p6ck+A=
 github.com/soypat/natiu-mqtt v0.5.1 h1:rwaDmlvjzD2+3MCOjMZc4QEkDkNwDzbct2TJbpz+TPc=
 github.com/soypat/natiu-mqtt v0.5.1/go.mod h1:xEta+cwop9izVCW7xOx2W+ct9PRMqr0gNVkvBPnQTc4=
+github.com/tinygo-org/pio v0.3.0 h1:opEnOtw58KGB4RJD3/n/Rd0/djYGX3DeJiXLI6y/yDI=
+github.com/tinygo-org/pio v0.3.0/go.mod h1:wf6c6lKZp+pQOzKKcpzchmRuhiMc27ABRuo7KVnaMFU=
 github.com/valyala/fastjson v1.6.3/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 golang.org/x/exp v0.0.0-20241204233417-43b7b7cde48d h1:0olWaB5pg3+oychR51GUVCEsGkeCU/2JxjBgIo4f3M0=
 golang.org/x/exp v0.0.0-20241204233417-43b7b7cde48d/go.mod h1:qj5a5QZpwLU2NLQudwIN5koi3beDhSAlJwa67PuM98c=

--- a/ws2812/ws2812.go
+++ b/ws2812/ws2812.go
@@ -1,4 +1,7 @@
 // Package ws2812 implements a driver for WS2812 and SK6812 RGB LED strips.
+//
+// On most platforms NewWS2812 uses bit-banging.
+// On RP2040/RP2350 it uses PIO for hardware-timed control.
 package ws2812 // import "tinygo.org/x/drivers/ws2812"
 
 //go:generate go run gen-ws2812.go -arch=cortexm 16 48 64 120 125 150 168 200
@@ -24,14 +27,11 @@ func New(pin machine.Pin) Device {
 	return NewWS2812(pin)
 }
 
-// New returns a new WS2812(RGB) driver.
-// It does not touch the pin object: you have
-// to configure it as an output pin before calling New.
+// NewWS2812 returns a new WS2812(RGB) driver.
+// On RP2040/RP2350, it uses PIO for hardware-timed control.
+// On other platforms, you must configure the pin as output before calling this.
 func NewWS2812(pin machine.Pin) Device {
-	return Device{
-		Pin:            pin,
-		writeColorFunc: writeColorsRGB,
-	}
+	return newWS2812Device(pin)
 }
 
 // New returns a new SK6812(RGBA) driver.

--- a/ws2812/ws2812_init_other.go
+++ b/ws2812/ws2812_init_other.go
@@ -1,0 +1,10 @@
+//go:build !rp2040 && !rp2350
+
+package ws2812
+
+import "machine"
+
+// newWS2812Device creates a WS2812 device using the bit-bang driver.
+func newWS2812Device(pin machine.Pin) Device {
+	return Device{Pin: pin, writeColorFunc: writeColorsRGB}
+}

--- a/ws2812/ws2812_rp2_pio.go
+++ b/ws2812/ws2812_rp2_pio.go
@@ -1,0 +1,33 @@
+//go:build rp2040 || rp2350
+
+package ws2812
+
+import (
+	"image/color"
+	"machine"
+
+	pio "github.com/tinygo-org/pio/rp2-pio"
+	"github.com/tinygo-org/pio/rp2-pio/piolib"
+)
+
+// newWS2812Device creates a WS2812 device using PIO for hardware-timed control.
+// If PIO initialization fails, it falls back to the bit-bang driver.
+func newWS2812Device(pin machine.Pin) Device {
+	sm, err := pio.PIO0.ClaimStateMachine()
+	if err != nil {
+		return Device{Pin: pin, writeColorFunc: writeColorsRGB}
+	}
+	ws, err := piolib.NewWS2812B(sm, pin)
+	if err != nil {
+		return Device{Pin: pin, writeColorFunc: writeColorsRGB}
+	}
+	return Device{
+		Pin: pin,
+		writeColorFunc: func(_ Device, buf []color.RGBA) error {
+			for _, c := range buf {
+				ws.PutRGB(c.R, c.G, c.B)
+			}
+			return nil
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- On RP2040/RP2350, `NewWS2812()` now uses **PIO** (via `tinygo-org/pio`) for hardware-timed control instead of bit-banging
- Falls back to the existing bit-bang driver if PIO initialization fails, or on all other platforms
- No changes to the exported API surface — existing code works without modification

## Motivation
The existing `ws2812` driver uses CPU-timed bit-banging assembly tuned for Cortex-M0+. The RP2350's Cortex-M33 has a write buffer and different pipeline that breaks the nanosecond-level GPIO timing. The Arduino Adafruit_NeoPixel library works on the same hardware because it uses PIO.

## Implementation
- `ws2812_rp2_pio.go` (`rp2040 || rp2350`): `newWS2812Device()` claims a PIO0 state machine and sets `writeColorFunc` to a PIO-based closure. Falls back to bit-bang on failure.
- `ws2812_init_other.go` (`!rp2040 && !rp2350`): `newWS2812Device()` returns the standard bit-bang device.
- `NewWS2812()` now delegates to `newWS2812Device()`.

## Test plan
- [x] `tinygo flash -target=pico2 ./examples/ws2812/` — verify LEDs work on RP2350 via PIO
- [ ] `tinygo build -target=circuitplay-express ./examples/ws2812/` — verify bit-bang fallback compiles
- [ ] `tinygo build -target=arduino ./examples/ws2812/` — verify AVR still works
- [ ] `tinygo build -target=m5stamp-c3 ./examples/ws2812/` — verify Xtensa/RISC-V still works