### PR TITLE
uc8151: fix LUT timing calculations

### DIFF
--- a/uc8151/uc8151.go
+++ b/uc8151/uc8151.go
@@ -412,21 +412,26 @@ func (d *Device) Invert(invert bool) {
 func (d *Device) SetLUT(speed Speed, flickerFree bool) error {
 	var lut LUTSet
 
+	if speed == DEFAULT {
+		return nil
+	}
+
 	// Num. of frames for single direction change.
 	period := 64
-	p := uint8(period / (2 ^ (int(speed) - 1)))
+	scale := 1 << (int(speed) - 1)
+	p := uint8(period / scale)
 	if p < 1 {
 		p = 1
 	}
 
 	// Num. of frames for back-and-forth change.
-	hperiod := period % 2
-	hp := uint8(hperiod / (2 ^ (int(speed) - 1)))
+	hperiod := period / 2
+	hp := uint8(hperiod / scale)
 	if hp < 1 {
 		hp = 1
 	}
 
-	if speed < FAST && !flickerFree {
+	if speed <= FAST && !flickerFree {
 		// For low speed everything is charge-neutral, even WB/BW.
 
 		// Phase 1: long go-inverted-color.


### PR DESCRIPTION
I hit a few bugs while testing out the Badger 2040 W that @deadprogram gave me at GopherCon :)

The LUT timing calculations had a few small Python-to-Go translation errors (`**` vs `^`, `//` vs `%`, and a boundary condition). In particular, `FAST` caused a divide-by-zero panic.

Tested on the actual badge with fast, flicker-free page updates.