### PR TITLE
ws2812: add brightness control

### DIFF
--- a/ws2812/ws2812.go
+++ b/ws2812/ws2812.go
@@ -18,7 +18,8 @@ var errUnknownClockSpeed = errors.New("ws2812: unknown CPU clock speed")
 // Device wraps a pin object for an easy driver interface.
 type Device struct {
 	Pin            machine.Pin
-	writeColorFunc func(Device, []color.RGBA) error
+	brightness     uint8
+	writeColorFunc func(Device, []color.RGBA, uint8) error
 }
 
 // deprecated, use NewWS2812 or NewSK6812 depending on which device you want.
@@ -40,8 +41,14 @@ func NewWS2812(pin machine.Pin) Device {
 func NewSK6812(pin machine.Pin) Device {
 	return Device{
 		Pin:            pin,
+		brightness:     255,
 		writeColorFunc: writeColorsRGBA,
 	}
+}
+
+// SetBrightness sets the global brightness (0-255).
+func (d *Device) SetBrightness(b uint8) {
+	d.brightness = b
 }
 
 // Write the raw bitstring out using the WS2812 protocol.
@@ -55,24 +62,35 @@ func (d Device) Write(buf []byte) (n int, err error) {
 // Write the given color slice out using the WS2812 protocol.
 // Colors are sent out in the usual GRB(A) format.
 func (d Device) WriteColors(buf []color.RGBA) (err error) {
-	return d.writeColorFunc(d, buf)
+	return d.writeColorFunc(d, buf, d.brightness)
 }
 
-func writeColorsRGB(d Device, buf []color.RGBA) (err error) {
+func writeColorsRGB(d Device, buf []color.RGBA, brightness uint8) (err error) {
 	for _, color := range buf {
-		d.WriteByte(color.G)       // green
-		d.WriteByte(color.R)       // red
-		err = d.WriteByte(color.B) // blue
+		r, g, b := applyBrightness(color, brightness)
+		d.WriteByte(g)       // green
+		d.WriteByte(r)       // red
+		err = d.WriteByte(b) // blue
 	}
 	return
 }
 
-func writeColorsRGBA(d Device, buf []color.RGBA) (err error) {
+func writeColorsRGBA(d Device, buf []color.RGBA, brightness uint8) (err error) {
 	for _, color := range buf {
-		d.WriteByte(color.G)       // green
-		d.WriteByte(color.R)       // red
-		d.WriteByte(color.B)       // blue
+		r, g, b := applyBrightness(color, brightness)
+
+		d.WriteByte(g)             // green
+		d.WriteByte(r)             // red
+		d.WriteByte(b)             // blue
 		err = d.WriteByte(color.A) // alpha
 	}
+	return
+}
+
+// applyBrightness scales a color by the brightness value.
+func applyBrightness(c color.RGBA, brightness uint8) (r, g, b uint8) {
+	r = uint8((uint16(c.R) * uint16(brightness)) >> 8)
+	g = uint8((uint16(c.G) * uint16(brightness)) >> 8)
+	b = uint8((uint16(c.B) * uint16(brightness)) >> 8)
 	return
 }

--- a/ws2812/ws2812_rp2_pio.go
+++ b/ws2812/ws2812_rp2_pio.go
@@ -22,10 +22,12 @@ func newWS2812Device(pin machine.Pin) Device {
 		return Device{Pin: pin, writeColorFunc: writeColorsRGB}
 	}
 	return Device{
-		Pin: pin,
-		writeColorFunc: func(_ Device, buf []color.RGBA) error {
+		Pin:        pin,
+		brightness: 255,
+		writeColorFunc: func(_ Device, buf []color.RGBA, brightness uint8) error {
 			for _, c := range buf {
-				ws.PutRGB(c.R, c.G, c.B)
+				r, g, b := applyBrightness(c, brightness)
+				ws.PutRGB(r, g, b)
 			}
 			return nil
 		},


### PR DESCRIPTION
## Summary

- Adds a `SetBrightness(b uint8)` method to `Device` for global brightness control (0–255, default 255)
- Introduces `applyBrightness()` helper that scales RGB channels using integer math (`uint16` multiply + bit shift to avoid float ops)
- Updates `writeColorsRGB`, `writeColorsRGBA`, and the RP2040/RP2350 PIO path to apply brightness before writing each color
- `brightness` field defaults to `255` (full brightness), ensuring backwards-compatible behavior for existing users

## Test plan

- [x] Flash to a WS2812 LED strip and verify full brightness at `255`
- [x] Call `SetBrightness(128)` and confirm ~50% perceived brightness
- [x] Call `SetBrightness(0)` and confirm LEDs are off
- [ ] Verify SK6812 RGBW strips: alpha channel is passed through unchanged (not dimmed)
- [x] Verify RP2040/RP2350 PIO path applies brightness correctly via `ws.PutRGB`