### PR TITLE
fill out more constants for lora driver

### DIFF
--- a/lora/config.go
+++ b/lora/config.go
@@ -60,16 +60,20 @@ const (
 )
 
 const (
-	Bandwidth_7_8   = iota // 7.8 kHz
-	Bandwidth_10_4         // 10.4 kHz
-	Bandwidth_15_6         // 15.6 kHz
-	Bandwidth_20_8         // 20.8 kHz
-	Bandwidth_31_25        // 31.25 kHz
-	Bandwidth_41_7         // 41.7 kHz
-	Bandwidth_62_5         // 62.5 kHz
-	Bandwidth_125_0        // 125.0 kHz
-	Bandwidth_250_0        // 250.0 kHz
-	Bandwidth_500_0        // 500.0 kHz
+	Bandwidth_7_8     = iota // 7.8 kHz
+	Bandwidth_10_4           // 10.4 kHz
+	Bandwidth_15_6           // 15.6 kHz
+	Bandwidth_20_8           // 20.8 kHz
+	Bandwidth_31_25          // 31.25 kHz
+	Bandwidth_41_7           // 41.7 kHz
+	Bandwidth_62_5           // 62.5 kHz
+	Bandwidth_125_0          // 125.0 kHz
+	Bandwidth_203_125        // 203.125 kHz
+	Bandwidth_250_0          // 250.0 kHz
+	Bandwidth_406_25         // 406.25 kHz
+	Bandwidth_500_0          // 500.0 kHz
+	Bandwidth_812_5          // 812.5 kHz
+	Bandwidth_1625_0         // 1625 kHz
 )
 
 const (

--- a/lora/radio_event.go
+++ b/lora/radio_event.go
@@ -6,6 +6,9 @@ const (
 	RadioEventTimeout
 	RadioEventWatchdog
 	RadioEventCrcError
+	RadioEventValidHeader
+	RadioEventCadDone
+	RadioEventCadDetected
 	RadioEventUnhandled
 )
 


### PR DESCRIPTION
I plan to do some work on adding a driver for the Semtech SX128x when I get my boards in here soon but figured I would start laying out some of the easy stuff that I can do without having them in hand.

This adds some basic constants to the generic lora driver

- new events (this aren't new for the sx128x stuff but not implemented in the sx126x or sx127x drivers)
- new bandwidths (these are new with the sx128x) I debated going with semtechs naming convetions which uses round number like `BW_400` for `406.25` but the existing bandwidth constants don't follow that so neither did I.

The SX128x chips operate in a different frequency space (2.4Ghz) but I'm not sure if there are any "standard" frequencies like the ones that seem to be defined for LoRaWAN regions. I couldn't find anything so left out adding constants for frequencies.