### PR TITLE
encoders: add missing ESP32, ESP32-S3, and ESP32-C6 targets to the build constraint

### DIFF
--- a/encoders/quadrature_interrupt.go
+++ b/encoders/quadrature_interrupt.go
@@ -1,4 +1,4 @@
-//go:build tinygo && (rp2040 || rp2350 || stm32 || k210 || esp32c3 || nrf || sam || (avr && (atmega328p || atmega328pb)))
+//go:build tinygo && (rp2040 || rp2350 || stm32 || k210 || esp32 || esp32c3 || esp32s3 || esp32c6 || nrf || sam || (avr && (atmega328p || atmega328pb)))
 
 // Implementation based on:
 // https://gist.github.com/aykevl/3fc1683ed77bb0a9c07559dfe857304a


### PR DESCRIPTION
Fixes #892

The build constraint in `encoders/quadrature_interrupt.go` left out `esp32`, `esp32s3`, and `esp32c6`, although all three define `machine.PinToggle`.

https://github.com/tinygo-org/tinygo/blob/02021b5853f39750fd0c12c92be2f3e09a9352ac/src/machine/machine_esp32.go#L366-L370

https://github.com/tinygo-org/tinygo/blob/02021b5853f39750fd0c12c92be2f3e09a9352ac/src/machine/machine_esp32s3.go#L319-L323

https://github.com/tinygo-org/tinygo/blob/02021b5853f39750fd0c12c92be2f3e09a9352ac/src/machine/machine_esp32c6.go#L80-L84