### PR TITLE
docs: add instructions to use ASD-STE-100 Simplified Technical English

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+## Communication style
+Use ASD-STE-100 Simplified Technical English when you speak to the operator.
+
+## Comments
+Use ASD-STE100 Simplified Technical English for content outside of the code like comments, PR description, PR title, github comments, and issues.
+
+Generally omit extra redundant comments. If a comment is absolutely needed, always keep it brief, no more than 2 lines. Avoid extra use of colons, semicolons, and dashes. When comments are required due to some specific requirements, include a reference such as to a datasheet or other definitive source to explain why this is the case, including the chapter/section number, page number, and/or URL.
+
+## No coding tool attributions
+Never add "created by XXX" or any other attributions from coding tools to any PRs, issues, comments, or anywhere else.


### PR DESCRIPTION
This PR adds instructions to use ASD-STE-100 Simplified Technical English like other TinyGo repos.