### PR TITLE
ws2812: fix PIO TX FIFO overflow on rp2040/rp2350 dropping LEDs

### DIFF
--- a/ws2812/ws2812_rp2_pio.go
+++ b/ws2812/ws2812_rp2_pio.go
@@ -5,6 +5,7 @@ package ws2812
 import (
 	"image/color"
 	"machine"
+	"runtime"
 
 	pio "github.com/tinygo-org/pio/rp2-pio"
 	"github.com/tinygo-org/pio/rp2-pio/piolib"
@@ -27,6 +28,9 @@ func newWS2812Device(pin machine.Pin) Device {
 		writeColorFunc: func(_ Device, buf []color.RGBA, brightness uint8) error {
 			for _, c := range buf {
 				r, g, b := applyBrightness(c, brightness)
+				for ws.IsQueueFull() {
+					runtime.Gosched()
+				}
 				ws.PutRGB(r, g, b)
 			}
 			return nil


### PR DESCRIPTION
PutRGB calls TxPut which is non-blocking and silently discards data when the TX FIFO is full.

Wait for FIFO space before each PutRGB using runtime.Gosched() to yield cooperatively, matching the pattern used by piolib.WriteRaw.

Should fix https://github.com/tinygo-org/drivers/issues/869