### PR TITLE
ws2812: fix build on ESP32-S3

### DIFF
--- a/ws2812/ws2812_freq_esp32s3.go
+++ b/ws2812/ws2812_freq_esp32s3.go
@@ -1,0 +1,13 @@
+//go:build esp32s3
+
+package ws2812
+
+import "machine"
+
+// cpuFrequency returns the current CPU frequency in Hz on the ESP32-S3, which
+// supports runtime frequency scaling and exposes GetCPUFrequency() instead of
+// the constant-style CPUFrequency().
+func cpuFrequency() uint32 {
+	f, _ := machine.GetCPUFrequency()
+	return f
+}

--- a/ws2812/ws2812_freq_xtensa.go
+++ b/ws2812/ws2812_freq_xtensa.go
@@ -1,0 +1,11 @@
+//go:build xtensa && !esp32s3
+
+package ws2812
+
+import "machine"
+
+// cpuFrequency returns the current CPU frequency in Hz on Xtensa targets that
+// expose the constant-style machine.CPUFrequency() (e.g. the original ESP32).
+func cpuFrequency() uint32 {
+	return machine.CPUFrequency()
+}

--- a/ws2812/ws2812_xtensa.go
+++ b/ws2812/ws2812_xtensa.go
@@ -4,7 +4,6 @@ package ws2812
 
 import (
 	"device"
-	"machine"
 	"runtime/interrupt"
 	"unsafe"
 )
@@ -14,7 +13,7 @@ func (d Device) WriteByte(c byte) error {
 	portClear, maskClear := d.Pin.PortMaskClear()
 	mask := interrupt.Disable()
 
-	switch machine.CPUFrequency() {
+	switch cpuFrequency() {
 	case 160e6: // 160MHz
 		// See:
 		// https://wp.josh.com/2014/05/13/ws2812-neopixels-are-not-so-finicky-once-you-get-to-know-them/


### PR DESCRIPTION
The ESP32-S3 `machine` package supports runtime CPU frequency scaling and exposes `machine.GetCPUFrequency()` instead of the constant-style `machine.CPUFrequency()`, so the xtensa WS2812 driver fails to build for esp32s3 targets:

```
ws2812/ws2812_xtensa.go:17:17: undefined: machine.CPUFrequency
```

This PR routes the frequency lookup through a small build-tagged `cpuFrequency()` helper:

- `ws2812_freq_xtensa.go` (`xtensa && !esp32s3`): keeps using `machine.CPUFrequency()` — no behavior change for ESP32 / ESP8266.
- `ws2812_freq_esp32s3.go` (`esp32s3`): uses `machine.GetCPUFrequency()`.

The existing bit-banged timing paths (160MHz / 80MHz) are unchanged; on the ESP32-S3 the driver works when the CPU is clocked at a supported frequency (e.g. after `machine.SetCPUFrequency(160e6)`) and returns `errUnknownClockSpeed` otherwise, matching the existing behavior on other chips.

Verified with the TinyGo dev branch: `tinygo build -target=esp32s3-generic` fails before this change and succeeds after; `-target=esp32-generic` still builds. Also tested on real hardware (ESP32-S3 board driving a NeoPixel at 160MHz).

🤖 Generated with [Claude Code](https://claude.com/claude-code)