### PR TITLE
Release 0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+0.36.0
+---
+- **new devices**
+    - **gdew0154m09**
+        - add e-paper display driver
+    - **scd30**
+        - add CO2 sensor driver
+    - **sd**
+        - redesign of the `sdcard` package (#639)
+    - **sx128x**
+        - add SPI driver for Semtech sx128x chips (#864)
+
+- **enhancements**
+    - **lora**
+        - set the maximum TX power to 16 for eu868 as in RP002-1.0.5 (#866)
+    - **netlink**
+        - add Hostname field and some godoc comments
+    - **ws2812**
+        - add support for the 160MHz cortex-m processors
+        - add support for the ESP32-C3 processor
+
+- **bugfixes**
+    - **uc8151**
+        - fix LUT timing calculations
+    - **ws2812**
+        - fix PIO TX FIFO overflow on rp2040/rp2350 that drops LEDs
+
+
 0.35.0
 ---
 - **new devices**

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PkgGoDev](https://pkg.go.dev/badge/tinygo.org/x/drivers)](https://pkg.go.dev/tinygo.org/x/drivers) [![Build](https://github.com/tinygo-org/drivers/actions/workflows/build.yml/badge.svg?branch=dev)](https://github.com/tinygo-org/drivers/actions/workflows/build.yml)
 
 
-This package provides a collection of over 140 different hardware drivers for devices such as sensors, displays, wireless adaptors, and actuators, that can be used together with [TinyGo](https://tinygo.org).
+This package provides a collection of over 145 different hardware drivers for devices such as sensors, displays, wireless adaptors, and actuators, that can be used together with [TinyGo](https://tinygo.org).
 
 For the complete list, please see:
 https://tinygo.org/docs/reference/devices/

--- a/version.go
+++ b/version.go
@@ -2,4 +2,4 @@ package drivers
 
 // Version returns a user-readable string showing the version of the drivers package for support purposes.
 // Update this value before release of new version of software.
-const Version = "0.35.0"
+const Version = "0.36.0"


### PR DESCRIPTION
Prepare the 0.36.0 release of the drivers package.

- update `Version` to 0.36.0
- add the 0.36.0 CHANGELOG entry
- update the driver count in the README to over 145

New devices in this release: gdew0154m09, scd30, sd, and sx128x.